### PR TITLE
Improved easynetwork.serializers module

### DIFF
--- a/src/easynetwork/serializers/__init__.py
+++ b/src/easynetwork/serializers/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "CBOREncoderConfig",
     "CBORSerializer",
     "EncryptorSerializer",
+    "FileBasedIncrementalPacketSerializer",
     "FileBasedPacketSerializer",
     "FixedSizePacketSerializer",
     "JSONDecoderConfig",

--- a/src/easynetwork/serializers/__init__.py
+++ b/src/easynetwork/serializers/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "NamedTupleStructSerializer",
     "PickleSerializer",
     "PicklerConfig",
+    "StringLineSerializer",
     "UnpicklerConfig",
     "ZlibCompressorSerializer",
 ]
@@ -36,6 +37,7 @@ from .abc import *
 from .base_stream import *
 from .cbor import *
 from .json import *
+from .line import *
 from .pickle import *
 from .struct import *
 from .wrapper import *

--- a/src/easynetwork/serializers/base_stream.py
+++ b/src/easynetwork/serializers/base_stream.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 __all__ = [
     "AutoSeparatedPacketSerializer",
+    "FileBasedIncrementalPacketSerializer",
     "FileBasedPacketSerializer",
     "FixedSizePacketSerializer",
 ]

--- a/src/easynetwork/serializers/cbor.py
+++ b/src/easynetwork/serializers/cbor.py
@@ -16,7 +16,7 @@ from dataclasses import asdict as dataclass_asdict, dataclass
 from functools import partial
 from typing import IO, TYPE_CHECKING, Any, Callable, TypeVar, final
 
-from .base_stream import FileBasedPacketSerializer
+from .base_stream import FileBasedIncrementalPacketSerializer
 
 if TYPE_CHECKING:
     import datetime
@@ -43,7 +43,7 @@ class CBORDecoderConfig:
     str_errors: str = "strict"
 
 
-class CBORSerializer(FileBasedPacketSerializer[_ST_contra, _DT_co]):
+class CBORSerializer(FileBasedIncrementalPacketSerializer[_ST_contra, _DT_co]):
     __slots__ = ("__encoder_cls", "__decoder_cls")
 
     def __init__(

--- a/src/easynetwork/serializers/line.py
+++ b/src/easynetwork/serializers/line.py
@@ -1,0 +1,61 @@
+# -*- coding: Utf-8 -*-
+# Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
+#
+#
+"""string line network packet serializer module"""
+
+from __future__ import annotations
+
+__all__ = ["StringLineSerializer"]
+
+from typing import Literal, assert_never, final
+
+from ..exceptions import DeserializeError
+from .base_stream import AutoSeparatedPacketSerializer
+
+
+class StringLineSerializer(AutoSeparatedPacketSerializer[str, str]):
+    __slots__ = ("__encoding", "__on_str_error")
+
+    def __init__(
+        self,
+        newline: Literal["LF", "CR", "CRLF"] = "LF",
+        *,
+        keepends: bool = False,
+        encoding: str = "ascii",
+        on_str_error: str = "strict",
+    ) -> None:
+        separator: bytes
+        match newline:
+            case "LF":
+                separator = b"\n"
+            case "CR":
+                separator = b"\r"
+            case "CRLF":
+                separator = b"\r\n"
+            case _:
+                assert_never(newline)
+        super().__init__(separator=separator, keepends=keepends)
+        self.__encoding: str = encoding
+        self.__on_str_error: str = on_str_error
+
+    @final
+    def serialize(self, packet: str) -> bytes:
+        if not isinstance(packet, str):
+            raise TypeError(f"Expected a string, got {packet!r}")
+        return packet.encode(self.__encoding, self.__on_str_error)
+
+    @final
+    def deserialize(self, data: bytes) -> str:
+        try:
+            return data.decode(self.__encoding, self.__on_str_error)
+        except UnicodeError as exc:
+            raise DeserializeError(str(exc)) from exc
+
+    @property
+    def encoding(self) -> str:
+        return self.__encoding
+
+    @property
+    def on_string_error(self) -> str:
+        return self.__on_str_error

--- a/src/easynetwork/serializers/struct.py
+++ b/src/easynetwork/serializers/struct.py
@@ -86,7 +86,7 @@ class NamedTupleStructSerializer(AbstractStructSerializer[_NT, _NT], Generic[_NT
             if any(c in _ENDIANNESS_CHARACTERS for c in field_fmt):
                 raise ValueError(f"{field!r}: Invalid field format")
             if field_fmt and field_fmt[-1] == "s":
-                if len(field_fmt) > 1 and not field_fmt[:-1].isdigit():
+                if len(field_fmt) > 1 and not field_fmt[:-1].isdecimal():
                     raise ValueError(f"{field!r}: Invalid field format")
                 string_fields.add(field)
             elif len(field_fmt) != 1 or not field_fmt.isalpha():

--- a/src/easynetwork/serializers/wrapper/base64.py
+++ b/src/easynetwork/serializers/wrapper/base64.py
@@ -30,8 +30,10 @@ class Base64EncodedSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co])
         self,
         serializer: AbstractPacketSerializer[_ST_contra, _DT_co],
         signing_key: str | bytes | None = None,
+        *,
+        separator: bytes = b"\r\n",
     ) -> None:
