### PR TITLE
easynetwork.api_async.backend improvements

### DIFF
--- a/src/easynetwork/api_async/backend/threads.py
+++ b/src/easynetwork/api_async/backend/threads.py
@@ -1,0 +1,81 @@
+# -*- coding: Utf-8 -*-
+# Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
+#
+#
+"""
+Asynchronous client/server module
+"""
+
+from __future__ import annotations
+
+__all__ = ["DefaultAsyncThreadPoolExecutor"]
+
+import concurrent.futures
+import contextvars
+import threading
+from typing import TYPE_CHECKING, Callable, ParamSpec, TypeVar, final
+
+from .abc import AbstractAsyncThreadPoolExecutor
+
+if TYPE_CHECKING:
+    from .abc import AbstractAsyncBackend
+
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
+
+
+@final
+class DefaultAsyncThreadPoolExecutor(AbstractAsyncThreadPoolExecutor):
+    __slots__ = ("__backend", "__executor", "__shutdown_future")
+
+    def __init__(self, backend: AbstractAsyncBackend, max_workers: int | None = None) -> None:
+        super().__init__()
+
+        self.__backend: AbstractAsyncBackend = backend
+        self.__executor = concurrent.futures.ThreadPoolExecutor(max_workers)
+        self.__shutdown_future: concurrent.futures.Future[None] | None = None
+
+    async def run(self, __func: Callable[_P, _T], /, *args: _P.args, **kwargs: _P.kwargs) -> _T:
+        ctx = contextvars.copy_context()
+
+        try:
+            import sniffio
+        except ImportError:
+            pass
+        else:
+            ctx.run(sniffio.current_async_library_cvar.set, None)
+
+        future: concurrent.futures.Future[_T] = self.__executor.submit(ctx.run, __func, *args, **kwargs)  # type: ignore[arg-type]
+        return await self.__backend.wait_future(future)
+
+    async def shutdown(self) -> None:
+        if self.__shutdown_future is not None:
+            return await self.__backend.wait_future(self.__shutdown_future)
+        shutdown_future: concurrent.futures.Future[None] = concurrent.futures.Future()
+        shutdown_future.set_running_or_notify_cancel()
+        assert shutdown_future.running()
+        thread = threading.Thread(target=self.__do_shutdown, args=(self.__executor, shutdown_future))
+        thread.start()
+        try:
+            self.__shutdown_future = shutdown_future
+            await self.__backend.wait_future(self.__shutdown_future)
+        finally:
+            del shutdown_future
+            thread.join()
+
+    @staticmethod
+    def __do_shutdown(
+        executor: concurrent.futures.ThreadPoolExecutor,
+        future: concurrent.futures.Future[None],
+    ) -> None:
+        try:
+            executor.shutdown(wait=True)
+        except BaseException as exc:  # pragma: no cover
+            future.set_exception(exc)
+        else:
+            future.set_result(None)
+        finally:
+            del future
+
+    def get_max_number_of_workers(self) -> int:
+        return self.__executor._max_workers

--- a/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
+++ b/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
@@ -10,9 +10,9 @@ from easynetwork.api_async.backend.abc import (
     AbstractAsyncDatagramSocketAdapter,
     AbstractAsyncListenerSocketAdapter,
     AbstractAsyncStreamSocketAdapter,
-    AbstractAsyncThreadPoolExecutor,
     AbstractTaskGroup,
     AbstractThreadsPortal,
+    ICondition,
     IEvent,
     ILock,
 )
@@ -64,10 +64,10 @@ class BaseFakeBackend(AbstractAsyncBackend):
     def create_event(self) -> IEvent:
         raise NotImplementedError
 
