### PR TITLE
`api_sync`: `client.recv_packet()` is now interrupted if `client.close()` has been called in a different thread

### DIFF
--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -179,9 +179,7 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             ##################
 
             # Enable socket
-            address: SocketAddress = new_socket_address(self.__socket.get_local_address(), self.__socket.socket().family)
-            self.__logger.info("Start serving at %s", address)
-            del address
+            self.__logger.info("Start serving at %s", self.get_address())
             #################
 
             # Server is up
@@ -322,6 +320,11 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             self.__logger.error("-" * 40)
             self.__logger.exception("Exception occurred during processing of request from %s", client_address)
             self.__logger.error("-" * 40)
+
+    def get_address(self) -> SocketAddress | None:
+        if (socket := self.__socket) is None or socket.is_closing():
+            return None
+        return new_socket_address(socket.get_local_address(), socket.socket().family)
 
     def get_backend(self) -> AbstractAsyncBackend:
         return self.__backend

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -140,7 +140,7 @@ def retry_socket_method(
             break
         is_retry_interval: bool
         wait_time: float | None
-        if retry_interval is None or (timeout is not None and timeout < retry_interval):
+        if retry_interval is None or (timeout is not None and timeout <= retry_interval):
             is_retry_interval = False
             wait_time = timeout
         else:

--- a/tests/functional_test/test_async/test_backend/test_tasks.py
+++ b/tests/functional_test/test_async/test_backend/test_tasks.py
@@ -71,3 +71,20 @@ class TestSingleTaskRunner:
             await runner.run()
 
         assert task.cancelled()
+
+    async def test____run____unhandled_exceptions(
+        self,
+        backend: AbstractAsyncBackend,
+        mocker: MockerFixture,
+    ) -> None:
+        my_exc = OSError()
+        coro_func = mocker.AsyncMock(spec=lambda *args, **kwargs: None, side_effect=[my_exc])
+        runner: SingleTaskRunner[Any] = SingleTaskRunner(backend, coro_func)
+
+        with pytest.raises(OSError) as exc_info_run_1:
+            _ = await runner.run()
+        with pytest.raises(OSError) as exc_info_run_2:
+            _ = await runner.run()
+
+        assert exc_info_run_1.value is my_exc
+        assert exc_info_run_2.value is my_exc

--- a/tests/functional_test/test_communication/test_async/test_server/test_standalone.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_standalone.py
@@ -37,7 +37,8 @@ class BaseTestStandaloneNetworkServer:
             t = threading.Thread(target=server.serve_forever, kwargs={"is_up_event": is_up_event}, daemon=True)
             t.start()
 
-            is_up_event.wait(timeout=1)
+            if not is_up_event.wait(timeout=1):
+                raise TimeoutError("Too long to start")
             assert server.is_serving()
 
             yield

--- a/tests/functional_test/test_communication/test_async/test_server/test_standalone.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_standalone.py
@@ -102,14 +102,20 @@ class TestStandaloneTCPNetworkServer(BaseTestStandaloneNetworkServer):
 
     def test____stop_listening____default_to_noop(self, server: StandaloneTCPNetworkServer[str, str]) -> None:
         with server:
+            assert not server.sockets
+            assert not server.get_addresses()
             server.stop_listening()
 
     @pytest.mark.usefixtures("start_server")
     def test____stop_listening____stop_accepting_new_connection(self, server: StandaloneTCPNetworkServer[str, str]) -> None:
         assert server.is_serving()
+        assert len(server.sockets) > 0
+        assert len(server.get_addresses()) > 0
 
         server.stop_listening()
         assert not server.is_serving()
+        assert len(server.sockets) > 0  # Sockets are closed, but always available until server_close() call
+        assert len(server.get_addresses()) == 0
 
 
 class TestStandaloneUDPNetworkServer(BaseTestStandaloneNetworkServer):
@@ -132,3 +138,13 @@ class TestStandaloneUDPNetworkServer(BaseTestStandaloneNetworkServer):
             backend="asyncio",
             backend_kwargs={"runner_factory": runner_factory},
         )
+
+    def test____socket_property____server_is_not_running(self, server: StandaloneUDPNetworkServer[str, str]) -> None:
+        with server:
+            assert server.socket is None
+            assert server.get_address() is None
+
+    @pytest.mark.usefixtures("start_server")
+    def test____socket_property____server_is_running(self, server: StandaloneUDPNetworkServer[str, str]) -> None:
+        assert server.socket is not None
+        assert server.get_address() is not None

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -297,6 +297,7 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
             backend_kwargs=backend_kwargs,
         ) as server:
             assert not server.sockets
+            assert not server.get_addresses()
             yield server
 
     @pytest_asyncio.fixture
