### PR TITLE
Async backend: Added task waiting interface

### DIFF
--- a/src/easynetwork/api_async/backend/abc.py
+++ b/src/easynetwork/api_async/backend/abc.py
@@ -93,6 +93,10 @@ class AbstractTask(Generic[_T_co], metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
+    async def wait(self) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
     async def join(self) -> _T_co:
         raise NotImplementedError
 
@@ -261,6 +265,10 @@ class AbstractAsyncBackend(metaclass=ABCMeta):
 
     @abstractmethod
     async def ignore_cancellation(self, coroutine: Coroutine[Any, Any, _T_co]) -> _T_co:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def wait_for(self, coroutine: Coroutine[Any, Any, _T_co], timeout: float | None) -> _T_co:
         raise NotImplementedError
 
     @abstractmethod

--- a/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
+++ b/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
@@ -34,6 +34,9 @@ class BaseFakeBackend(AbstractAsyncBackend):
     async def ignore_cancellation(self, coroutine: Coroutine[Any, Any, Any]) -> Any:
         raise NotImplementedError
 
+    async def wait_for(self, coroutine: Coroutine[Any, Any, Any], timeout: float | None) -> Any:
+        raise NotImplementedError
+
     def get_cancelled_exc_class(self) -> type[BaseException]:
         raise NotImplementedError
 

--- a/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
@@ -752,38 +752,6 @@ class TestAsyncIOBackend:
         func_stub.assert_not_called()
         assert ret_val is mocker.sentinel.return_value
 
-    async def test____run_in_thread____early_cancel(
-        self,
-        event_loop: asyncio.AbstractEventLoop,
-        backend: AsyncioBackend,
-        mocker: MockerFixture,
-    ) -> None:
-        # Arrange
-        func_stub = mocker.stub()
-        mock_to_thread: AsyncMock = mocker.patch(
-            "asyncio.to_thread",
-            new_callable=mocker.AsyncMock,
-            return_value=mocker.sentinel.return_value,
-        )
-
-        # Act
-        task = event_loop.create_task(
-            backend.run_in_thread(
-                func_stub,
-                mocker.sentinel.arg1,
-                mocker.sentinel.arg2,
-                kw1=mocker.sentinel.kwargs1,
-                kw2=mocker.sentinel.kwargs2,
-            )
-        )
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-
-        # Assert
-        mock_to_thread.assert_not_awaited()
-        func_stub.assert_not_called()
-
     @pytest.mark.parametrize("max_workers", [None, 1, 99])
     async def test___create_thread_pool_executor____returns_AsyncThreadPoolExecutor_instance(
         self,


### PR DESCRIPTION
- Added `Task.wait()` method to wait for task completion without unwrapping result
- Added `AsyncBackend.wait_for(coro, timeout)` to wait for a coroutine to finish within a certain delay