-        super().__init__(separator=b"\r\n", keepends=False)
+        super().__init__(separator=separator, keepends=False)
         assert isinstance(serializer, AbstractPacketSerializer)
         self.__serializer: AbstractPacketSerializer[_ST_contra, _DT_co] = serializer
         if signing_key is not None:

--- a/src/easynetwork/serializers/wrapper/encryptor.py
+++ b/src/easynetwork/serializers/wrapper/encryptor.py
@@ -29,13 +29,14 @@ class EncryptorSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co]):
         key: str | bytes,
         *,
         token_ttl: int | None = None,
+        separator: bytes = b"\r\n",
     ) -> None:
         try:
             import cryptography.fernet
         except ModuleNotFoundError as exc:  # pragma: no cover
             raise ModuleNotFoundError("encryption dependencies are missing. Consider adding 'encryption' extra") from exc
 
-        super().__init__(separator=b"\r\n", keepends=False)
+        super().__init__(separator=separator, keepends=False)
         assert isinstance(serializer, AbstractPacketSerializer)
         self.__serializer: AbstractPacketSerializer[_ST_contra, _DT_co] = serializer
         self.__fernet = cryptography.fernet.Fernet(key)

--- a/tests/functional_test/test_serializers/base.py
+++ b/tests/functional_test/test_serializers/base.py
@@ -231,8 +231,6 @@ class BaseTestIncrementalSerializer(BaseTestSerializer):
         invalid_partial_data_extra_data: bytes | None,
     ) -> None:
         # Arrange
-        if invalid_partial_data_extra_data is not None:
-            assert len(invalid_partial_data_extra_data) > 0
         consumer = serializer_for_deserialization.incremental_deserialize()
         next(consumer)
 

--- a/tests/functional_test/test_serializers/test_json.py
+++ b/tests/functional_test/test_serializers/test_json.py
@@ -1,4 +1,5 @@
 # -*- coding: Utf-8 -*-
+# mypy: disable-error-code=override
 
 from __future__ import annotations
 
@@ -71,12 +72,19 @@ class TestJSONSerializer(BaseTestIncrementalSerializer):
 
     #### Invalid data
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="class", params=[b"invalid", b"\0"])
     @staticmethod
-    def invalid_complete_data() -> bytes:
-        return b"invalid"
+    def invalid_complete_data(request: Any) -> bytes:
+        return getattr(request, "param")
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="class", params=[b"[ invalid ]", b"\0"])
     @staticmethod
-    def invalid_partial_data() -> bytes:
-        return b"[ invalid ]"
+    def invalid_partial_data(request: Any) -> bytes:
+        return getattr(request, "param")
+
+    @pytest.fixture
+    @staticmethod
+    def invalid_partial_data_extra_data(invalid_partial_data: bytes) -> bytes:
+        if invalid_partial_data == b"\0":
+            return b""
+        return b"remaining_data"

