### PR TITLE
Servers: Fixed memory leak on protocol parse error

### DIFF
--- a/src/easynetwork/api_async/server/tcp.py
+++ b/src/easynetwork/api_async/server/tcp.py
@@ -31,6 +31,7 @@ from ...protocol import StreamProtocol
 from ...tools._utils import (
     check_real_socket_state as _check_real_socket_state,
     concatenate_chunks as _concatenate_chunks,
+    recursively_clear_exception_traceback_frames as _recursively_clear_exception_traceback_frames,
     set_tcp_keepalive as _set_tcp_keepalive,
     set_tcp_nodelay as _set_tcp_nodelay,
 )
@@ -481,6 +482,7 @@ class _RequestReceiver(Generic[_RequestT, _ResponseT]):
                 return next(consumer)
             except StreamProtocolParseError as exc:
                 logger.debug("Malformed request sent by %s", client.address)
+                _recursively_clear_exception_traceback_frames(exc)
                 await self.__request_handler.bad_request(client, exc)
                 await self.__backend.coro_yield()
                 continue

--- a/src/easynetwork/api_async/server/tcp.py
+++ b/src/easynetwork/api_async/server/tcp.py
@@ -482,7 +482,10 @@ class _RequestReceiver(Generic[_RequestT, _ResponseT]):
                 return next(consumer)
             except StreamProtocolParseError as exc:
                 logger.debug("Malformed request sent by %s", client.address)
-                _recursively_clear_exception_traceback_frames(exc)
+                try:
+                    _recursively_clear_exception_traceback_frames(exc)
+                except RecursionError:
+                    logger.warning("Recursion depth reached when clearing exception's traceback frames")
                 await self.__request_handler.bad_request(client, exc)
                 await self.__backend.coro_yield()
                 continue

--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -16,7 +16,10 @@ from weakref import WeakValueDictionary
 
 from ...exceptions import ClientClosedError, DatagramProtocolParseError
 from ...protocol import DatagramProtocol
-from ...tools._utils import check_real_socket_state as _check_real_socket_state
+from ...tools._utils import (
+    check_real_socket_state as _check_real_socket_state,
+    recursively_clear_exception_traceback_frames as _recursively_clear_exception_traceback_frames,
+)
 from ...tools.socket import SocketAddress, SocketProxy, new_socket_address
 from ..backend.factory import AsyncBackendFactory
 from ..backend.tasks import SingleTaskRunner
@@ -261,6 +264,7 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
                             request: _RequestT = self.__protocol.build_packet_from_datagram(datagram)
                         except DatagramProtocolParseError as exc:
                             self.__logger.debug("Malformed request sent by %s", client.address)
+                            _recursively_clear_exception_traceback_frames(exc)
                             await self.__request_handler.bad_request(client, exc)
                             await backend.coro_yield()
                             continue

--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -264,7 +264,10 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
                             request: _RequestT = self.__protocol.build_packet_from_datagram(datagram)
                         except DatagramProtocolParseError as exc:
                             self.__logger.debug("Malformed request sent by %s", client.address)
-                            _recursively_clear_exception_traceback_frames(exc)
+                            try:
+                                _recursively_clear_exception_traceback_frames(exc)
+                            except RecursionError:
+                                self.__logger.warning("Recursion depth reached when clearing exception's traceback frames")
                             await self.__request_handler.bad_request(client, exc)
                             await backend.coro_yield()
                             continue

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -28,6 +28,7 @@ import os
 import selectors as _selectors
 import socket as _socket
 import time
+import traceback
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, ParamSpec, TypeGuard, TypeVar, assert_never
 
 if TYPE_CHECKING:
@@ -305,3 +306,11 @@ def transform_future_exception(exc: BaseException) -> BaseException:
         case _:
             pass
     return exc
+
+
+def recursively_clear_exception_traceback_frames(exc: BaseException) -> None:
+    traceback.clear_frames(exc.__traceback__)
+    if exc.__context__ is not None:
+        recursively_clear_exception_traceback_frames(exc.__context__)
+    if exc.__cause__ is not exc.__context__ and exc.__cause__ is not None:
+        recursively_clear_exception_traceback_frames(exc.__cause__)

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -596,6 +596,31 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
         assert await reader.read() == b""
         assert len(caplog.records) == 3
 
