### PR TITLE
Synchronous clients: Do not ever use socket.settimeout()

### DIFF
--- a/tests/unit_test/test_sync/test_client/base.py
+++ b/tests/unit_test/test_sync/test_client/base.py
@@ -2,8 +2,18 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ...base import BaseTestSocket
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+    from pytest_mock import MockerFixture
 
 
 class BaseTestClient(BaseTestSocket):
-    pass
+    @staticmethod
+    def selector_timeout_after_n_calls(mock_selector_select: MagicMock, mocker: MockerFixture, nb_calls: int) -> None:
+        key = mocker.sentinel.key
+        mock_selector_select.side_effect = [[key] for _ in range(nb_calls)] + [[]]

--- a/tests/unit_test/test_sync/test_client/conftest.py
+++ b/tests/unit_test/test_sync/test_client/conftest.py
@@ -1,0 +1,37 @@
+# -*- coding: Utf-8 -*-
+
+from __future__ import annotations
+
+from selectors import BaseSelector
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def mock_selector(mocker: MockerFixture) -> MagicMock:
+    mock_selector = mocker.NonCallableMagicMock(spec=BaseSelector)
+    mock_selector.__enter__.return_value = mock_selector
+    mock_selector.register.return_value = None
+    mock_selector.select.return_value = [mocker.sentinel.key]
+    return mock_selector
+
+
+@pytest.fixture(autouse=True)
+def mock_selector_cls(mock_selector: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("selectors.PollSelector", return_value=mock_selector, create=True)
+
+
+@pytest.fixture
+def mock_selector_register(mock_selector: MagicMock) -> MagicMock:
+    return mock_selector.register
+
+
+@pytest.fixture
+def mock_selector_select(mock_selector: MagicMock) -> MagicMock:
+    return mock_selector.select


### PR DESCRIPTION
With the PR #30 where there is two distinct locks for `send_packet()` and `recv_packet()`, `socket.settimeout()` should not be used.