### PR TITLE
easynetwork_asyncio: Improvements/optimizations

### DIFF
--- a/src/easynetwork_asyncio/_utils.py
+++ b/src/easynetwork_asyncio/_utils.py
@@ -25,7 +25,14 @@ async def _ensure_resolved(
     proto: int = 0,
     flags: int = 0,
 ) -> Sequence[tuple[int, int, int, str, tuple[Any, ...]]]:
-    info = await loop.getaddrinfo(host, port, family=family, type=type, proto=proto, flags=flags)
+    try:
+        info = _socket.getaddrinfo(
+            host, port, family=family, type=type, proto=proto, flags=flags | _socket.AI_NUMERICHOST | _socket.AI_NUMERICSERV
+        )
+    except _socket.gaierror as exc:
+        if exc.errno != _socket.EAI_NONAME:
+            raise
+        info = await loop.getaddrinfo(host, port, family=family, type=type, proto=proto, flags=flags)
     if not info:
         raise OSError(f"getaddrinfo({host!r}) returned empty list")
     return info

--- a/src/easynetwork_asyncio/backend.py
+++ b/src/easynetwork_asyncio/backend.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 __all__ = ["AsyncioBackend"]  # type: list[str]
 
+import contextvars
 import functools
 import inspect
 import socket as _socket
@@ -416,7 +417,18 @@ class AsyncioBackend(AbstractAsyncBackend):
     async def run_in_thread(self, __func: Callable[_P, _T], /, *args: _P.args, **kwargs: _P.kwargs) -> _T:
         import asyncio
 
-        return await self.ignore_cancellation(asyncio.to_thread(__func, *args, **kwargs))
+        loop = asyncio.get_running_loop()
+        ctx = contextvars.copy_context()
+
+        try:
+            import sniffio
+        except ImportError:
+            pass
+        else:
+            ctx.run(sniffio.current_async_library_cvar.set, None)
+
+        func_call: Callable[..., _T] = functools.partial(ctx.run, __func, *args, **kwargs)  # type: ignore[assignment]
+        return await self._cancel_shielded_wait_asyncio_future(loop.run_in_executor(None, func_call))
 
     def create_thread_pool_executor(self, max_workers: int | None = None) -> AbstractAsyncThreadPoolExecutor:
         from .threads import AsyncThreadPoolExecutor

--- a/src/easynetwork_asyncio/backend.py
+++ b/src/easynetwork_asyncio/backend.py
@@ -297,6 +297,7 @@ class AsyncioBackend(AbstractAsyncBackend):
         reuse_port: bool = False,
     ) -> Sequence[AbstractAsyncListenerSocketAdapter]:
         self._check_ssl_support()
+        self.__verify_ssl_context(ssl_context)
 
         from .stream.listener import AcceptedSSLSocket
 

--- a/tests/unit_test/test_async/conftest.py
+++ b/tests/unit_test/test_async/conftest.py
@@ -23,6 +23,13 @@ class FakeCancellation(BaseException):
     pass
 
 
+@pytest.fixture(scope="package", autouse=True)
+def __mute_socket_getaddrinfo(package_mocker: MockerFixture) -> None:
+    from socket import EAI_NONAME, gaierror
+
+    package_mocker.patch("socket.getaddrinfo", autospec=True, side_effect=gaierror(EAI_NONAME, "Name or service not known"))
+
+
 @pytest.fixture(scope="session")
 def fake_cancellation_cls() -> type[BaseException]:
     return FakeCancellation


### PR DESCRIPTION
- Set `sniffio.current_async_library_cvar` if `sniffio` package is installed. This impacts:
  - `AsyncioBackend.run_in_thread()`
    - Do not use `asyncio.to_thread()` anymore
  - `AsyncThreadPoolExecutor.run()`
  - `ThreadsPortal.run_coroutine()`
  - `ThreadsPortal.run_sync()`
- `_ensure_resolved`: Use numeric host flag in order not to always call `getaddrinfo()` in thread