### PR TITLE
Serializers: API update

### DIFF
--- a/src/easynetwork/protocol.py
+++ b/src/easynetwork/protocol.py
@@ -116,7 +116,8 @@ class StreamProtocol(Generic[_SentPacketT, _ReceivedPacketT]):
         try:
             packet, remaining_data = yield from self.__serializer.incremental_deserialize()
         except IncrementalDeserializeError as exc:
-            raise StreamProtocolParseError(exc.remaining_data, "deserialization", str(exc), error_info=exc.error_info) from exc
+            remaining_data, exc.remaining_data = exc.remaining_data, b""
+            raise StreamProtocolParseError(remaining_data, "deserialization", str(exc), error_info=exc.error_info) from exc
         except DeserializeError as exc:
             raise RuntimeError("DeserializeError raised instead of IncrementalDeserializeError") from exc
 

--- a/src/easynetwork/serializers/line.py
+++ b/src/easynetwork/serializers/line.py
@@ -42,10 +42,22 @@ class StringLineSerializer(AutoSeparatedPacketSerializer[str, str]):
     def serialize(self, packet: str) -> bytes:
         if not isinstance(packet, str):
             raise TypeError(f"Expected a string, got {packet!r}")
-        return packet.encode(self.__encoding, self.__unicode_errors)
+        if len(packet) == 0:
+            raise ValueError("Empty packet")
+        data = packet.encode(self.__encoding, self.__unicode_errors)
+        if self.separator in data:
+            raise ValueError("Newline found in string")
+        return data
 
     @final
     def deserialize(self, data: bytes) -> str:
+        separator: bytes = self.separator
+        while data.endswith(separator):
+            data = data.removesuffix(separator)
+        if len(data) == 0:
+            raise DeserializeError("Empty packet")
+        if separator in data:
+            raise DeserializeError("Newline found in data which was not at the end")
         try:
             return data.decode(self.__encoding, self.__unicode_errors)
         except UnicodeError as exc:

--- a/src/easynetwork/serializers/line.py
+++ b/src/easynetwork/serializers/line.py
@@ -55,13 +55,13 @@ class StringLineSerializer(AutoSeparatedPacketSerializer[str, str]):
         while data.endswith(separator):
             data = data.removesuffix(separator)
         if len(data) == 0:
-            raise DeserializeError("Empty packet")
+            raise DeserializeError("Empty packet", error_info={"data": data})
         if separator in data:
-            raise DeserializeError("Newline found in data which was not at the end")
+            raise DeserializeError("Newline found in data which was not at the end", error_info={"data": data})
         try:
             return data.decode(self.__encoding, self.__unicode_errors)
         except UnicodeError as exc:
-            raise DeserializeError(str(exc)) from exc
+            raise DeserializeError(str(exc), error_info={"data": data}) from exc
 
     @property
     def encoding(self) -> str:

--- a/src/easynetwork/serializers/msgpack.py
+++ b/src/easynetwork/serializers/msgpack.py
@@ -96,8 +96,8 @@ class MessagePackSerializer(AbstractPacketSerializer[_ST_contra, _DT_co]):
         try:
             return self.__unpackb(data)
         except msgpack.OutOfData as exc:
-            raise DeserializeError("Missing data to create packet") from exc
+            raise DeserializeError("Missing data to create packet", error_info={"data": data}) from exc
         except msgpack.ExtraData as exc:
-            raise DeserializeError("Extra data caught") from exc
+            raise DeserializeError("Extra data caught", error_info={"packet": exc.unpacked, "extra": exc.extra}) from exc  # type: ignore[attr-defined]
         except Exception as exc:  # The documentation says to catch all exceptions :)
-            raise DeserializeError(str(exc)) from exc
+            raise DeserializeError(str(exc) or "Invalid token", error_info={"data": data}) from exc

--- a/src/easynetwork/serializers/pickle.py
+++ b/src/easynetwork/serializers/pickle.py
@@ -87,7 +87,7 @@ class PickleSerializer(AbstractPacketSerializer[_ST_contra, _DT_co]):
             try:
                 packet: _DT_co = self.__unpickler_cls(buffer).load()
             except Exception as exc:
-                raise DeserializeError(str(exc) or "Invalid token") from exc
-            if buffer.read():  # There is still data after deserialization
-                raise DeserializeError("Extra data caught")
+                raise DeserializeError(str(exc) or "Invalid token", error_info={"data": buffer.getvalue()}) from exc
+            if extra := buffer.read():  # There is still data after deserialization
+                raise DeserializeError("Extra data caught", {"packet": packet, "extra": extra})
         return packet

--- a/src/easynetwork/serializers/struct.py
+++ b/src/easynetwork/serializers/struct.py
@@ -52,11 +52,14 @@ class AbstractStructSerializer(FixedSizePacketSerializer[_ST_contra, _DT_co]):
         try:
             packet_tuple: tuple[Any, ...] = self.__s.unpack(data)
         except _struct.error as exc:
-            raise DeserializeError(f"Invalid value: {exc}") from exc
+            raise DeserializeError(f"Invalid value: {exc}", error_info={"data": data}) from exc
         try:
             return self.from_tuple(packet_tuple)
         except Exception as exc:
