### PR TITLE
Improved easynetwork.serializers module, part 2

### DIFF
--- a/src/easynetwork/serializers/__init__.py
+++ b/src/easynetwork/serializers/__init__.py
@@ -18,7 +18,6 @@ __all__ = [
     "CBOREncoderConfig",
     "CBORSerializer",
     "EncryptorSerializer",
-    "FileBasedIncrementalPacketSerializer",
     "FileBasedPacketSerializer",
     "FixedSizePacketSerializer",
     "JSONDecoderConfig",

--- a/src/easynetwork/serializers/cbor.py
+++ b/src/easynetwork/serializers/cbor.py
@@ -16,7 +16,7 @@ from dataclasses import asdict as dataclass_asdict, dataclass
 from functools import partial
 from typing import IO, TYPE_CHECKING, Any, Callable, TypeVar, final
 
-from .base_stream import FileBasedIncrementalPacketSerializer
+from .base_stream import FileBasedPacketSerializer
 
 if TYPE_CHECKING:
     import datetime
@@ -43,7 +43,7 @@ class CBORDecoderConfig:
     str_errors: str = "strict"
 
 
-class CBORSerializer(FileBasedIncrementalPacketSerializer[_ST_contra, _DT_co]):
+class CBORSerializer(FileBasedPacketSerializer[_ST_contra, _DT_co]):
     __slots__ = ("__encoder_cls", "__decoder_cls")
 
     def __init__(

--- a/src/easynetwork/serializers/line.py
+++ b/src/easynetwork/serializers/line.py
@@ -15,15 +15,14 @@ from .base_stream import AutoSeparatedPacketSerializer
 
 
 class StringLineSerializer(AutoSeparatedPacketSerializer[str, str]):
-    __slots__ = ("__encoding", "__on_str_error")
+    __slots__ = ("__encoding", "__unicode_errors")
 
     def __init__(
         self,
         newline: Literal["LF", "CR", "CRLF"] = "LF",
         *,
-        keepends: bool = False,
         encoding: str = "ascii",
-        on_str_error: str = "strict",
+        unicode_errors: str = "strict",
     ) -> None:
         separator: bytes
         match newline:
@@ -35,20 +34,20 @@ class StringLineSerializer(AutoSeparatedPacketSerializer[str, str]):
                 separator = b"\r\n"
             case _:
                 assert_never(newline)
-        super().__init__(separator=separator, keepends=keepends)
+        super().__init__(separator=separator)
         self.__encoding: str = encoding
-        self.__on_str_error: str = on_str_error
+        self.__unicode_errors: str = unicode_errors
 
     @final
     def serialize(self, packet: str) -> bytes:
         if not isinstance(packet, str):
             raise TypeError(f"Expected a string, got {packet!r}")
-        return packet.encode(self.__encoding, self.__on_str_error)
+        return packet.encode(self.__encoding, self.__unicode_errors)
 
     @final
     def deserialize(self, data: bytes) -> str:
         try:
-            return data.decode(self.__encoding, self.__on_str_error)
+            return data.decode(self.__encoding, self.__unicode_errors)
         except UnicodeError as exc:
             raise DeserializeError(str(exc)) from exc
 
@@ -57,5 +56,5 @@ class StringLineSerializer(AutoSeparatedPacketSerializer[str, str]):
         return self.__encoding
 
     @property
-    def on_string_error(self) -> str:
-        return self.__on_str_error
+    def unicode_errors(self) -> str:
+        return self.__unicode_errors

--- a/src/easynetwork/serializers/wrapper/base64.py
+++ b/src/easynetwork/serializers/wrapper/base64.py
@@ -33,7 +33,7 @@ class Base64EncodedSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co])
         *,
         separator: bytes = b"\r\n",
     ) -> None:
-        super().__init__(separator=separator, keepends=False)
+        super().__init__(separator=separator)
         assert isinstance(serializer, AbstractPacketSerializer)
         self.__serializer: AbstractPacketSerializer[_ST_contra, _DT_co] = serializer
         if signing_key is not None:

--- a/src/easynetwork/serializers/wrapper/encryptor.py
+++ b/src/easynetwork/serializers/wrapper/encryptor.py
@@ -36,7 +36,7 @@ class EncryptorSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co]):
         except ModuleNotFoundError as exc:  # pragma: no cover
             raise ModuleNotFoundError("encryption dependencies are missing. Consider adding 'encryption' extra") from exc
 
-        super().__init__(separator=separator, keepends=False)
+        super().__init__(separator=separator)
         assert isinstance(serializer, AbstractPacketSerializer)
         self.__serializer: AbstractPacketSerializer[_ST_contra, _DT_co] = serializer
         self.__fernet = cryptography.fernet.Fernet(key)

--- a/tests/unit_test/test_serializers/test_cbor.py
+++ b/tests/unit_test/test_serializers/test_cbor.py
@@ -92,10 +92,10 @@ class TestCBORSerializer(BaseSerializerConfigInstanceCheck):
     @pytest.mark.parametrize("method", ["serialize", "incremental_serialize", "deserialize", "incremental_deserialize"])
     def test____base_class____implements_default_methods(self, method: str) -> None:
         # Arrange