+    async def test____serve_forever____bad_request____recursive_traceback_frame_clear_error(
+        self,
+        client_factory: Callable[[], Awaitable[tuple[asyncio.StreamReader, asyncio.StreamWriter]]],
+        caplog: pytest.LogCaptureFixture,
+        server: MyAsyncTCPServer,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        caplog.set_level(logging.WARNING, server.logger.name)
+        reader, writer = await client_factory()
+
+        def infinite_recursion(exc: BaseException) -> None:
+            infinite_recursion(exc)
+
+        monkeypatch.setattr(
+            f"{AsyncTCPNetworkServer.__module__}._recursively_clear_exception_traceback_frames",
+            infinite_recursion,
+        )
+
+        writer.write("\u00E9\n".encode("latin-1"))  # StringSerializer does not accept unicode
+        await writer.drain()
+        await asyncio.sleep(0.1)
+
+        assert await reader.readline() == b"wrong encoding man.\n"
+        assert "Recursion depth reached when clearing exception's traceback frames" in [rec.message for rec in caplog.records]
+
     async def test____serve_forever____unexpected_error_during_process(
         self,
         client_factory: Callable[[], Awaitable[tuple[asyncio.StreamReader, asyncio.StreamWriter]]],

--- a/tests/unit_test/test_tools/test_utils.py
+++ b/tests/unit_test/test_tools/test_utils.py
@@ -617,3 +617,85 @@ def test____recursively_clear_exception_traceback_frames____exception_without_co
 
     # Assert
     mock_clear_frames.assert_called_once_with(exception.__traceback__)
+
+
+def test____recursively_clear_exception_traceback_frames____exception_with_context_but_no_explicit_cause(
+    mocker: MockerFixture,
+) -> None:
+    # Arrange
+    mock_clear_frames = mocker.patch("traceback.clear_frames", autospec=True)
+
+    def func() -> None:
+        try:
+            1 / 0
+        except ZeroDivisionError:
+            raise Exception()
+
+    # Act
+    exception = pytest.raises(Exception, func).value
+    assert isinstance(exception.__context__, ZeroDivisionError)
+    assert exception.__cause__ is None
+    recursively_clear_exception_traceback_frames(exception)
+
+    # Assert
+    assert mock_clear_frames.mock_calls == [
+        mocker.call(exception.__traceback__),
+        mocker.call(exception.__context__.__traceback__),
+    ]
+
+
+def test____recursively_clear_exception_traceback_frames____exception_with_explicit_cause(
+    mocker: MockerFixture,
+) -> None:
+    # Arrange
+    mock_clear_frames = mocker.patch("traceback.clear_frames", autospec=True)
+
+    def func() -> None:
+        try:
+            1 / 0
+        except ZeroDivisionError as exc:
+            raise Exception() from exc
+
+    # Act
+    exception = pytest.raises(Exception, func).value
+    assert isinstance(exception.__context__, ZeroDivisionError)
+    assert exception.__cause__ is exception.__context__
+    recursively_clear_exception_traceback_frames(exception)
+
+    # Assert
+    assert mock_clear_frames.mock_calls == [
+        mocker.call(exception.__traceback__),
+        mocker.call(exception.__context__.__traceback__),
+    ]
+
+
+def test____recursively_clear_exception_traceback_frames____exception_with_context_but_different_cause(
+    mocker: MockerFixture,
+) -> None:
+    # Arrange
+    mock_clear_frames = mocker.patch("traceback.clear_frames", autospec=True)
+
+    def func() -> None:
+        try:
+            1 / 0
+        except ZeroDivisionError as exc:
+            try:
+                raise ValueError()
+            except ValueError:
+                raise Exception() from exc
+
+    # Act
+    exception = pytest.raises(Exception, func).value
+    assert isinstance(exception.__context__, ValueError)
+    assert isinstance(exception.__context__.__context__, ZeroDivisionError)
+    assert exception.__context__.__cause__ is None
+    assert isinstance(exception.__cause__, ZeroDivisionError)
+    recursively_clear_exception_traceback_frames(exception)
+
+    # Assert
+    assert mock_clear_frames.mock_calls == [
+        mocker.call(exception.__traceback__),
+        mocker.call(exception.__context__.__traceback__),
+        mocker.call(exception.__context__.__context__.__traceback__),
+        mocker.call(exception.__cause__.__traceback__),
+    ]

--- a/tests/unit_test/test_tools/test_utils.py
+++ b/tests/unit_test/test_tools/test_utils.py
@@ -29,6 +29,7 @@ from easynetwork.tools._utils import (
     is_ssl_eof_error,
     is_ssl_socket,
     open_listener_sockets_from_getaddrinfo_result,
+    recursively_clear_exception_traceback_frames,
     replace_kwargs,
     set_reuseport,
     set_tcp_keepalive,
@@ -598,3 +599,21 @@ def test____transform_future_exception____make_cancelled_error_from_exception(ex
     assert new_exception.__cause__ is exception
     assert new_exception.__context__ is exception
     assert new_exception.__suppress_context__
+
+
+def test____recursively_clear_exception_traceback_frames____exception_without_context_nor_cause(
+    mocker: MockerFixture,
+) -> None:
+    # Arrange
+    mock_clear_frames = mocker.patch("traceback.clear_frames", autospec=True)
+
+    def func() -> None:
+        raise Exception()
+
+    # Act
+    exception = pytest.raises(Exception, func).value
+    assert exception.__context__ is None and exception.__cause__ is None
+    recursively_clear_exception_traceback_frames(exception)
+
+    # Assert
+    mock_clear_frames.assert_called_once_with(exception.__traceback__)


### PR DESCRIPTION
`request_handler.bad_request()` is called in a `try/except` clause, therefore the stack frames was kept alive until `bad_request` have finished.

In order to reduce the memory footprint, [`traceback.clear_frames()`](https://docs.python.org/3.11/library/traceback.html#traceback.clear_frames) is applied to the `BaseProtocolParseError` instance