-            raise DeserializeError(f"Error when building packet from unpacked struct value: {exc}") from exc
+            raise DeserializeError(
+                f"Error when building packet from unpacked struct value: {exc}",
+                error_info={"unpacked_struct": packet_tuple},
+            ) from exc
 
     @property
     @final

--- a/src/easynetwork/serializers/wrapper/base64.py
+++ b/src/easynetwork/serializers/wrapper/base64.py
@@ -76,5 +76,5 @@ class Base64EncodedSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co])
         if (checksum := self.__checksum) is not None:
             data, digest = data[:-32], data[-32:]
             if not compare_digest(checksum(data), digest):
-                raise DeserializeError("Invalid token")
+                raise DeserializeError("Invalid token", error_info=None)
         return self.__serializer.deserialize(data)

--- a/src/easynetwork/serializers/wrapper/base64.py
+++ b/src/easynetwork/serializers/wrapper/base64.py
@@ -12,8 +12,9 @@ __all__ = [
 
 import base64
 import binascii
+from hashlib import sha256 as hashlib_sha256
 from hmac import compare_digest, digest as hmac_digest
-from typing import TypeVar, final
+from typing import Callable, TypeVar, assert_never, final
 
 from ...exceptions import DeserializeError
 from ..abc import AbstractPacketSerializer
@@ -24,26 +25,34 @@ _DT_co = TypeVar("_DT_co", covariant=True)
 
 
 class Base64EncodedSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co]):
-    __slots__ = ("__serializer", "__signing_key")
+    __slots__ = ("__serializer", "__checksum")
 
     def __init__(
         self,
         serializer: AbstractPacketSerializer[_ST_contra, _DT_co],
-        signing_key: str | bytes | None = None,
         *,
+        checksum: bool | str | bytes = False,
         separator: bytes = b"\r\n",
     ) -> None:
         super().__init__(separator=separator)
         assert isinstance(serializer, AbstractPacketSerializer)
         self.__serializer: AbstractPacketSerializer[_ST_contra, _DT_co] = serializer
-        if signing_key is not None:
-            try:
-                signing_key = base64.urlsafe_b64decode(signing_key)
-            except binascii.Error as exc:
-                raise ValueError("signing key must be 32 url-safe base64-encoded bytes.") from exc
-            if len(signing_key) != 32:
-                raise ValueError("signing key must be 32 url-safe base64-encoded bytes.")
-        self.__signing_key: bytes | None = signing_key
+        self.__checksum: Callable[[bytes], bytes] | None
+        match checksum:
+            case False:
+                self.__checksum = None
+            case True:
+                self.__checksum = lambda data: hashlib_sha256(data).digest()
+            case str() | bytes():
+                try:
+                    key: bytes = base64.urlsafe_b64decode(checksum)
+                except binascii.Error as exc:
+                    raise ValueError("signing key must be 32 url-safe base64-encoded bytes.") from exc
+                if len(key) != 32:
+                    raise ValueError("signing key must be 32 url-safe base64-encoded bytes.")
+                self.__checksum = lambda data: hmac_digest(key, data, "sha256")
+            case _:  # pragma: no cover
+                assert_never(checksum)
 
     @classmethod
     def generate_key(cls) -> bytes:
@@ -54,8 +63,8 @@ class Base64EncodedSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co])
     @final
     def serialize(self, packet: _ST_contra) -> bytes:
         data = self.__serializer.serialize(packet)
-        if key := self.__signing_key:
-            data += hmac_digest(key, data, "sha256")
+        if (checksum := self.__checksum) is not None:
+            data += checksum(data)
         return base64.urlsafe_b64encode(data)
 
     @final
@@ -64,8 +73,8 @@ class Base64EncodedSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co])
             data = base64.urlsafe_b64decode(data)
         except binascii.Error:
             raise DeserializeError("Invalid token") from None
-        if key := self.__signing_key:
-            data, signature = data[:-32], data[-32:]
-            if not compare_digest(hmac_digest(key, data, "sha256"), signature):
+        if (checksum := self.__checksum) is not None:
+            data, digest = data[:-32], data[-32:]
+            if not compare_digest(checksum(data), digest):
                 raise DeserializeError("Invalid token")
         return self.__serializer.deserialize(data)

--- a/src/easynetwork/serializers/wrapper/encryptor.py
+++ b/src/easynetwork/serializers/wrapper/encryptor.py
@@ -63,5 +63,5 @@ class EncryptorSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co]):
         try:
             data = self.__fernet.decrypt(data, ttl=self.__token_ttl)
         except InvalidToken:
-            raise DeserializeError("Invalid token") from None
+            raise DeserializeError("Invalid token", error_info=None) from None
         return self.__serializer.deserialize(data)

--- a/tests/functional_test/test_serializers/test_line.py
+++ b/tests/functional_test/test_serializers/test_line.py
@@ -85,10 +85,18 @@ class TestStringLineSerializer(BaseTestIncrementalSerializer):
 
     #### Invalid data
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="class", params=["unicode-error", "newline-error", "empty-string"])
     @staticmethod
