### PR TITLE
AbstractAsyncBackend: Removed wait_for() method

### DIFF
--- a/src/easynetwork/api_async/backend/abc.py
+++ b/src/easynetwork/api_async/backend/abc.py
@@ -298,10 +298,6 @@ class AbstractAsyncBackend(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    async def wait_for(self, coroutine: Coroutine[Any, Any, _T_co], timeout: float | None) -> _T_co:
-        raise NotImplementedError
-
-    @abstractmethod
     def timeout(self, delay: float) -> AsyncContextManager[AbstractTimeoutHandle]:
         raise NotImplementedError
 

--- a/src/easynetwork_asyncio/backend.py
+++ b/src/easynetwork_asyncio/backend.py
@@ -88,12 +88,6 @@ class AsyncioBackend(AbstractAsyncBackend):
         finally:
             del task
 
-    async def wait_for(self, coroutine: Coroutine[Any, Any, _T_co], timeout: float | None) -> _T_co:
-        assert asyncio.iscoroutine(coroutine), "Expected a coroutine object"
-
-        async with asyncio.timeout(timeout):
-            return await coroutine
-
     def timeout(self, delay: float) -> AsyncContextManager[AbstractTimeoutHandle]:
         from .tasks import timeout
 

--- a/tests/functional_test/test_async/test_backend/test_asyncio_backend.py
+++ b/tests/functional_test/test_async/test_backend/test_asyncio_backend.py
@@ -84,36 +84,6 @@ class TestAsyncioBackend:
             await task
         assert task.cancelled()
 
-    async def test____wait_for____without_timeout(
-        self,
-        backend: AsyncioBackend,
-    ) -> None:
-        assert (await backend.wait_for(asyncio.sleep(0.5, 42), None)) == 42
-
-    async def test____wait_for____with_timeout____respected(
-        self,
-        backend: AsyncioBackend,
-    ) -> None:
-        assert (await backend.wait_for(asyncio.sleep(0.5, 42), 1)) == 42
-
-    async def test____wait_for____with_timeout____timeout_error(
-        self,
-        backend: AsyncioBackend,
-    ) -> None:
-        with pytest.raises(TimeoutError):
-            await backend.wait_for(asyncio.sleep(0.5, 42), 0.25)
-
-    async def test____wait_for____with_timeout____cancellation(
-        self,
-        event_loop: asyncio.AbstractEventLoop,
-        backend: AsyncioBackend,
-    ) -> None:
-        task = event_loop.create_task(backend.wait_for(asyncio.sleep(0.5, 42), 0.25))
-        event_loop.call_later(0.10, task.cancel)
-
-        await asyncio.wait({task})
-        assert task.cancelled()
-
     async def test____timeout____respected(
         self,
         backend: AsyncioBackend,

--- a/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
+++ b/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
@@ -41,9 +41,6 @@ class BaseFakeBackend(AbstractAsyncBackend):
     async def ignore_cancellation(self, coroutine: Coroutine[Any, Any, Any]) -> Any:
         raise NotImplementedError
 
-    async def wait_for(self, coroutine: Coroutine[Any, Any, Any], timeout: float | None) -> Any:
-        raise NotImplementedError
-
     def timeout(self, delay: Any) -> AsyncContextManager[AbstractTimeoutHandle]:
         raise NotImplementedError
 


### PR DESCRIPTION
Use `backend.timeout()` and `backend.timeout_at()` should be prioritized