--- a/tests/functional_test/test_serializers/test_line.py
+++ b/tests/functional_test/test_serializers/test_line.py
@@ -1,0 +1,103 @@
+# -*- coding: Utf-8 -*-
+# mypy: disable_error_code=override
+
+from __future__ import annotations
+
+from typing import Literal, final
+
+from easynetwork.serializers.line import StringLineSerializer
+
+import pytest
+
+from .base import BaseTestIncrementalSerializer
+
+_NEWLINES: dict[str, bytes] = {
+    "LF": b"\n",
+    "CR": b"\r",
+    "CRLF": b"\r\n",
+}
+
+
+@final
+class TestStringLineSerializer(BaseTestIncrementalSerializer):
+    #### Serializers
+    @pytest.fixture(scope="class", params=list(_NEWLINES))
+    @staticmethod
+    def newline(request: pytest.FixtureRequest) -> Literal["LF", "CR", "CRLF"]:
+        return getattr(request, "param")
+
+    @pytest.fixture(scope="class", params=["ascii", "utf-8"])
+    @staticmethod
+    def encoding(request: pytest.FixtureRequest) -> str:
+        return getattr(request, "param")
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def serializer(newline: Literal["LF", "CR", "CRLF"], encoding: str) -> StringLineSerializer:
+        return StringLineSerializer(newline, encoding=encoding)
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def serializer_for_serialization(serializer: StringLineSerializer) -> StringLineSerializer:
+        return serializer
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def serializer_for_deserialization(serializer: StringLineSerializer) -> StringLineSerializer:
+        return serializer
+
+    #### Packets to test
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def packet_to_serialize(encoding: str) -> str:
+        if encoding == "utf-8":
+            return "simple line with unicode 'é'"
+        return "simple line"
+
+    #### One-shot Serialize
+
+    @pytest.fixture(scope="class")
+    @classmethod
+    def expected_complete_data(cls, packet_to_serialize: str, encoding: str) -> bytes:
+        return packet_to_serialize.encode(encoding)
+
+    #### Incremental Serialize
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def expected_joined_data(expected_complete_data: bytes, newline: Literal["CR", "LF", "CRLF"]) -> bytes:
+        return expected_complete_data + _NEWLINES[newline]
+
+    #### One-shot Deserialize
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def complete_data(expected_complete_data: bytes) -> bytes:
+        return expected_complete_data
+
+    #### Incremental Deserialize
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def complete_data_for_incremental_deserialize(complete_data: bytes, newline: Literal["CR", "LF", "CRLF"]) -> bytes:
+        return complete_data + _NEWLINES[newline]
+
+    #### Invalid data
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def invalid_complete_data() -> bytes:
+        return "é".encode("latin-1")
+
+    @pytest.fixture
+    @staticmethod
+    def invalid_partial_data() -> bytes:
+        pytest.skip("Cannot be tested")
+
+    #### Other
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def oneshot_extra_data() -> bytes:
+        pytest.skip("Does not recognize extra data")

--- a/tests/functional_test/test_serializers/test_pickle.py
+++ b/tests/functional_test/test_serializers/test_pickle.py
@@ -11,14 +11,14 @@ from easynetwork.serializers.pickle import PicklerConfig, PickleSerializer, Unpi
 
 import pytest
 
-from .base import BaseTestIncrementalSerializer
+from .base import BaseTestSerializer
 from .samples.pickle import SAMPLES
 
 ALL_PROTOCOLS: tuple[int, ...] = tuple(range(0, pickle.HIGHEST_PROTOCOL + 1))
 
 
 @final
-class TestPickleSerializer(BaseTestIncrementalSerializer):
+class TestPickleSerializer(BaseTestSerializer):
     @pytest.fixture(scope="class", params=ALL_PROTOCOLS, ids=lambda p: f"pickle_data_protocol=={p}")
     @staticmethod
     def pickle_data_protocol(request: Any) -> int:
@@ -74,13 +74,6 @@ class TestPickleSerializer(BaseTestIncrementalSerializer):
             data = pickletools.optimize(data)
         return data
 
-    #### Incremental Serialize
-
-    @pytest.fixture(scope="class")
-    @staticmethod
-    def expected_joined_data(expected_complete_data: bytes) -> bytes:
-        return expected_complete_data
-
     #### One-shot Deserialize
 
     @pytest.fixture(scope="class")
@@ -97,13 +90,6 @@ class TestPickleSerializer(BaseTestIncrementalSerializer):
         if pickler_optimize:
             data = pickletools.optimize(data)
         return data
-
-    #### Incremental Deserialize
-
-    @pytest.fixture(scope="class")
-    @staticmethod
-    def complete_data_for_incremental_deserialize(complete_data: bytes) -> bytes:
-        return complete_data
 
     #### Invalid data
 

--- a/tests/scripts/async_server_test.py
+++ b/tests/scripts/async_server_test.py
@@ -10,25 +10,9 @@ from easynetwork.api_async.server.handler import AsyncBaseRequestHandler, AsyncC
 from easynetwork.api_async.server.tcp import AsyncTCPNetworkServer
 from easynetwork.api_async.server.udp import AsyncUDPNetworkServer
 from easynetwork.protocol import DatagramProtocol, StreamProtocol