@@ -305,7 +306,9 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
         async with asyncio.timeout(1):
             await run_server.wait()
         assert server.is_serving()
-        return server.sockets[0].getsockname()[:2]
+        server_addresses = server.get_addresses()
+        assert len(server_addresses) == 1
+        return server_addresses[0].for_connection()
 
     @pytest.fixture
     @staticmethod

--- a/tests/functional_test/test_communication/test_async/test_server/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_udp.py
@@ -186,6 +186,7 @@ class TestAsyncUDPNetworkServer(BaseTestAsyncServer):
             backend_kwargs=backend_kwargs,
         ) as server:
             assert server.socket is None
+            assert server.get_address() is None
             yield server
 
     @pytest_asyncio.fixture
@@ -195,7 +196,9 @@ class TestAsyncUDPNetworkServer(BaseTestAsyncServer):
             await run_server.wait()
         assert server.is_serving()
         assert server.socket is not None
-        return server.socket.getsockname()[:2]
+        server_address = server.get_address()
+        assert server_address is not None
+        return server_address.for_connection()
 
     @pytest.fixture
     @staticmethod

--- a/tests/functional_test/test_concurrency/conftest.py
+++ b/tests/functional_test/test_concurrency/conftest.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import threading
+from typing import AsyncGenerator, Iterator, Literal
+
+from easynetwork.api_async.server.handler import AsyncBaseRequestHandler, AsyncClientInterface
+from easynetwork.api_async.server.standalone import (
+    AbstractStandaloneNetworkServer,
+    StandaloneTCPNetworkServer,
+    StandaloneUDPNetworkServer,
+)
+from easynetwork.exceptions import BaseProtocolParseError
+from easynetwork.protocol import DatagramProtocol, StreamProtocol
+from easynetwork.serializers.line import StringLineSerializer
+
+import pytest
+
+
+class EchoRequestHandler(AsyncBaseRequestHandler[str, str]):
+    async def handle(self, client: AsyncClientInterface[str]) -> AsyncGenerator[None, str]:
+        request = yield
+        await client.send_packet(request)
+
+    async def bad_request(self, client: AsyncClientInterface[str], exc: BaseProtocolParseError, /) -> None:
+        await client.aclose()
+
+
+@pytest.fixture(params=["TCP", "UDP"])
+def ipproto(request: pytest.FixtureRequest) -> Literal["TCP", "UDP"]:
+    return getattr(request, "param").upper()
+
+
+def _build_server(ipproto: Literal["TCP", "UDP"]) -> AbstractStandaloneNetworkServer:
+    serializer = StringLineSerializer()
+    request_handler = EchoRequestHandler()
+    backend = "asyncio"
+    match ipproto:
+        case "TCP":
+            return StandaloneTCPNetworkServer(None, 0, StreamProtocol(serializer), request_handler, backend)
+        case "UDP":
+            return StandaloneUDPNetworkServer(None, 0, DatagramProtocol(serializer), request_handler, backend)
+        case _:
+            pytest.fail("Invalid ipproto")
+
+
+def _run_server(server: AbstractStandaloneNetworkServer) -> None:
+    is_up_event = threading.Event()
+    t = threading.Thread(target=server.serve_forever, kwargs={"is_up_event": is_up_event}, daemon=True)
+    t.start()
+
+    if not is_up_event.wait(timeout=1):
+        raise TimeoutError("Too long to start")
+    assert server.is_serving()
+
+
+def _retrieve_server_port(server: AbstractStandaloneNetworkServer) -> int:
+    match server:
+        case StandaloneTCPNetworkServer():
+            addresses = server.get_addresses()
+            assert addresses
+            return addresses[0].port
+        case StandaloneUDPNetworkServer():
+            address = server.get_address()
+            assert address
+            return address.port
+        case _:
+            pytest.fail("Cannot retrieve server port")
+
+
+@pytest.fixture
+def server(ipproto: Literal["TCP", "UDP"]) -> Iterator[tuple[str, int]]:
+    with _build_server(ipproto) as server:
+        try:
+            _run_server(server)
+            yield "localhost", _retrieve_server_port(server)
+        finally:
+            server.shutdown()

