### PR TITLE
Fixed potential deadlocks after fork on UNIX platforms

### DIFF
--- a/src/easynetwork/tools/lock.py
+++ b/src/easynetwork/tools/lock.py
@@ -1,0 +1,42 @@
+# -*- coding: Utf-8 -*-
+# Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
+#
+#
+"""
+Synchronization primitive extension module
+"""
+
+from __future__ import annotations
+
+__all__ = ["ForkSafeLock"]
+
+import os
+import threading
+from typing import Callable, Generic, TypeVar, cast, overload
+
+_L = TypeVar("_L", bound="threading.RLock | threading.Lock")
+
+
+class ForkSafeLock(Generic[_L]):
+    __slots__ = ("__pid", "__unsafe_lock", "__lock_factory", "__weakref__")
+
+    @overload
+    def __init__(self: ForkSafeLock[threading.RLock], lock_factory: None = ...) -> None:
+        ...
+
+    @overload
+    def __init__(self, lock_factory: Callable[[], _L]) -> None:
+        ...
+
+    def __init__(self, lock_factory: Callable[[], _L] | None = None) -> None:
+        if lock_factory is None:
+            lock_factory = cast(Callable[[], _L], threading.RLock)
+        self.__unsafe_lock: _L = lock_factory()
+        self.__pid: int = os.getpid()
+        self.__lock_factory: Callable[[], _L] = lock_factory
+
+    def get(self) -> _L:
+        if self.__pid != os.getpid():
+            self.__unsafe_lock = self.__lock_factory()
+            self.__pid = os.getpid()
+        return self.__unsafe_lock

--- a/tests/unit_test/test_sync/test_client/test_tcp.py
+++ b/tests/unit_test/test_sync/test_client/test_tcp.py
@@ -32,11 +32,6 @@ from ...base import UNSUPPORTED_FAMILIES
 from .base import BaseTestClient
 
 
-@pytest.fixture(scope="module", autouse=True)
-def setup_dummy_lock(module_mocker: MockerFixture, dummy_lock_cls: Any) -> None:
-    module_mocker.patch(f"{TCPNetworkClient.__module__}._Lock", new=dummy_lock_cls)
-
-
 @pytest.fixture(autouse=True)
 def remove_ssl_OP_IGNORE_UNEXPECTED_EOF(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delattr("ssl.OP_IGNORE_UNEXPECTED_EOF", raising=False)

--- a/tests/unit_test/test_sync/test_client/test_udp.py
+++ b/tests/unit_test/test_sync/test_client/test_udp.py
@@ -21,11 +21,6 @@ from ...base import UNSUPPORTED_FAMILIES
 from .base import BaseTestClient
 
 
-@pytest.fixture(scope="module", autouse=True)
-def setup_dummy_lock(module_mocker: MockerFixture, dummy_lock_cls: Any) -> None:
-    module_mocker.patch(f"{UDPNetworkEndpoint.__module__}._Lock", new=dummy_lock_cls)
-
-
 class TestUDPNetworkEndpoint(BaseTestClient):
     @pytest.fixture(scope="class", params=["AF_INET", "AF_INET6"])
     @staticmethod

--- a/tests/unit_test/test_tools/test_lock.py
+++ b/tests/unit_test/test_tools/test_lock.py
@@ -1,0 +1,68 @@
+# -*- coding: Utf-8 -*-
+
+from __future__ import annotations
+
+import os
+import random
+import threading
+from typing import TYPE_CHECKING
+
+from easynetwork.tools.lock import ForkSafeLock
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+    from pytest_mock import MockerFixture
+
+
+class TestForkSafeLock:
+    def test____dunder_init____create_threading_RLock_by_default(self) -> None:
+        # Arrange
+        safe_lock = ForkSafeLock()
+
+        # Act
+        lock = safe_lock.get()
+
+        # Assert
+        assert isinstance(lock, threading.RLock)
+
+    def test____dunder_init____custom_lock_factory(self, mocker: MockerFixture) -> None:
+        # Arrange
+        lock_factory: MagicMock = mocker.MagicMock(side_effect=threading.Lock)
+        safe_lock: ForkSafeLock[threading.Lock] = ForkSafeLock(lock_factory)
+
+        # Act
+        lock = safe_lock.get()
+
+        # Assert
+        lock_factory.assert_called_once_with()
+        assert isinstance(lock, threading.Lock)
+
+    def test____get____always_return_the_same_lock_object(self, mocker: MockerFixture) -> None:
+        # Arrange
+        lock_factory: MagicMock = mocker.MagicMock(side_effect=threading.Lock)
+        safe_lock: ForkSafeLock[threading.Lock] = ForkSafeLock(lock_factory)
+        lock = safe_lock.get()
+        lock_factory.reset_mock()
+
+        # Act & Assert
+        assert all(safe_lock.get() is lock for _ in range(100))
+
+        # Assert
+        lock_factory.assert_not_called()
+
+    def test____get____create_a_new_lock_if_the_pid_is_different(self, mocker: MockerFixture) -> None:
+        # Arrange
+        lock_factory: MagicMock = mocker.MagicMock(side_effect=threading.Lock)
+        safe_lock: ForkSafeLock[threading.Lock] = ForkSafeLock(lock_factory)
+        older_lock = safe_lock.get()
+        lock_factory.reset_mock()
+
+        # Act & Assert
+        mocker.patch("os.getpid", return_value=os.getpid() + random.randint(1, 20))  # Simulate os.fork()
+        new_lock = safe_lock.get()
+        assert new_lock is not older_lock
+        assert all(safe_lock.get() is new_lock for _ in range(100))
+
+        # Assert
+        lock_factory.assert_called_once_with()


### PR DESCRIPTION
- Added `ForkSafeLock` class which manages the lock to use by checking `os.getpid()` value