-from easynetwork.serializers.base_stream import AutoSeparatedPacketSerializer
+from easynetwork.serializers.line import StringLineSerializer
 
 PORT = 9000
-
-
-class MyServerSerializer(AutoSeparatedPacketSerializer[str, str]):
-    def __init__(self) -> None:
-        super().__init__(separator=b"\n", keepends=False)
-
-    def serialize(self, packet: str) -> bytes:
-        return packet.encode("utf-8")
-
-    def deserialize(self, data: bytes) -> str:
-        try:
-            return data.decode("utf-8")
-        except UnicodeError as exc:
-            from easynetwork.exceptions import DeserializeError
-
-            raise DeserializeError(str(exc)) from exc
 
 
 class MyAsyncRequestHandler(AsyncBaseRequestHandler[str, str]):
@@ -37,11 +21,11 @@ class MyAsyncRequestHandler(AsyncBaseRequestHandler[str, str]):
 
 
 def create_tcp_server() -> AsyncTCPNetworkServer[str, str]:
-    return AsyncTCPNetworkServer(None, PORT, StreamProtocol(MyServerSerializer()), MyAsyncRequestHandler())
+    return AsyncTCPNetworkServer(None, PORT, StreamProtocol(StringLineSerializer()), MyAsyncRequestHandler())
 
 
 def create_udp_server() -> AsyncUDPNetworkServer[str, str]:
-    return AsyncUDPNetworkServer(None, PORT, DatagramProtocol(MyServerSerializer()), MyAsyncRequestHandler())
+    return AsyncUDPNetworkServer(None, PORT, DatagramProtocol(StringLineSerializer()), MyAsyncRequestHandler())
 
 
 async def main() -> None:

--- a/tests/unit_test/test_serializers/test_cbor.py
+++ b/tests/unit_test/test_serializers/test_cbor.py
@@ -92,10 +92,10 @@ class TestCBORSerializer(BaseSerializerConfigInstanceCheck):
     @pytest.mark.parametrize("method", ["serialize", "incremental_serialize", "deserialize", "incremental_deserialize"])
     def test____base_class____implements_default_methods(self, method: str) -> None:
         # Arrange
-        from easynetwork.serializers.base_stream import FileBasedPacketSerializer
+        from easynetwork.serializers.base_stream import FileBasedIncrementalPacketSerializer
 
         # Act & Assert