--- a/tests/functional_test/test_concurrency/test_sync/conftest.py
+++ b/tests/functional_test/test_concurrency/test_sync/conftest.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+from typing import Iterator, Literal
+
+from easynetwork.api_sync.client import AbstractNetworkClient, TCPNetworkClient, UDPNetworkClient
+from easynetwork.protocol import DatagramProtocol, StreamProtocol
+from easynetwork.serializers.line import StringLineSerializer
+
+import pytest
+
+
+def _build_client(ipproto: Literal["TCP", "UDP"], server_address: tuple[str, int]) -> AbstractNetworkClient[str, str]:
+    serializer = StringLineSerializer()
+    match ipproto:
+        case "TCP":
+            return TCPNetworkClient(server_address, StreamProtocol(serializer))
+        case "UDP":
+            return UDPNetworkClient(server_address, DatagramProtocol(serializer))
+        case _:
+            pytest.fail("Invalid ipproto")
+
+
+@pytest.fixture
+def client(ipproto: Literal["TCP", "UDP"], server: tuple[str, int]) -> Iterator[AbstractNetworkClient[str, str]]:
+    with _build_client(ipproto, server) as client:
+        yield client

--- a/tests/functional_test/test_concurrency/test_sync/test_threaded_client.py
+++ b/tests/functional_test/test_concurrency/test_sync/test_threaded_client.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Iterator, TypeAlias
+
+from easynetwork.api_sync.client.abc import AbstractNetworkClient
+
+import pytest
+
+ClientType: TypeAlias = AbstractNetworkClient[str, str]
+
+
+@pytest.fixture
+def executor(client: ClientType) -> Iterator[ThreadPoolExecutor]:
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        try:
+            yield executor
+        finally:
+            client.close()
+
+
+def test____recv_packet____in_a_background_thread(executor: ThreadPoolExecutor, client: ClientType) -> None:
+    recv_packet = executor.submit(client.recv_packet, timeout=None)
+    while not recv_packet.running():
+        time.sleep(0.1)
+
+    client.send_packet("Hello world!")
+    assert recv_packet.result() == "Hello world!"
+
+
+@pytest.mark.slow
+def test____recv_packet____close_while_waiting(executor: ThreadPoolExecutor, client: ClientType) -> None:
+    recv_packet = executor.submit(client.recv_packet, timeout=2)
+    while not recv_packet.running():
+        time.sleep(0.1)
+
+    time.sleep(1.1)
+
+    client.close()
+    assert isinstance(recv_packet.exception(), ConnectionAbortedError)

