### PR TITLE
Reduced overhead created by importing sniffio

### DIFF
--- a/src/easynetwork/api_async/backend/factory.py
+++ b/src/easynetwork/api_async/backend/factory.py
@@ -15,6 +15,7 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Mapping, final
 
 from .abc import AbstractAsyncBackend
+from .sniffio import current_async_library as _sniffio_current_async_library
 
 if TYPE_CHECKING:
     from importlib.metadata import EntryPoint
@@ -32,15 +33,10 @@ class AsyncBackendFactory:
         if isinstance(backend, type):
             return backend
         if backend is None:
-            try:
-                if not guess_current_async_library:
-                    raise ModuleNotFoundError
-
-                import sniffio
-            except ModuleNotFoundError:
-                backend = "asyncio"
+            if guess_current_async_library:
+                backend = _sniffio_current_async_library()  # must raise if not recognized
             else:
-                backend = sniffio.current_async_library()  # must raise if not recognized
+                backend = "asyncio"
         return AsyncBackendFactory.__get_backend_cls(
             backend,
             "Running library {name!r} misses the backend implementation",

--- a/src/easynetwork/api_async/backend/sniffio.py
+++ b/src/easynetwork/api_async/backend/sniffio.py
@@ -1,0 +1,32 @@
+# -*- coding: Utf-8 -*-
+# Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
+#
+#
+"""
+Asynchronous client/server module
+"""
+
+from __future__ import annotations
+
+__all__ = ["current_async_library", "current_async_library_cvar"]
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from contextvars import ContextVar
+
+
+current_async_library_cvar: ContextVar[str | None] | None
+
+try:
+    import sniffio
+    from sniffio import current_async_library_cvar as current_async_library_cvar
+
+    def current_async_library() -> str:
+        return sniffio.current_async_library()
+
+except ImportError:
+    current_async_library_cvar = None
+
+    def current_async_library() -> str:
+        return "asyncio"

--- a/src/easynetwork/api_async/backend/threads.py
+++ b/src/easynetwork/api_async/backend/threads.py
@@ -16,6 +16,7 @@ import threading
 from typing import TYPE_CHECKING, Callable, ParamSpec, TypeVar, final
 
 from .abc import AbstractAsyncThreadPoolExecutor
+from .sniffio import current_async_library_cvar as _sniffio_current_async_library_cvar
 
 if TYPE_CHECKING:
     from .abc import AbstractAsyncBackend
@@ -38,13 +39,8 @@ class DefaultAsyncThreadPoolExecutor(AbstractAsyncThreadPoolExecutor):
     async def run(self, __func: Callable[_P, _T], /, *args: _P.args, **kwargs: _P.kwargs) -> _T:
         ctx = contextvars.copy_context()
 
-        try:
-            from sniffio import current_async_library_cvar
-        except ImportError:
-            pass
-        else:
-            ctx.run(current_async_library_cvar.set, None)
-            del current_async_library_cvar
+        if _sniffio_current_async_library_cvar is not None:
+            ctx.run(_sniffio_current_async_library_cvar.set, None)
 
         future: concurrent.futures.Future[_T] = self.__executor.submit(ctx.run, __func, *args, **kwargs)  # type: ignore[arg-type]
         return await self.__backend.wait_future(future)

--- a/src/easynetwork/api_async/backend/threads.py
+++ b/src/easynetwork/api_async/backend/threads.py
@@ -39,11 +39,12 @@ class DefaultAsyncThreadPoolExecutor(AbstractAsyncThreadPoolExecutor):
         ctx = contextvars.copy_context()
 
         try:
-            import sniffio
+            from sniffio import current_async_library_cvar
         except ImportError:
             pass
         else:
-            ctx.run(sniffio.current_async_library_cvar.set, None)
+            ctx.run(current_async_library_cvar.set, None)
+            del current_async_library_cvar
 
         future: concurrent.futures.Future[_T] = self.__executor.submit(ctx.run, __func, *args, **kwargs)  # type: ignore[arg-type]
         return await self.__backend.wait_future(future)


### PR DESCRIPTION
Lazy imports is fine if and only if the module always exists.

Otherwise the expensive import machinery does the same work each time and finally does not find the module.