-        from easynetwork.serializers.base_stream import FileBasedIncrementalPacketSerializer
+        from easynetwork.serializers.base_stream import FileBasedPacketSerializer
 
         # Act & Assert
-        assert getattr(CBORSerializer, method) is getattr(FileBasedIncrementalPacketSerializer, method)
+        assert getattr(CBORSerializer, method) is getattr(FileBasedPacketSerializer, method)
 
     def test____dump_to_file____with_config(
         self,

--- a/tests/unit_test/test_serializers/test_line.py
+++ b/tests/unit_test/test_serializers/test_line.py
@@ -32,13 +32,13 @@ class TestStringLineSerializer:
 
     @pytest.fixture(params=["strict", "ignore", "replace"])
     @staticmethod
-    def on_string_error(request: pytest.FixtureRequest) -> str:
+    def unicode_errors(request: pytest.FixtureRequest) -> str:
         return getattr(request, "param")
 
     @pytest.fixture
     @staticmethod
-    def serializer(newline: Literal["LF", "CR", "CRLF"], encoding: str, on_string_error: str) -> StringLineSerializer:
-        return StringLineSerializer(newline, encoding=encoding, on_str_error=on_string_error)
+    def serializer(newline: Literal["LF", "CR", "CRLF"], encoding: str, unicode_errors: str) -> StringLineSerializer:
+        return StringLineSerializer(newline, encoding=encoding, unicode_errors=unicode_errors)
 
     @pytest.mark.parametrize("method", ["incremental_serialize", "incremental_deserialize"])
     def test____base_class____implements_default_methods(self, method: str) -> None:
@@ -57,27 +57,23 @@ class TestStringLineSerializer:
         # Assert
         assert serializer.separator == b"\n"
         assert serializer.encoding == "ascii"
-        assert serializer.on_string_error == "strict"
-        assert not serializer.keepends
+        assert serializer.unicode_errors == "strict"
 
-    @pytest.mark.parametrize("keepends", [False, True], ids=lambda boolean: f"keepends=={boolean}")
     def test____dunder_init____with_parameters(
         self,
-        keepends: bool,
         newline: Literal["LF", "CR", "CRLF"],
         encoding: str,
-        on_string_error: str,
+        unicode_errors: str,
     ) -> None:
         # Arrange
 
         # Act
-        serializer = StringLineSerializer(newline, keepends=keepends, encoding=encoding, on_str_error=on_string_error)
+        serializer = StringLineSerializer(newline, encoding=encoding, unicode_errors=unicode_errors)
 
         # Assert
         assert serializer.separator == _NEWLINES[newline]
         assert serializer.encoding == encoding
-        assert serializer.on_string_error == on_string_error
-        assert serializer.keepends == keepends
+        assert serializer.unicode_errors == unicode_errors
 
     def test____dunder_init____invalid_newline_value(
         self,
@@ -92,7 +88,7 @@ class TestStringLineSerializer:
         self,
         serializer: StringLineSerializer,
         encoding: str,
-        on_string_error: str,
+        unicode_errors: str,
         mocker: MockerFixture,
     ) -> None:
         # Arrange
@@ -104,7 +100,7 @@ class TestStringLineSerializer:
 
         # Assert
         assert data is mocker.sentinel.result
-        mock_string.encode.assert_called_once_with(encoding, on_string_error)
+        mock_string.encode.assert_called_once_with(encoding, unicode_errors)
 
     def test____serialize____not_a_string_error(
         self,
@@ -120,7 +116,7 @@ class TestStringLineSerializer:
         self,
         serializer: StringLineSerializer,
         encoding: str,
-        on_string_error: str,
+        unicode_errors: str,
         mocker: MockerFixture,
     ) -> None:
         # Arrange
@@ -132,13 +128,13 @@ class TestStringLineSerializer:
 
         # Assert
         assert line is mocker.sentinel.result
-        mock_bytes.decode.assert_called_once_with(encoding, on_string_error)
+        mock_bytes.decode.assert_called_once_with(encoding, unicode_errors)
 
     def test____deserialize____decode_string_error(
         self,
         serializer: StringLineSerializer,
         encoding: str,
-        on_string_error: str,
+        unicode_errors: str,
         mocker: MockerFixture,
     ) -> None:
         # Arrange
@@ -150,4 +146,4 @@ class TestStringLineSerializer:
             serializer.deserialize(mock_bytes)
 
         # Assert
-        mock_bytes.decode.assert_called_once_with(encoding, on_string_error)
+        mock_bytes.decode.assert_called_once_with(encoding, unicode_errors)


### PR DESCRIPTION
- Removed `keepends` parameter for `AutoSeparatedPacketSerializer`
- `PickleSerializer` do not depend on `FileBasedPacketSerializer` anymore
- `StringLineSerializer`: `on_str_error` option renamed to `unicode_errors`