-        assert getattr(CBORSerializer, method) is getattr(FileBasedPacketSerializer, method)
+        assert getattr(CBORSerializer, method) is getattr(FileBasedIncrementalPacketSerializer, method)
 
     def test____dump_to_file____with_config(
         self,

--- a/tests/unit_test/test_serializers/test_line.py
+++ b/tests/unit_test/test_serializers/test_line.py
@@ -1,0 +1,153 @@
+# -*- coding: Utf-8 -*
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from easynetwork.exceptions import DeserializeError
+from easynetwork.serializers.line import StringLineSerializer
+
+import pytest
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+_NEWLINES: dict[str, bytes] = {
+    "LF": b"\n",
+    "CR": b"\r",
+    "CRLF": b"\r\n",
+}
+
+
+class TestStringLineSerializer:
+    @pytest.fixture(params=list(_NEWLINES))
+    @staticmethod
+    def newline(request: pytest.FixtureRequest) -> Literal["LF", "CR", "CRLF"]:
+        return getattr(request, "param")
+
+    @pytest.fixture(params=["ascii", "utf-8"])
+    @staticmethod
+    def encoding(request: pytest.FixtureRequest) -> str:
+        return getattr(request, "param")
+
+    @pytest.fixture(params=["strict", "ignore", "replace"])
+    @staticmethod
+    def on_string_error(request: pytest.FixtureRequest) -> str:
+        return getattr(request, "param")
+
+    @pytest.fixture
+    @staticmethod
+    def serializer(newline: Literal["LF", "CR", "CRLF"], encoding: str, on_string_error: str) -> StringLineSerializer:
+        return StringLineSerializer(newline, encoding=encoding, on_str_error=on_string_error)
+
+    @pytest.mark.parametrize("method", ["incremental_serialize", "incremental_deserialize"])
+    def test____base_class____implements_default_methods(self, method: str) -> None:
+        # Arrange
+        from easynetwork.serializers.base_stream import AutoSeparatedPacketSerializer
+
+        # Act & Assert
+        assert getattr(StringLineSerializer, method) is getattr(AutoSeparatedPacketSerializer, method)
+
+    def test____dunder_init____default(self) -> None:
+        # Arrange
+
+        # Act
+        serializer = StringLineSerializer()
+
+        # Assert
+        assert serializer.separator == b"\n"
+        assert serializer.encoding == "ascii"
+        assert serializer.on_string_error == "strict"
+        assert not serializer.keepends
+
+    @pytest.mark.parametrize("keepends", [False, True], ids=lambda boolean: f"keepends=={boolean}")
+    def test____dunder_init____with_parameters(
+        self,
+        keepends: bool,
+        newline: Literal["LF", "CR", "CRLF"],
+        encoding: str,
+        on_string_error: str,
+    ) -> None:
+        # Arrange
+
+        # Act
+        serializer = StringLineSerializer(newline, keepends=keepends, encoding=encoding, on_str_error=on_string_error)
+
+        # Assert
+        assert serializer.separator == _NEWLINES[newline]
+        assert serializer.encoding == encoding
+        assert serializer.on_string_error == on_string_error
+        assert serializer.keepends == keepends
+
+    def test____dunder_init____invalid_newline_value(
+        self,
+    ) -> None:
+        # Arrange
+
+        # Act & Assert
+        with pytest.raises(AssertionError):
+            StringLineSerializer("something else")  # type: ignore[arg-type]
+
+    def test____serialize____encode_string(
+        self,
+        serializer: StringLineSerializer,
+        encoding: str,
+        on_string_error: str,
+        mocker: MockerFixture,
+    ) -> None:
+        # Arrange
+        mock_string = mocker.NonCallableMagicMock(spec=str)
+        mock_string.encode.return_value = mocker.sentinel.result
+
+        # Act
+        data = serializer.serialize(mock_string)
+
+        # Assert
+        assert data is mocker.sentinel.result
+        mock_string.encode.assert_called_once_with(encoding, on_string_error)
+
+    def test____serialize____not_a_string_error(
+        self,
+        serializer: StringLineSerializer,
+    ) -> None:
+        # Arrange
+
+        # Act & Assert
+        with pytest.raises(TypeError, match=r"^Expected a string, got 4$"):
+            serializer.serialize(4)  # type: ignore[arg-type]
+
+    def test____deserialize____decode_string(
+        self,
+        serializer: StringLineSerializer,
+        encoding: str,
+        on_string_error: str,
+        mocker: MockerFixture,
+    ) -> None:
+        # Arrange
+        mock_bytes = mocker.NonCallableMagicMock(spec=bytes)
+        mock_bytes.decode.return_value = mocker.sentinel.result
+
+        # Act
+        line = serializer.deserialize(mock_bytes)
+
+        # Assert
+        assert line is mocker.sentinel.result
+        mock_bytes.decode.assert_called_once_with(encoding, on_string_error)
+
+    def test____deserialize____decode_string_error(
+        self,
+        serializer: StringLineSerializer,
+        encoding: str,
+        on_string_error: str,
+        mocker: MockerFixture,
+    ) -> None:
+        # Arrange
+        mock_bytes = mocker.NonCallableMagicMock(spec=bytes)
+        mock_bytes.decode.side_effect = UnicodeError
+
+        # Act
+        with pytest.raises(DeserializeError):
+            serializer.deserialize(mock_bytes)
+
+        # Assert
+        mock_bytes.decode.assert_called_once_with(encoding, on_string_error)

--- a/tests/unit_test/test_serializers/test_pickle.py
+++ b/tests/unit_test/test_serializers/test_pickle.py
@@ -90,7 +90,7 @@ class TestPickleSerializer(BaseSerializerConfigInstanceCheck):
     def mock_pickletools_optimize(mocker: MockerFixture) -> MagicMock:
         return mocker.patch("pickletools.optimize", autospec=True)
 
-    @pytest.mark.parametrize("method", ["serialize", "incremental_serialize", "deserialize", "incremental_deserialize"])
+    @pytest.mark.parametrize("method", ["serialize", "deserialize"])
     def test____base_class____implements_default_methods(self, method: str) -> None:
         # Arrange
         from easynetwork.serializers.base_stream import FileBasedPacketSerializer


### PR DESCRIPTION
- `PickleSerializer` cannot be used in `StreamProtocol` anymore
  - There is a lot of memory issues (including `SystemError` raise ^^)
- Added missing tests for `JSONSerializer` and `NamedTupleStructSerializer`
- Added `StringLineSerializer`
- `FileBasedSerializer` has been splitted to two classes:
  - `FileBasedSerializer` is only for one-shot (de)serialization
  - `FileBasedIncrementalSerializer` which also handle incremental mode