### PR TITLE
AsyncSocket: Already in use operation now raises EBUSY error

### DIFF
--- a/src/easynetwork_asyncio/socket.py
+++ b/src/easynetwork_asyncio/socket.py
@@ -119,7 +119,7 @@ class AsyncSocket:
             raise _error_from_errno(_errno.ENOTSOCK)
 
         if task_id in self.__waiters:
-            raise _error_from_errno(_errno.EINPROGRESS)
+            raise _error_from_errno(_errno.EBUSY)
 
         if abort_errno is None:
             abort_errno = _errno.EINTR

--- a/tests/unit_test/test_async/test_asyncio_backend/test_socket.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_socket.py
@@ -82,7 +82,7 @@ class MixinTestAsyncSocketBusy(BaseTestAsyncSocket):
         mock_socket_method: MagicMock,
     ) -> None:
         # Arrange
-        from errno import EINPROGRESS
+        from errno import EBUSY
 
         with self._set_sock_method_in_blocking_state(mock_socket_method):
             _ = await self._busy_socket_task(socket_method(), event_loop, mock_socket_method)
@@ -92,7 +92,7 @@ class MixinTestAsyncSocketBusy(BaseTestAsyncSocket):
             await socket_method()
 
         # Assert
-        assert exc_info.value.errno == EINPROGRESS
+        assert exc_info.value.errno == EBUSY
         mock_socket_method.assert_not_called()
 
     async def test____method____closed_socket____before_attempt(


### PR DESCRIPTION
What made me choose `EINPROGRESS` over `EBUSY` ? I don't really know.