### PR TITLE
AsyncExecutor: Do not use contextvars.copy_context() by default

### DIFF
--- a/src/easynetwork/api_async/backend/futures.py
+++ b/src/easynetwork/api_async/backend/futures.py
@@ -8,11 +8,11 @@ Asynchronous client/server module
 
 from __future__ import annotations
 
-__all__ = ["AsyncPoolExecutor"]
+__all__ = ["AsyncExecutor", "AsyncThreadPoolExecutor"]
 
 import concurrent.futures
 import contextvars
-from typing import TYPE_CHECKING, Callable, ParamSpec, Self, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, ParamSpec, Self, TypeVar, overload
 
 from .sniffio import current_async_library_cvar as _sniffio_current_async_library_cvar
 
@@ -25,7 +25,7 @@ _P = ParamSpec("_P")
 _T = TypeVar("_T")
 
 
-class AsyncPoolExecutor:
+class AsyncExecutor:
     __slots__ = ("__backend", "__executor", "__weakref__")
 
     def __init__(self, backend: AbstractAsyncBackend, executor: concurrent.futures.Executor) -> None:
@@ -44,20 +44,47 @@ class AsyncPoolExecutor:
         await self.shutdown()
 
     async def run(self, __func: Callable[_P, _T], /, *args: _P.args, **kwargs: _P.kwargs) -> _T:
-        ctx = contextvars.copy_context()
-
-        if _sniffio_current_async_library_cvar is not None:
-            ctx.run(_sniffio_current_async_library_cvar.set, None)
-
-        future: concurrent.futures.Future[_T] = self.__executor.submit(ctx.run, __func, *args, **kwargs)  # type: ignore[arg-type]
-        del __func, args, kwargs
         try:
-            return await self.__backend.wait_future(future)
+            return await self.__backend.wait_future(self.__executor.submit(__func, *args, **kwargs))
         finally:
-            del future
+            del __func, args, kwargs
 
     def shutdown_nowait(self, *, cancel_futures: bool = False) -> None:
         self.__executor.shutdown(wait=False, cancel_futures=cancel_futures)
 
     async def shutdown(self, *, cancel_futures: bool = False) -> None:
         await self.__backend.run_in_thread(self.__executor.shutdown, wait=True, cancel_futures=cancel_futures)
+
+
+class AsyncThreadPoolExecutor(AsyncExecutor):
+    __slots__ = ()
+
+    @overload
+    def __init__(self, backend: AbstractAsyncBackend) -> None:
+        ...
+
+    @overload
+    def __init__(
+        self,
+        backend: AbstractAsyncBackend,
+        *,
+        max_workers: int | None = ...,
+        thread_name_prefix: str = ...,
+        initializer: Callable[..., object] | None = ...,
+        initargs: tuple[Any, ...] = ...,
+    ) -> None:
+        ...
+
+    def __init__(self, backend: AbstractAsyncBackend, **kwargs: Any) -> None:
+        super().__init__(backend, concurrent.futures.ThreadPoolExecutor(**kwargs))
+
+    async def run(self, __func: Callable[_P, _T], /, *args: _P.args, **kwargs: _P.kwargs) -> _T:
+        ctx = contextvars.copy_context()
+
+        if _sniffio_current_async_library_cvar is not None:
+            ctx.run(_sniffio_current_async_library_cvar.set, None)
+
+        try:
+            return await super().run(ctx.run, __func, *args, **kwargs)  # type: ignore[arg-type]
+        finally:
+            del __func, args, kwargs

--- a/tests/unit_test/test_async/test_api/test_backend/test_futures.py
+++ b/tests/unit_test/test_async/test_api/test_backend/test_futures.py
@@ -6,7 +6,7 @@ import concurrent.futures
 import contextvars
 from typing import TYPE_CHECKING
 
-from easynetwork.api_async.backend.futures import AsyncPoolExecutor
+from easynetwork.api_async.backend.futures import AsyncExecutor, AsyncThreadPoolExecutor
 from easynetwork.api_async.backend.sniffio import current_async_library_cvar
 
 import pytest
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.asyncio
-class TestAsyncPoolExecutor:
+class TestAsyncExecutor:
     @pytest.fixture
     @staticmethod
     def mock_stdlib_executor(mocker: MockerFixture) -> MagicMock:
@@ -28,12 +28,176 @@ class TestAsyncPoolExecutor:
 
     @pytest.fixture
     @staticmethod