--- a/tests/functional_test/test_concurrency/test_sync/test_threaded_client.py
+++ b/tests/functional_test/test_concurrency/test_sync/test_threaded_client.py
@@ -33,7 +33,7 @@ def test____recv_packet____in_a_background_thread(executor: ThreadPoolExecutor, 
 
 @pytest.mark.slow
 def test____recv_packet____close_while_waiting(executor: ThreadPoolExecutor, client: ClientType) -> None:
-    recv_packet = executor.submit(client.recv_packet, timeout=2)
+    recv_packet = executor.submit(client.recv_packet, timeout=3)
     while not recv_packet.running():
         time.sleep(0.1)
 

--- a/tests/scripts/async_client_test.py
+++ b/tests/scripts/async_client_test.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from typing import Callable
+
+from easynetwork.api_async.client import AbstractAsyncNetworkClient, AsyncTCPNetworkClient, AsyncUDPNetworkClient
+from easynetwork.protocol import DatagramProtocol, StreamProtocol
+from easynetwork.serializers.line import StringLineSerializer
+
+logger = logging.getLogger("app")
+
+
+def create_tcp_client(port: int) -> AsyncTCPNetworkClient[str, str]:
+    return AsyncTCPNetworkClient(("localhost", port), StreamProtocol(StringLineSerializer()), backend_kwargs={"transport": False})
+
+
+def create_udp_client(port: int) -> AsyncUDPNetworkClient[str, str]:
+    return AsyncUDPNetworkClient(("localhost", port), DatagramProtocol(StringLineSerializer()))
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="log_level",
+        action="store_const",
+        const="DEBUG",
+        default="INFO",
+        help="Increase verbose level",
+    )
+    parser.add_argument(
+        "-p",
+        "--port",
+        dest="server_port",
+        type=int,
+        default=9000,
+        help="Server port",
+    )
+
+    ipproto_group = parser.add_mutually_exclusive_group()
+    ipproto_group.add_argument(
+        "-t",
+        "--tcp",
+        dest="client_factory",
+        action="store_const",
+        const=create_tcp_client,
+        help="launch TCP client (the default)",
+    )
+    ipproto_group.add_argument(
+        "-u",
+        "--udp",
+        dest="client_factory",
+        action="store_const",
+        const=create_udp_client,
+        help="launch UDP client",
+    )
+    parser.set_defaults(client_factory=create_tcp_client)
+
+    args = parser.parse_args()
+
+    client_factory: Callable[[int], AbstractAsyncNetworkClient[str, str]] = args.client_factory
+    server_port: int = args.server_port
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="[ %(asctime)s ] [ %(levelname)s ] [ %(name)s ] %(message)s",
+    )
+
+    async with client_factory(server_port) as client:
+        task = asyncio.create_task(client.recv_packet())
+
+        logger.info("client.recv_packet() in task")
+        await asyncio.sleep(1.1)
+
+        await client.aclose()
+        logger.info("client.aclose() called")
+        await asyncio.wait({task})
+        logger.info("Returned exception: %r", task.exception())
+        logger.info("successfully aborted")
+        logger.info("End")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/tests/scripts/threaded_client_test.py
+++ b/tests/scripts/threaded_client_test.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import logging
+import time
+from typing import Callable
+
+from easynetwork.api_sync.client import AbstractNetworkClient, TCPNetworkClient, UDPNetworkClient
+from easynetwork.protocol import DatagramProtocol, StreamProtocol
+from easynetwork.serializers.line import StringLineSerializer
+
+logger = logging.getLogger("app")
+
+
+def create_tcp_client(port: int) -> TCPNetworkClient[str, str]:
+    return TCPNetworkClient(("localhost", port), StreamProtocol(StringLineSerializer()))
+
+
+def create_udp_client(port: int) -> UDPNetworkClient[str, str]:
+    return UDPNetworkClient(("localhost", port), DatagramProtocol(StringLineSerializer()))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="log_level",
+        action="store_const",
+        const="DEBUG",
+        default="INFO",
+        help="Increase verbose level",
+    )
+    parser.add_argument(
+        "-p",
+        "--port",
+        dest="server_port",
+        type=int,
+        default=9000,
+        help="Server port",
+    )
+
+    ipproto_group = parser.add_mutually_exclusive_group()
+    ipproto_group.add_argument(
+        "-t",
+        "--tcp",
+        dest="client_factory",
+        action="store_const",
+        const=create_tcp_client,
+        help="launch TCP client (the default)",
+    )
+    ipproto_group.add_argument(
+        "-u",
+        "--udp",
+        dest="client_factory",
+        action="store_const",
+        const=create_udp_client,
+        help="launch UDP client",
+    )
+    parser.set_defaults(client_factory=create_tcp_client)
+
+    args = parser.parse_args()
+
+    client_factory: Callable[[int], AbstractNetworkClient[str, str]] = args.client_factory
+    server_port: int = args.server_port
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="[ %(asctime)s ] [ %(levelname)s ] [ %(name)s ] %(message)s",
+    )
+
+    with (
+        concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor,
+        client_factory(server_port) as client,
+    ):
+        fut = executor.submit(client.recv_packet, timeout=None)
+        # fut = executor.submit(client.recv_packet, timeout=3)
+
+        logger.info("client.recv_packet() in thread")
+        time.sleep(1.1)
+
+        client.close()
+        logger.info("client.close() called")
+        logger.info("Returned exception: %r", fut.exception())
+        logger.info("successfully aborted")
+        logger.info("End")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
### What's changed
- In `TCPNetworkClient`:
  - `close()` now calls `socket.shutdown(SHUT_RDWR)` before calling `socket.close()`
- In `UDPNetworkEndpoint`:
  - Like `TCPNetworkClient`, if the socket have been closed while using it, `ConnectionAbortedError` is raised
  - Added `retry_interval` (in seconds) parameter
    - `send_packet_to()` now retries after (at most) the given seconds to call `socket.sendto()` until success
      - If the socket have been closed between attempts, `ConnectionAbortedError` is raised
    - `recv_packet_from()` now retries after (at most) the given seconds to call `socket.recvfrom()` until success
      - This does not impact the `timeout` parameter
      - If the socket have been closed between attempts, `ConnectionAbortedError` is raised
    - If `retry_interval==math.inf`, this feature is disabled

### Miscellaneous
#### easynetwork.api_sync
- The following methods explicitly supports `timeout=math.inf` parameter. This is equivalent to `timeout=None`:
  - `TCPNetworkClient.recv_packet()`
  - `TCPNetworkClient.iter_received_packets()`
  - `UDPNetworkClient.recv_packet()`
  - `UDPNetworkClient.iter_received_packets()`
  - `UDPNetworkEndpoint.recv_packet_from()`
  - `UDPNetworkEndpoint.iter_received_packets_from()`

#### easynetwork.api_async
- `SingleTaskRunner.run()` now does not wrap the coroutine exception in an `ExceptionGroup`
- Added `AsyncTCPNetworkServer.get_addresses()`
- Added `AsyncUDPNetworkServer.get_address()`
- Added `StandaloneTCPNetworkServer.get_addresses()`
- Added `StandaloneTCPNetworkServer.sockets` property
- Added `StandaloneUDPNetworkServer.get_address()`
- Added `StandaloneUDPNetworkServer.socket` property