### PR TITLE
AsyncioBackend: transport=True by default

### DIFF
--- a/src/easynetwork_asyncio/backend.py
+++ b/src/easynetwork_asyncio/backend.py
@@ -38,7 +38,7 @@ _T_co = TypeVar("_T_co", covariant=True)
 class AsyncioBackend(AbstractAsyncBackend):
     __slots__ = ("__use_asyncio_transport",)
 
-    def __init__(self, *, transport: bool = False) -> None:
+    def __init__(self, *, transport: bool = True) -> None:
         self.__use_asyncio_transport: bool = bool(transport)
 
     @staticmethod
@@ -309,3 +309,6 @@ class AsyncioBackend(AbstractAsyncBackend):
                 self._really_uncancel_task(self._current_asyncio_task())
 
         return await self._cancel_shielded_wait_asyncio_future(asyncio.wrap_future(future))
+
+    def use_asyncio_transport(self) -> bool:
+        return self.__use_asyncio_transport

--- a/tests/functional_test/test_async/test_backend/test_asyncio_backend.py
+++ b/tests/functional_test/test_async/test_backend/test_asyncio_backend.py
@@ -20,6 +20,9 @@ class TestAsyncioBackend:
         assert isinstance(backend, AsyncioBackend)
         return backend
 
+    async def test____use_asyncio_transport____True_by_default(self, backend: AsyncioBackend) -> None:
+        assert backend.use_asyncio_transport()
+
     async def test____ignore_cancellation____always_continue_on_cancellation(
         self,
         event_loop: asyncio.AbstractEventLoop,

--- a/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
@@ -37,6 +37,13 @@ class TestAsyncIOBackend:
     def remote_address(request: Any) -> tuple[str, int] | None:
         return request.param
 
+    async def test____use_asyncio_transport____follows_option(
+        self,
+        backend: AsyncioBackend,
+        use_asyncio_transport: bool,
+    ) -> None:
+        assert backend.use_asyncio_transport() == use_asyncio_transport
+
     async def test____coro_yield____use_asyncio_sleep(
         self,
         backend: AsyncioBackend,


### PR DESCRIPTION
Since `asyncio` transports has been around much longer and is much more stable, it makes sense to use this API by default ^^'