-    def executor(mock_backend: MagicMock, mock_stdlib_executor: MagicMock) -> AsyncPoolExecutor:
-        return AsyncPoolExecutor(mock_backend, mock_stdlib_executor)
+    def executor(mock_backend: MagicMock, mock_stdlib_executor: MagicMock) -> AsyncExecutor:
+        return AsyncExecutor(mock_backend, mock_stdlib_executor)
 
     async def test____run____submit_to_executor_and_wait(
         self,
-        executor: AsyncPoolExecutor,
+        executor: AsyncExecutor,
+        mock_backend: MagicMock,
+        mock_stdlib_executor: MagicMock,
+        mocker: MockerFixture,
+    ) -> None:
+        # Arrange
+        func = mocker.stub()
+        mock_stdlib_executor.submit.return_value = mocker.sentinel.future
+        mock_backend.wait_future.return_value = mocker.sentinel.result
+
+        # Act
+        result = await executor.run(
+            func,
+            mocker.sentinel.arg1,
+            mocker.sentinel.arg2,
+            kw1=mocker.sentinel.kw1,
+            kw2=mocker.sentinel.kw2,
+        )
+
+        # Assert
+        mock_stdlib_executor.submit.assert_called_once_with(
+            func,
+            mocker.sentinel.arg1,
+            mocker.sentinel.arg2,
+            kw1=mocker.sentinel.kw1,
+            kw2=mocker.sentinel.kw2,
+        )
+        func.assert_not_called()
+        mock_backend.wait_future.assert_awaited_once_with(mocker.sentinel.future)
+        assert result is mocker.sentinel.result
+
+    async def test____shutdown_nowait____shutdown_executor(
+        self,
+        executor: AsyncExecutor,
+        mock_stdlib_executor: MagicMock,
+    ) -> None:
+        # Arrange
+
+        # Act
+        executor.shutdown_nowait()
+
+        # Assert
+        mock_stdlib_executor.shutdown.assert_called_once_with(wait=False, cancel_futures=False)
+
+    @pytest.mark.parametrize("cancel_futures", [False, True])
+    async def test____shutdown_nowait____shutdown_executor____cancel_futures(
+        self,
+        cancel_futures: bool,
+        executor: AsyncExecutor,
+        mock_stdlib_executor: MagicMock,
+    ) -> None:
+        # Arrange
+
+        # Act
+        executor.shutdown_nowait(cancel_futures=cancel_futures)
+
+        # Assert
+        mock_stdlib_executor.shutdown.assert_called_once_with(wait=False, cancel_futures=cancel_futures)
+
+    async def test____shutdown____shutdown_executor(
+        self,
+        executor: AsyncExecutor,
+        mock_backend: MagicMock,
+        mock_stdlib_executor: MagicMock,
+    ) -> None:
+        # Arrange
+        mock_backend.run_in_thread.return_value = None
+
+        # Act
+        await executor.shutdown()
+
+        # Assert
+        mock_stdlib_executor.shutdown.assert_not_called()
+        mock_backend.run_in_thread.assert_awaited_once_with(mock_stdlib_executor.shutdown, wait=True, cancel_futures=False)
+
+    @pytest.mark.parametrize("cancel_futures", [False, True])
+    async def test____shutdown____shutdown_executor____cancel_futures(
+        self,
+        cancel_futures: bool,
+        executor: AsyncExecutor,
+        mock_backend: MagicMock,
+        mock_stdlib_executor: MagicMock,
+    ) -> None:
+        # Arrange
+        mock_backend.run_in_thread.return_value = None
+
+        # Act
+        await executor.shutdown(cancel_futures=cancel_futures)
+
+        # Assert
+        mock_stdlib_executor.shutdown.assert_not_called()
+        mock_backend.run_in_thread.assert_awaited_once_with(
+            mock_stdlib_executor.shutdown,
+            wait=True,
+            cancel_futures=cancel_futures,
+        )
+
+    async def test____context_manager____shutdown_executor_at_end(
+        self,
+        executor: AsyncExecutor,
+        mock_backend: MagicMock,
+        mock_stdlib_executor: MagicMock,
+    ) -> None:
+        # Arrange
+        mock_backend.run_in_thread.return_value = None
+
+        # Act
+        async with executor as _self:
+            assert _self is executor
+            del _self
+            mock_stdlib_executor.shutdown.assert_not_called()
+            mock_backend.run_in_thread.assert_not_called()
+
+        # Assert
+        mock_stdlib_executor.shutdown.assert_not_called()
+        mock_backend.run_in_thread.assert_awaited_once_with(mock_stdlib_executor.shutdown, wait=True, cancel_futures=False)
+
+
+@pytest.mark.asyncio
+class TestAsyncThreadPoolExecutor:
+    @pytest.fixture
+    @staticmethod
+    def mock_stdlib_executor(mocker: MockerFixture) -> MagicMock:
+        executor = mocker.NonCallableMagicMock(spec=concurrent.futures.ThreadPoolExecutor)
+        executor.shutdown.return_value = None
+        return executor
+
+    @pytest.fixture(autouse=True)
+    @staticmethod
+    def mock_stdlib_executor_cls(mocker: MockerFixture, mock_stdlib_executor: MagicMock) -> MagicMock:
+        return mocker.patch("concurrent.futures.ThreadPoolExecutor", return_value=mock_stdlib_executor)
+
+    @pytest.fixture
+    @staticmethod
+    def executor(mock_backend: MagicMock) -> AsyncThreadPoolExecutor:
+        return AsyncThreadPoolExecutor(mock_backend)
+
+    async def test____dunder_init____pass_kwargs_to_executor_cls(
+        self,
+        mock_backend: MagicMock,
+        mock_stdlib_executor_cls: MagicMock,
+        mocker: MockerFixture,
+    ) -> None:
+        # Arrange
+
+        # Act
+        _ = AsyncThreadPoolExecutor(
+            mock_backend,
+            max_workers=mocker.sentinel.max_workers,
+            thread_name_prefix=mocker.sentinel.thread_name_prefix,
+            initializer=mocker.sentinel.initializer,
+            initargs=mocker.sentinel.initargs,
+        )
+
+        # Assert
+        mock_stdlib_executor_cls.assert_called_once_with(
+            max_workers=mocker.sentinel.max_workers,
+            thread_name_prefix=mocker.sentinel.thread_name_prefix,
+            initializer=mocker.sentinel.initializer,
+            initargs=mocker.sentinel.initargs,
+        )
+
+    async def test____run____submit_to_executor_and_wait(
+        self,
+        executor: AsyncThreadPoolExecutor,
         mock_backend: MagicMock,
         mock_stdlib_executor: MagicMock,
         mocker: MockerFixture,
@@ -75,89 +239,3 @@ class TestAsyncPoolExecutor:
         func.assert_not_called()
         mock_backend.wait_future.assert_awaited_once_with(mocker.sentinel.future)
         assert result is mocker.sentinel.result
-
-    async def test____shutdown_nowait____shutdown_executor(
-        self,
-        executor: AsyncPoolExecutor,
-        mock_stdlib_executor: MagicMock,
-    ) -> None:
-        # Arrange
-
-        # Act
-        executor.shutdown_nowait()
-
-        # Assert
-        mock_stdlib_executor.shutdown.assert_called_once_with(wait=False, cancel_futures=False)
-
-    @pytest.mark.parametrize("cancel_futures", [False, True])
-    async def test____shutdown_nowait____shutdown_executor____cancel_futures(
-        self,
-        cancel_futures: bool,
-        executor: AsyncPoolExecutor,
-        mock_stdlib_executor: MagicMock,
-    ) -> None:
-        # Arrange
-
-        # Act
-        executor.shutdown_nowait(cancel_futures=cancel_futures)
-
-        # Assert
-        mock_stdlib_executor.shutdown.assert_called_once_with(wait=False, cancel_futures=cancel_futures)
-
-    async def test____shutdown____shutdown_executor(
-        self,
-        executor: AsyncPoolExecutor,
-        mock_backend: MagicMock,
-        mock_stdlib_executor: MagicMock,
-    ) -> None:
-        # Arrange
-        mock_backend.run_in_thread.return_value = None
-
-        # Act
-        await executor.shutdown()
-
-        # Assert
-        mock_stdlib_executor.shutdown.assert_not_called()
-        mock_backend.run_in_thread.assert_awaited_once_with(mock_stdlib_executor.shutdown, wait=True, cancel_futures=False)
-
-    @pytest.mark.parametrize("cancel_futures", [False, True])
-    async def test____shutdown____shutdown_executor____cancel_futures(
-        self,
-        cancel_futures: bool,
-        executor: AsyncPoolExecutor,
-        mock_backend: MagicMock,
-        mock_stdlib_executor: MagicMock,
-    ) -> None:
-        # Arrange
-        mock_backend.run_in_thread.return_value = None
-
-        # Act
-        await executor.shutdown(cancel_futures=cancel_futures)
-
-        # Assert
-        mock_stdlib_executor.shutdown.assert_not_called()
-        mock_backend.run_in_thread.assert_awaited_once_with(
-            mock_stdlib_executor.shutdown,
-            wait=True,
-            cancel_futures=cancel_futures,
-        )
-
-    async def test____context_manager____shutdown_executor_at_end(
-        self,
-        executor: AsyncPoolExecutor,
-        mock_backend: MagicMock,
-        mock_stdlib_executor: MagicMock,
-    ) -> None:
-        # Arrange
-        mock_backend.run_in_thread.return_value = None
-
-        # Act
-        async with executor as _self:
-            assert _self is executor
-            del _self
-            mock_stdlib_executor.shutdown.assert_not_called()
-            mock_backend.run_in_thread.assert_not_called()
-
-        # Assert
-        mock_stdlib_executor.shutdown.assert_not_called()
-        mock_backend.run_in_thread.assert_awaited_once_with(mock_stdlib_executor.shutdown, wait=True, cancel_futures=False)


### PR DESCRIPTION
- Added `AsyncThreadPoolExecutor` which is a specialization of `AsyncExecutor` carrying out `contextvars.copy_context()` usage