-    async def run_in_thread(self, __func: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
+    def create_condition_var(self, lock: ILock | None = ...) -> ICondition:
         raise NotImplementedError
 
-    def create_thread_pool_executor(self, *args: Any, **kwargs: Any) -> AbstractAsyncThreadPoolExecutor:
+    async def run_in_thread(self, __func: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError
 
     def create_threads_portal(self) -> AbstractThreadsPortal:

--- a/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
@@ -1148,6 +1148,24 @@ class TestAsyncIOBackend:
         mock_Event.assert_called_once_with()
         assert event is mocker.sentinel.event
 
+    @pytest.mark.parametrize("use_lock", [None, asyncio.Lock])
+    async def test____create_condition_var____use_asyncio_Condition_class(
+        self,
+        use_lock: type[asyncio.Lock] | None,
+        backend: AsyncioBackend,
+        mocker: MockerFixture,
+    ) -> None:
+        # Arrange
+        mock_lock: MagicMock | None = None if use_lock is None else mocker.NonCallableMagicMock(spec=use_lock)
+        mock_Condition = mocker.patch("asyncio.Condition", return_value=mocker.sentinel.condition_var)
+
+        # Act
+        condition = backend.create_condition_var(mock_lock)
+
+        # Assert
+        mock_Condition.assert_called_once_with(mock_lock)
+        assert condition is mocker.sentinel.condition_var
+
     async def test____run_in_thread____use_loop_run_in_executor(
         self,
         event_loop: asyncio.AbstractEventLoop,
@@ -1194,14 +1212,14 @@ class TestAsyncIOBackend:
         backend: AsyncioBackend,
     ) -> None:
         # Arrange
-        from easynetwork_asyncio.threads import AsyncThreadPoolExecutor
+        from easynetwork.api_async.backend.threads import DefaultAsyncThreadPoolExecutor
 
         # Act
         async with backend.create_thread_pool_executor(max_workers) as executor:
             pass
 
         # Assert
-        assert isinstance(executor, AsyncThreadPoolExecutor)
+        assert isinstance(executor, DefaultAsyncThreadPoolExecutor)
         if max_workers is None:
             assert executor.get_max_number_of_workers() > 0
         else:

--- a/tests/unit_test/test_async/test_asyncio_backend/test_threads.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_threads.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any
 from easynetwork_asyncio.threads import ThreadsPortal
 
 import pytest
-import pytest_asyncio
 
 if TYPE_CHECKING:
     from unittest.mock import AsyncMock, MagicMock
@@ -18,14 +17,16 @@ if TYPE_CHECKING:
 
 @pytest.mark.asyncio
 class TestAsyncioThreadsPortal:
-    @pytest_asyncio.fixture
+    @pytest.fixture
     @staticmethod
-    async def threads_portal() -> ThreadsPortal:
-        return ThreadsPortal()
+    def threads_portal(event_loop: asyncio.AbstractEventLoop) -> ThreadsPortal:
+        return ThreadsPortal(loop=event_loop)
 
+    @pytest.mark.parametrize("run_soon", [False, True], ids=lambda p: f"run_soon=={p}")
     async def test____run_coroutine____use_asyncio_run_coroutine_threadsafe(
         self,
         event_loop: asyncio.AbstractEventLoop,
+        run_soon: bool,
         threads_portal: ThreadsPortal,
         mocker: MockerFixture,
     ) -> None:
@@ -42,13 +43,23 @@ class TestAsyncioThreadsPortal:
 
         def test_thread() -> None:
             nonlocal ret_val
-            ret_val = threads_portal.run_coroutine(
-                coro_func_stub,
-                mocker.sentinel.arg1,
-                mocker.sentinel.arg2,
-                kw1=mocker.sentinel.kwargs1,
-                kw2=mocker.sentinel.kwargs2,
-            )
+            if run_soon:
+                future = threads_portal.run_coroutine_soon(
+                    coro_func_stub,
+                    mocker.sentinel.arg1,
+                    mocker.sentinel.arg2,
+                    kw1=mocker.sentinel.kwargs1,
+                    kw2=mocker.sentinel.kwargs2,
+                )
+                ret_val = future.result()
+            else:
+                ret_val = threads_portal.run_coroutine(
+                    coro_func_stub,
+                    mocker.sentinel.arg1,
+                    mocker.sentinel.arg2,
+                    kw1=mocker.sentinel.kwargs1,
+                    kw2=mocker.sentinel.kwargs2,
+                )
 
         await asyncio.to_thread(test_thread)
 
@@ -69,7 +80,10 @@ class TestAsyncioThreadsPortal:
     ) -> None:
         # Arrange
         func_stub: AsyncMock = mocker.async_stub()
-        mock_run_coroutine_threadsafe: MagicMock = mocker.patch("asyncio.run_coroutine_threadsafe")
+        mock_run_coroutine_threadsafe: MagicMock = mocker.patch(
+            "asyncio.run_coroutine_threadsafe",
+            side_effect=asyncio.run_coroutine_threadsafe,
+        )
 
         # Act
         with pytest.raises(RuntimeError):
@@ -85,9 +99,37 @@ class TestAsyncioThreadsPortal:
         func_stub.assert_not_called()
         mock_run_coroutine_threadsafe.assert_not_called()
 
+    async def test____run_coroutine_soon____can_be_called_from_event_loop_thread(
+        self,
+        threads_portal: ThreadsPortal,
+        mocker: MockerFixture,
+    ) -> None:
+        # Arrange
+        func_stub: AsyncMock = mocker.async_stub()
+        mock_run_coroutine_threadsafe: MagicMock = mocker.patch(
+            "asyncio.run_coroutine_threadsafe",
+            side_effect=asyncio.run_coroutine_threadsafe,
+        )
+
+        # Act
+        future = threads_portal.run_coroutine_soon(
+            func_stub,
+            mocker.sentinel.arg1,
+            mocker.sentinel.arg2,
+            kw1=mocker.sentinel.kwargs1,
+            kw2=mocker.sentinel.kwargs2,
+        )
+
+        # Assert
+        mock_run_coroutine_threadsafe.assert_called_once()
+
+        await asyncio.wrap_future(future)
+
+    @pytest.mark.parametrize("run_soon", [False, True], ids=lambda p: f"run_soon=={p}")
     async def test____run_sync____use_asyncio_event_loop_call_soon_threadsafe(
         self,
         event_loop: asyncio.AbstractEventLoop,
+        run_soon: bool,
         threads_portal: ThreadsPortal,
         mocker: MockerFixture,
     ) -> None:
@@ -105,13 +147,23 @@ class TestAsyncioThreadsPortal:
 
         def test_thread() -> None:
             nonlocal ret_val
-            ret_val = threads_portal.run_sync(
-                func_stub,
-                mocker.sentinel.arg1,
-                mocker.sentinel.arg2,
-                kw1=mocker.sentinel.kwargs1,
-                kw2=mocker.sentinel.kwargs2,
-            )
+            if run_soon:
+                future = threads_portal.run_sync_soon(
+                    func_stub,
+                    mocker.sentinel.arg1,
+                    mocker.sentinel.arg2,
+                    kw1=mocker.sentinel.kwargs1,
+                    kw2=mocker.sentinel.kwargs2,
+                )
+                ret_val = future.result()
+            else:
+                ret_val = threads_portal.run_sync(
+                    func_stub,
+                    mocker.sentinel.arg1,
+                    mocker.sentinel.arg2,
+                    kw1=mocker.sentinel.kwargs1,
+                    kw2=mocker.sentinel.kwargs2,
+                )
             mock_loop_call_soon_threadsafe.assert_called_once()
 
         await asyncio.to_thread(test_thread)
@@ -152,3 +204,30 @@ class TestAsyncioThreadsPortal:
         # Assert
         func_stub.assert_not_called()
         mock_loop_call_soon_threadsafe.assert_not_called()
+
+    async def test____run_sync_soon____can_be_called_from_event_loop_thread(
+        self,
+        event_loop: asyncio.AbstractEventLoop,
+        threads_portal: ThreadsPortal,
+        mocker: MockerFixture,
+    ) -> None:
+        # Arrange
+        func_stub: MagicMock = mocker.stub()
+        mock_loop_call_soon_threadsafe: MagicMock = mocker.patch.object(
+            event_loop,
+            "call_soon_threadsafe",
+            side_effect=event_loop.call_soon_threadsafe,
+        )
+
+        # Act
+        _ = threads_portal.run_sync_soon(
+            func_stub,
+            mocker.sentinel.arg1,
+            mocker.sentinel.arg2,
+            kw1=mocker.sentinel.kwargs1,
+            kw2=mocker.sentinel.kwargs2,
+        )
+
+        # Assert
+        func_stub.assert_not_called()
+        mock_loop_call_soon_threadsafe.assert_called_once()


### PR DESCRIPTION
AbstractThreadsPortal:
- Added `run_sync_soon()`, returning a `concurrent.futures.Future`
- Added `run_coroutine_soon()`, returning a `concurrent.futures.Future`
- Remove `parent_thread_id`
- For `easynetwork_asyncio.ThreadsPortal`:
  - use `asyncio.get_running_loop()` to detect potential deadlock instead of `self.parent_thread_id`
  - Added `loop` parameter

AbstractAsyncBackend:
- Added `create_condition_var(lock: ILock | None = ...)`, returning `ICondition` with the following methods:
  - `async def acquire()`
  - `def release()`
  - `def locked()`
  - `def notify(n: int = ..., /)`
  - `def notify_all()`
  - `async def wait()`
- Moved `easynetwork_asyncio.AsyncThreadPoolExecutor` as `DefaultAsyncThreadPoolExecutor`
  - `create_thread_pool_executor()` returns an instance of `DefaultAsyncThreadPoolExecutor` by default

AsyncioBackend is no longer a final class