-    def invalid_complete_data() -> bytes:
-        return "é".encode("latin-1")
+    def invalid_complete_data(request: pytest.FixtureRequest, newline: Literal["CR", "LF", "CRLF"]) -> bytes:
+        match getattr(request, "param"):
+            case "unicode-error":
+                return "é".encode("latin-1")
+            case "newline-error":
+                return b"string with " + _NEWLINES[newline] + b" in it"
+            case "empty-string":
+                return b""
+            case _:
+                pytest.fail("Invalid fixture parameter")
 
     @pytest.fixture
     @staticmethod

--- a/tests/scripts/async_server_test.py
+++ b/tests/scripts/async_server_test.py
@@ -21,11 +21,11 @@ logger = logging.getLogger("app")
 
 class MyAsyncRequestHandler(AsyncBaseRequestHandler[str, str]):
     async def handle(self, client: AsyncClientInterface[str]) -> AsyncGenerator[None, str]:
-        request: str = (yield).removesuffix("\n")
+        request: str = yield
         logger.debug(f"Received {request!r}")
         if request == "wait:":
-            request = (yield).removesuffix("\n") + " after wait"
-        await client.send_packet(request.upper() + "\n")
+            request = (yield) + " after wait"
+        await client.send_packet(request.upper())
 
     async def bad_request(self, client: AsyncClientInterface[str], exc: BaseProtocolParseError) -> None:
         pass

--- a/tests/unit_test/test_serializers/test_encryptor.py
+++ b/tests/unit_test/test_serializers/test_encryptor.py
@@ -119,3 +119,4 @@ class TestEncryptorSerializer:
         mock_serializer.deserialize.assert_not_called()
         assert exception.__context__ is mock_fernet.decrypt.side_effect
         assert exception.__cause__ is None
+        assert exception.error_info is None

--- a/tests/unit_test/test_serializers/test_msgpack.py
+++ b/tests/unit_test/test_serializers/test_msgpack.py
@@ -145,6 +145,7 @@ class TestMessagePackSerializer(BaseSerializerConfigInstanceCheck):
 
         # Assert
         assert isinstance(exc_info.value.__cause__, msgpack.OutOfData)
+        assert exc_info.value.error_info == {"data": mocker.sentinel.data}
 
     def test____deserialize____extra_data(
         self,
@@ -155,7 +156,7 @@ class TestMessagePackSerializer(BaseSerializerConfigInstanceCheck):
         import msgpack
 
         serializer: MessagePackSerializer[Any, Any] = MessagePackSerializer()
-        mock_unpackb.side_effect = msgpack.ExtraData(mocker.sentinel.something, b"extra")
+        mock_unpackb.side_effect = msgpack.ExtraData(mocker.sentinel.packet, b"extra")
 
         # Act & Assert
         with pytest.raises(DeserializeError) as exc_info:
@@ -163,6 +164,7 @@ class TestMessagePackSerializer(BaseSerializerConfigInstanceCheck):
 
         # Assert
         assert isinstance(exc_info.value.__cause__, msgpack.ExtraData)
+        assert exc_info.value.error_info == {"packet": mocker.sentinel.packet, "extra": b"extra"}
 
     def test____deserialize____any_exception_occurs(
         self,
@@ -179,3 +181,4 @@ class TestMessagePackSerializer(BaseSerializerConfigInstanceCheck):
 
         # Assert
         assert isinstance(exc_info.value.__cause__, Exception)
+        assert exc_info.value.error_info == {"data": mocker.sentinel.data}

--- a/tests/unit_test/test_serializers/test_struct.py
+++ b/tests/unit_test/test_serializers/test_struct.py
@@ -145,6 +145,7 @@ class TestAbstractStructSerializer(BaseTestStructBasedSerializer):
         mock_struct_unpack.assert_called_once_with(mocker.sentinel.data)
         mock_serializer_from_tuple.assert_not_called()
         assert exception.__cause__ is mock_struct_unpack.side_effect
+        assert exception.error_info == {"data": mocker.sentinel.data}
 
     def test____deserialize____translate_any_exception_raised_by_from_tuple_method(
         self,
@@ -168,6 +169,7 @@ class TestAbstractStructSerializer(BaseTestStructBasedSerializer):
         mock_struct_unpack.assert_called_once_with(mocker.sentinel.data)
         mock_serializer_from_tuple.assert_called_once_with(mocker.sentinel.packet_tuple)
         assert exception.__cause__ is mock_serializer_from_tuple.side_effect
+        assert exception.error_info == {"unpacked_struct": mocker.sentinel.packet_tuple}
 
 
 class TestNamedTupleStructSerializer(BaseTestStructBasedSerializer):


### PR DESCRIPTION
- `NamedTupleStructSerializer`:
  - Renamed `errors` parameter to `unicode_errors`
- `Base64EncodedSerializer`:
  - `signing_key` parameter replaced by `checksum`
- `StringLineSerializer`:
  - Added new verifications
- Fulfilled `error_info` field for deserialization errors