### PR TITLE
Removed lazy imports (except for serializers)

### DIFF
--- a/src/easynetwork/api_async/backend/factory.py
+++ b/src/easynetwork/api_async/backend/factory.py
@@ -11,14 +11,14 @@ from __future__ import annotations
 __all__ = ["AsyncBackendFactory"]
 
 import functools
+import importlib.metadata
+import inspect
+from collections import Counter
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Final, Mapping, final
+from typing import Any, Final, Mapping, final
 
 from .abc import AbstractAsyncBackend
 from .sniffio import current_async_library as _sniffio_current_async_library
-
-if TYPE_CHECKING:
-    from importlib.metadata import EntryPoint
 
 
 @final
@@ -45,8 +45,6 @@ class AsyncBackendFactory:
 
     @staticmethod
     def set_default_backend(backend: str | type[AbstractAsyncBackend] | None) -> None:
-        import inspect
-
         match backend:
             case type() if not issubclass(backend, AbstractAsyncBackend) or inspect.isabstract(backend):
                 raise TypeError(f"Invalid backend class: {backend!r}")
@@ -128,9 +126,7 @@ class AsyncBackendFactory:
     @staticmethod
     @functools.cache
     def __load_backend_cls_from_entry_point(name: str) -> type[AbstractAsyncBackend]:
-        import inspect
-
-        entry_point: EntryPoint = AsyncBackendFactory.__get_available_backends()[name]
+        entry_point: importlib.metadata.EntryPoint = AsyncBackendFactory.__get_available_backends()[name]
 
         entry_point_cls: Any = entry_point.load()
         if (
@@ -143,17 +139,14 @@ class AsyncBackendFactory:
 
     @staticmethod
     @functools.cache
-    def __get_available_backends() -> MappingProxyType[str, EntryPoint]:
-        from collections import Counter
-        from importlib.metadata import entry_points as get_all_entry_points
-
-        entry_points = get_all_entry_points(group=AsyncBackendFactory.GROUP_NAME)
+    def __get_available_backends() -> MappingProxyType[str, importlib.metadata.EntryPoint]:
+        entry_points = importlib.metadata.entry_points(group=AsyncBackendFactory.GROUP_NAME)
         duplicate_counter: Counter[str] = Counter([ep.name for ep in entry_points])
 
         if duplicates := set(name for name in duplicate_counter if duplicate_counter[name] > 1):
             raise TypeError(f"Conflicting backend name caught: {', '.join(map(repr, sorted(duplicates)))}")
 
-        backends: dict[str, EntryPoint] = {ep.name: ep for ep in entry_points}
+        backends: dict[str, importlib.metadata.EntryPoint] = {ep.name: ep for ep in entry_points}
 
         assert "asyncio" in backends, "SystemError: Missing 'asyncio' entry point."
 

--- a/src/easynetwork/api_async/client/tcp.py
+++ b/src/easynetwork/api_async/client/tcp.py
@@ -22,9 +22,18 @@ from typing import (
     NoReturn,
     TypedDict,
     TypeVar,
+    cast,
     final,
     overload,
 )
+
+try:
+    import ssl as _ssl
+except ImportError:  # pragma: no cover
+    _ssl_module = None
+else:
+    _ssl_module = _ssl
+    del _ssl
 
 from ...exceptions import ClientClosedError, StreamProtocolParseError
 from ...protocol import StreamProtocol
@@ -145,10 +154,10 @@ class AsyncTCPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
         self.__info: _ClientInfo | None = None
 
         if ssl:
+            if _ssl_module is None:
+                raise RuntimeError("stdlib ssl module not available")
             if isinstance(ssl, bool):
-                from ssl import create_default_context
-
-                ssl = create_default_context()
+                ssl = cast("_SSLContext", _ssl_module.create_default_context())
                 if server_hostname is not None and not server_hostname:
                     ssl.check_hostname = False
         else:

--- a/src/easynetwork/api_sync/client/abc.py
+++ b/src/easynetwork/api_sync/client/abc.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 __all__ = ["AbstractNetworkClient"]
 
+import time
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Any, Generic, Iterator, Self, TypeVar
 
@@ -57,7 +58,7 @@ class AbstractNetworkClient(Generic[_SentPacketT, _ReceivedPacketT], metaclass=A
         raise NotImplementedError
 
     def iter_received_packets(self, timeout: float | None = 0) -> Iterator[_ReceivedPacketT]:
-        from time import monotonic
+        monotonic = time.monotonic
 
         recv_packet = self.recv_packet
         while True:

--- a/src/easynetwork/serializers/abc.py
+++ b/src/easynetwork/serializers/abc.py
@@ -14,6 +14,9 @@ __all__ = [
 from abc import ABCMeta, abstractmethod
 from typing import Any, Generator, Generic, TypeVar
 
+from ..exceptions import DeserializeError
+from ..tools._utils import concatenate_chunks as _concatenate_chunks
+
 _ST_contra = TypeVar("_ST_contra", contravariant=True)
 _DT_co = TypeVar("_DT_co", covariant=True)
 
@@ -45,13 +48,9 @@ class AbstractIncrementalPacketSerializer(AbstractPacketSerializer[_ST_contra, _
         raise NotImplementedError
 
     def serialize(self, packet: _ST_contra) -> bytes:
-        from ..tools._utils import concatenate_chunks
-
-        return concatenate_chunks(self.incremental_serialize(packet))
+        return _concatenate_chunks(self.incremental_serialize(packet))
 
     def deserialize(self, data: bytes) -> _DT_co:
-        from ..exceptions import DeserializeError
-
         consumer: Generator[None, bytes, tuple[_DT_co, bytes]] = self.incremental_deserialize()
         try:
             next(consumer)

--- a/src/easynetwork/serializers/pickle.py
+++ b/src/easynetwork/serializers/pickle.py
@@ -12,23 +12,30 @@ __all__ = [
     "UnpicklerConfig",
 ]
 
-import pickle as _pickle
-import pickletools as _pickletools
-from dataclasses import asdict as dataclass_asdict, dataclass
+from dataclasses import asdict as dataclass_asdict, dataclass, field
 from functools import partial
 from io import BytesIO
-from typing import IO, Callable, TypeVar, final
+from typing import IO, TYPE_CHECKING, Callable, TypeVar, final
 
 from ..exceptions import DeserializeError
 from .abc import AbstractPacketSerializer
+
+if TYPE_CHECKING:
+    from pickle import Pickler as _Pickler, Unpickler as _Unpickler
 
 _ST_contra = TypeVar("_ST_contra", contravariant=True)
 _DT_co = TypeVar("_DT_co", covariant=True)
 
 
+def _get_default_pickler_protocol() -> int:
+    import pickle
+
+    return pickle.DEFAULT_PROTOCOL
+
+
 @dataclass(kw_only=True)
 class PicklerConfig:
-    protocol: int = _pickle.DEFAULT_PROTOCOL
+    protocol: int = field(default_factory=_get_default_pickler_protocol)
     fix_imports: bool = False
 
 
@@ -47,14 +54,21 @@ class PickleSerializer(AbstractPacketSerializer[_ST_contra, _DT_co]):
         pickler_config: PicklerConfig | None = None,
         unpickler_config: UnpicklerConfig | None = None,
         *,
-        pickler_cls: type[_pickle.Pickler] | None = None,
-        unpickler_cls: type[_pickle.Unpickler] | None = None,
+        pickler_cls: type[_Pickler] | None = None,
+        unpickler_cls: type[_Unpickler] | None = None,
         optimize: bool = False,
     ) -> None:
         super().__init__()
-        self.__optimize = bool(optimize)
-        self.__pickler_cls: Callable[[IO[bytes]], _pickle.Pickler]
-        self.__unpickler_cls: Callable[[IO[bytes]], _pickle.Unpickler]
+
+        import pickle
+
+        self.__optimize: Callable[[bytes], bytes] | None = None
+        if optimize:
+            import pickletools
+
+            self.__optimize = pickletools.optimize
+        self.__pickler_cls: Callable[[IO[bytes]], _Pickler]
+        self.__unpickler_cls: Callable[[IO[bytes]], _Unpickler]
 
         if pickler_config is None:
             pickler_config = PicklerConfig()
@@ -68,16 +82,16 @@ class PickleSerializer(AbstractPacketSerializer[_ST_contra, _DT_co]):
                 f"Invalid unpickler config: expected {UnpicklerConfig.__name__}, got {type(unpickler_config).__name__}"
             )
 
-        self.__pickler_cls = partial(pickler_cls or _pickle.Pickler, **dataclass_asdict(pickler_config), buffer_callback=None)
-        self.__unpickler_cls = partial(unpickler_cls or _pickle.Unpickler, **dataclass_asdict(unpickler_config), buffers=None)
+        self.__pickler_cls = partial(pickler_cls or pickle.Pickler, **dataclass_asdict(pickler_config), buffer_callback=None)
+        self.__unpickler_cls = partial(unpickler_cls or pickle.Unpickler, **dataclass_asdict(unpickler_config), buffers=None)
 
     @final
     def serialize(self, packet: _ST_contra) -> bytes:
         with BytesIO() as buffer:
             self.__pickler_cls(buffer).dump(packet)
             pickle: bytes = buffer.getvalue()
-        if self.__optimize:
-            pickle = _pickletools.optimize(pickle)
+        if (optimize := self.__optimize) is not None:
+            pickle = optimize(pickle)
         return pickle
 
     @final

--- a/src/easynetwork/serializers/wrapper/base64.py
+++ b/src/easynetwork/serializers/wrapper/base64.py
@@ -12,6 +12,7 @@ __all__ = [
 
 import base64
 import binascii
+import os
 from hashlib import sha256 as hashlib_sha256
 from hmac import compare_digest, digest as hmac_digest
 from typing import Callable, TypeVar, assert_never, final
@@ -56,9 +57,7 @@ class Base64EncodedSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co])
 
     @classmethod
     def generate_key(cls) -> bytes:
-        from os import urandom
-
-        return base64.urlsafe_b64encode(urandom(32))
+        return base64.urlsafe_b64encode(os.urandom(32))
 
     @final
     def serialize(self, packet: _ST_contra) -> bytes:

--- a/src/easynetwork/serializers/wrapper/base64.py
+++ b/src/easynetwork/serializers/wrapper/base64.py
@@ -10,11 +10,7 @@ __all__ = [
     "Base64EncodedSerializer",
 ]
 
-import base64
-import binascii
 import os
-from hashlib import sha256 as hashlib_sha256
-from hmac import compare_digest, digest as hmac_digest
 from typing import Callable, TypeVar, assert_never, final
 
 from ...exceptions import DeserializeError
@@ -26,7 +22,7 @@ _DT_co = TypeVar("_DT_co", covariant=True)
 
 
 class Base64EncodedSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co]):
-    __slots__ = ("__serializer", "__checksum")
+    __slots__ = ("__serializer", "__encode", "__decode", "__compare_digest", "__decode_error_cls", "__checksum")
 
     def __init__(
         self,
@@ -35,6 +31,11 @@ class Base64EncodedSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co])
         checksum: bool | str | bytes = False,
         separator: bytes = b"\r\n",
     ) -> None:
+        import base64
+        import binascii
+        from hashlib import sha256 as hashlib_sha256
+        from hmac import compare_digest, digest as hmac_digest
+
         super().__init__(separator=separator)
         assert isinstance(serializer, AbstractPacketSerializer)
         self.__serializer: AbstractPacketSerializer[_ST_contra, _DT_co] = serializer
@@ -55,8 +56,15 @@ class Base64EncodedSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co])
             case _:  # pragma: no cover
                 assert_never(checksum)
 
+        self.__encode = base64.urlsafe_b64encode
+        self.__decode = base64.urlsafe_b64decode
+        self.__decode_error_cls = binascii.Error
+        self.__compare_digest = compare_digest
+
     @classmethod
     def generate_key(cls) -> bytes:
+        import base64
+
         return base64.urlsafe_b64encode(os.urandom(32))
 
     @final
@@ -64,16 +72,16 @@ class Base64EncodedSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co])
         data = self.__serializer.serialize(packet)
         if (checksum := self.__checksum) is not None:
             data += checksum(data)
-        return base64.urlsafe_b64encode(data)
+        return self.__encode(data)
 
     @final
     def deserialize(self, data: bytes) -> _DT_co:
         try:
-            data = base64.urlsafe_b64decode(data)
-        except binascii.Error:
+            data = self.__decode(data)
+        except self.__decode_error_cls:
             raise DeserializeError("Invalid token") from None
         if (checksum := self.__checksum) is not None:
             data, digest = data[:-32], data[-32:]
-            if not compare_digest(checksum(data), digest):
+            if not self.__compare_digest(checksum(data), digest):
                 raise DeserializeError("Invalid token", error_info=None)
         return self.__serializer.deserialize(data)

--- a/src/easynetwork/serializers/wrapper/compressor.py
+++ b/src/easynetwork/serializers/wrapper/compressor.py
@@ -13,10 +13,8 @@ __all__ = [
 ]
 
 import abc
-import bz2
-import zlib
 from collections import deque
-from typing import Generator, Protocol, TypeVar, final
+from typing import Final, Generator, Protocol, TypeVar, final
 
 from ...exceptions import DeserializeError, IncrementalDeserializeError
 from ..abc import AbstractIncrementalPacketSerializer, AbstractPacketSerializer
@@ -147,17 +145,27 @@ class AbstractCompressorSerializer(AbstractIncrementalPacketSerializer[_ST_contr
 class BZ2CompressorSerializer(AbstractCompressorSerializer[_ST_contra, _DT_co]):
     __slots__ = ("__compresslevel",)
 
-    def __init__(self, serializer: AbstractPacketSerializer[_ST_contra, _DT_co], *, compress_level: int = 9) -> None:
+    BEST_COMPRESSION_LEVEL: Final[int] = 9
+
+    def __init__(self, serializer: AbstractPacketSerializer[_ST_contra, _DT_co], *, compress_level: int | None = None) -> None:
+        import bz2  # Import it now
+
+        del bz2
+
         super().__init__(serializer=serializer, expected_decompress_error=OSError)
-        self.__compresslevel: int = compress_level
+        self.__compresslevel: int = compress_level if compress_level is not None else self.BEST_COMPRESSION_LEVEL
 
     @final
-    def new_compressor_stream(self) -> bz2.BZ2Compressor:
-        return bz2.BZ2Compressor(self.__compresslevel)
+    def new_compressor_stream(self) -> CompressorInterface:
+        from bz2 import BZ2Compressor
+
+        return BZ2Compressor(self.__compresslevel)
 
     @final
-    def new_decompressor_stream(self) -> bz2.BZ2Decompressor:
-        return bz2.BZ2Decompressor()
+    def new_decompressor_stream(self) -> DecompressorInterface:
+        from bz2 import BZ2Decompressor
+
+        return BZ2Decompressor()
 
 
 class ZlibCompressorSerializer(AbstractCompressorSerializer[_ST_contra, _DT_co]):
@@ -167,15 +175,21 @@ class ZlibCompressorSerializer(AbstractCompressorSerializer[_ST_contra, _DT_co])
         self,
         serializer: AbstractPacketSerializer[_ST_contra, _DT_co],
         *,
-        compress_level: int = zlib.Z_BEST_COMPRESSION,
+        compress_level: int | None = None,
     ) -> None:
+        import zlib
+
         super().__init__(serializer=serializer, expected_decompress_error=zlib.error)
-        self.__compresslevel: int = compress_level
+        self.__compresslevel: int = compress_level if compress_level is not None else zlib.Z_BEST_COMPRESSION
 
     @final
-    def new_compressor_stream(self) -> zlib._Compress:
+    def new_compressor_stream(self) -> CompressorInterface:
+        import zlib
+
         return zlib.compressobj(self.__compresslevel)
 
     @final
-    def new_decompressor_stream(self) -> zlib._Decompress:
+    def new_decompressor_stream(self) -> DecompressorInterface:
+        import zlib
+
         return zlib.decompressobj()

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -31,6 +31,14 @@ import time
 import traceback
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, ParamSpec, TypeGuard, TypeVar, assert_never
 
+try:
+    import ssl as _ssl
+except ImportError:  # pragma: no cover
+    ssl = None
+else:
+    ssl = _ssl
+    del _ssl
+
 if TYPE_CHECKING:
     from ssl import SSLError as _SSLError, SSLSocket as _SSLSocket
 
@@ -81,11 +89,8 @@ def check_real_socket_state(socket: _socket.socket | _SocketProxy) -> None:
 
 
 def is_ssl_socket(socket: _socket.socket) -> TypeGuard[_SSLSocket]:
-    try:
-        import ssl
-    except ImportError:  # pragma: no cover
+    if ssl is None:
         return False
-
     return isinstance(socket, ssl.SSLSocket)
 
 
@@ -164,10 +169,10 @@ def retry_ssl_socket_method(
     *args: _P.args,
     **kwargs: _P.kwargs,
 ) -> _R:
+    if ssl is None:
+        raise RuntimeError("stdlib ssl module not available")
     assert is_ssl_socket(socket), "Expected an ssl.SSLSocket instance"
     assert socket.gettimeout() == 0, "The socket must be non-blocking"
-
-    import ssl
 
     monotonic = time.monotonic  # pull function to local namespace
     event: Literal["read", "write"]
@@ -190,9 +195,7 @@ def retry_ssl_socket_method(
 
 
 def is_ssl_eof_error(exc: BaseException) -> TypeGuard[_SSLError]:
-    try:
-        import ssl
-    except ImportError:  # pragma: no cover
+    if ssl is None:
         return False
 
     match exc:

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -39,6 +39,8 @@ else:
     ssl = _ssl
     del _ssl
 
+from .socket import AddressFamily
+
 if TYPE_CHECKING:
     from ssl import SSLError as _SSLError, SSLSocket as _SSLSocket
 
@@ -65,8 +67,6 @@ def error_from_errno(errno: int) -> OSError:
 
 
 def check_socket_family(family: int) -> None:
-    from .socket import AddressFamily
-
     supported_families: dict[str, int] = dict(AddressFamily.__members__)
 
     if family not in list(supported_families.values()):

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -169,8 +169,7 @@ def retry_ssl_socket_method(
     *args: _P.args,
     **kwargs: _P.kwargs,
 ) -> _R:
-    if ssl is None:
-        raise RuntimeError("stdlib ssl module not available")
+    assert ssl is not None, "stdlib ssl module not available"
     assert is_ssl_socket(socket), "Expected an ssl.SSLSocket instance"
     assert socket.gettimeout() == 0, "The socket must be non-blocking"
 

--- a/src/easynetwork/tools/stream.py
+++ b/src/easynetwork/tools/stream.py
@@ -11,6 +11,7 @@ __all__ = [
     "StreamDataProducer",
 ]
 
+import threading
 from collections import deque
 from typing import Any, Generator, Generic, Iterator, TypeVar, final
 
@@ -37,9 +38,7 @@ class StreamDataProducer(Generic[_SentPacketT]):
         self.__g: Generator[bytes, None, None] | None = None
         self.__q: deque[_SentPacketT] = deque()
 
-        from threading import Lock
-
-        self.__lock = ForkSafeLock(Lock)
+        self.__lock = ForkSafeLock(threading.Lock)
 
     def __del__(self) -> None:  # pragma: no cover
         try:
@@ -110,9 +109,7 @@ class StreamDataConsumer(Generic[_ReceivedPacketT]):
         self.__c: Generator[None, bytes, tuple[_ReceivedPacketT, bytes]] | None = None
         self.__b: bytes = b""
 
-        from threading import Lock
-
-        self.__lock = ForkSafeLock(Lock)
+        self.__lock = ForkSafeLock(threading.Lock)
 
     def __del__(self) -> None:  # pragma: no cover
         try:

--- a/src/easynetwork_asyncio/backend.py
+++ b/src/easynetwork_asyncio/backend.py
@@ -13,7 +13,10 @@ import asyncio
 import asyncio.base_events
 import contextvars
 import functools
+import itertools
+import os
 import socket as _socket
+import sys
 from typing import TYPE_CHECKING, Any, AsyncContextManager, Callable, Coroutine, NoReturn, ParamSpec, Sequence, TypeVar
 
 try:
@@ -26,23 +29,24 @@ else:
 
 from easynetwork.api_async.backend.abc import AbstractAsyncBackend
 from easynetwork.api_async.backend.sniffio import current_async_library_cvar as _sniffio_current_async_library_cvar
+from easynetwork.tools._utils import open_listener_sockets_from_getaddrinfo_result
+from easynetwork.tools.socket import MAX_STREAM_BUFSIZE
+
+from ._utils import _ensure_resolved, create_connection, create_datagram_socket
+from .datagram.endpoint import create_datagram_endpoint
+from .datagram.socket import AsyncioTransportDatagramSocketAdapter, RawDatagramSocketAdapter
+from .stream.listener import AcceptedSocket, AcceptedSSLSocket, ListenerSocketAdapter
+from .stream.socket import AsyncioTransportStreamSocketAdapter, RawStreamSocketAdapter
+from .tasks import TaskGroup, timeout, timeout_at
+from .threads import ThreadsPortal
 
 if TYPE_CHECKING:
     import concurrent.futures
     from ssl import SSLContext as _SSLContext
 
-    from easynetwork.api_async.backend.abc import (
-        AbstractAcceptedSocket,
-        AbstractAsyncDatagramSocketAdapter,
-        AbstractAsyncListenerSocketAdapter,
-        AbstractAsyncStreamSocketAdapter,
-        AbstractTaskGroup,
-        AbstractThreadsPortal,
-        AbstractTimeoutHandle,
-        ICondition,
-        IEvent,
-        ILock,
-    )
+    from easynetwork.api_async.backend.abc import AbstractAcceptedSocket, ILock
+
+    from .tasks import TimeoutHandle
 
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
@@ -97,14 +101,10 @@ class AsyncioBackend(AbstractAsyncBackend):
         finally:
             del task
 
-    def timeout(self, delay: float) -> AsyncContextManager[AbstractTimeoutHandle]:
-        from .tasks import timeout
-
+    def timeout(self, delay: float) -> AsyncContextManager[TimeoutHandle]:
         return timeout(delay)
 
-    def timeout_at(self, deadline: float) -> AsyncContextManager[AbstractTimeoutHandle]:
-        from .tasks import timeout_at
-
+    def timeout_at(self, deadline: float) -> AsyncContextManager[TimeoutHandle]:
         return timeout_at(deadline)
 
     @classmethod
@@ -136,9 +136,7 @@ class AsyncioBackend(AbstractAsyncBackend):
         await loop.create_future()
         raise AssertionError("await an unused future cannot end in any other way than by cancellation")
 
-    def create_task_group(self) -> AbstractTaskGroup:
-        from .tasks import TaskGroup
-
+    def create_task_group(self) -> TaskGroup:
         return TaskGroup()
 
     async def create_tcp_connection(
@@ -148,7 +146,7 @@ class AsyncioBackend(AbstractAsyncBackend):
         *,
         local_address: tuple[str, int] | None = None,
         happy_eyeballs_delay: float | None = None,
-    ) -> AbstractAsyncStreamSocketAdapter:
+    ) -> AsyncioTransportStreamSocketAdapter | RawStreamSocketAdapter:
         assert host is not None, "Expected 'host' to be a str"
         assert port is not None, "Expected 'port' to be an int"
 
@@ -156,19 +154,11 @@ class AsyncioBackend(AbstractAsyncBackend):
             self._check_asyncio_transport("'happy_eyeballs_delay' option")
 
         if not self.__use_asyncio_transport:
-            from ._utils import create_connection
-            from .stream.socket import RawStreamSocketAdapter
-
             loop = asyncio.get_running_loop()
-
             socket = await create_connection(host, port, loop, local_address=local_address)
             return RawStreamSocketAdapter(socket, loop)
 
         happy_eyeballs_delay = self._default_happy_eyeballs_delay(happy_eyeballs_delay)
-
-        from easynetwork.tools.socket import MAX_STREAM_BUFSIZE
-
-        from .stream.socket import AsyncioTransportStreamSocketAdapter
 
         if happy_eyeballs_delay is None:
             reader, writer = await asyncio.open_connection(
@@ -198,15 +188,11 @@ class AsyncioBackend(AbstractAsyncBackend):
         ssl_shutdown_timeout: float,
         local_address: tuple[str, int] | None = None,
         happy_eyeballs_delay: float | None = None,
-    ) -> AbstractAsyncStreamSocketAdapter:
+    ) -> AsyncioTransportStreamSocketAdapter:
         self._check_ssl_support()
         self.__verify_ssl_context(ssl_context)
 
         happy_eyeballs_delay = self._default_happy_eyeballs_delay(happy_eyeballs_delay)
-
-        from easynetwork.tools.socket import MAX_STREAM_BUFSIZE
-
-        from .stream.socket import AsyncioTransportStreamSocketAdapter
 
         if happy_eyeballs_delay is None:
             reader, writer = await asyncio.open_connection(
@@ -241,18 +227,15 @@ class AsyncioBackend(AbstractAsyncBackend):
                 happy_eyeballs_delay = 0.25  # Recommended value by the RFC 6555
         return happy_eyeballs_delay
 
-    async def wrap_tcp_client_socket(self, socket: _socket.socket) -> AbstractAsyncStreamSocketAdapter:
+    async def wrap_tcp_client_socket(
+        self,
+        socket: _socket.socket,
+    ) -> AsyncioTransportStreamSocketAdapter | RawStreamSocketAdapter:
         assert socket is not None, "Expected 'socket' to be a socket.socket instance"
         socket.setblocking(False)
 
         if not self.__use_asyncio_transport:
-            from .stream.socket import RawStreamSocketAdapter
-
             return RawStreamSocketAdapter(socket, asyncio.get_running_loop())
-
-        from easynetwork.tools.socket import MAX_STREAM_BUFSIZE
-
-        from .stream.socket import AsyncioTransportStreamSocketAdapter
 
         reader, writer = await asyncio.open_connection(sock=socket, limit=MAX_STREAM_BUFSIZE)
         return AsyncioTransportStreamSocketAdapter(reader, writer)
@@ -265,16 +248,12 @@ class AsyncioBackend(AbstractAsyncBackend):
         server_hostname: str,
         ssl_handshake_timeout: float,
         ssl_shutdown_timeout: float,
-    ) -> AbstractAsyncStreamSocketAdapter:
+    ) -> AsyncioTransportStreamSocketAdapter:
         self._check_ssl_support()
         self.__verify_ssl_context(ssl_context)
 
         assert socket is not None, "Expected 'socket' to be a socket.socket instance"
         socket.setblocking(False)
-
-        from easynetwork.tools.socket import MAX_STREAM_BUFSIZE
-
-        from .stream.socket import AsyncioTransportStreamSocketAdapter
 
         reader, writer = await asyncio.open_connection(
             sock=socket,
@@ -293,9 +272,7 @@ class AsyncioBackend(AbstractAsyncBackend):
         backlog: int,
         *,
         reuse_port: bool = False,
-    ) -> Sequence[AbstractAsyncListenerSocketAdapter]:
-        from .stream.listener import AcceptedSocket
-
+    ) -> Sequence[ListenerSocketAdapter]:
         return await self._create_tcp_listeners(
             host,
             port,
@@ -314,11 +291,9 @@ class AsyncioBackend(AbstractAsyncBackend):
         ssl_shutdown_timeout: float,
         *,
         reuse_port: bool = False,
-    ) -> Sequence[AbstractAsyncListenerSocketAdapter]:
+    ) -> Sequence[ListenerSocketAdapter]:
         self._check_ssl_support()
         self.__verify_ssl_context(ssl_context)
-
-        from .stream.listener import AcceptedSSLSocket
 
         return await self._create_tcp_listeners(
             host,
@@ -341,16 +316,8 @@ class AsyncioBackend(AbstractAsyncBackend):
         accepted_socket_factory: Callable[[_socket.socket, asyncio.AbstractEventLoop], AbstractAcceptedSocket],
         *,
         reuse_port: bool,
-    ) -> Sequence[AbstractAsyncListenerSocketAdapter]:
+    ) -> Sequence[ListenerSocketAdapter]:
         assert port is not None, "Expected 'port' to be an int"
-
-        import os
-        import sys
-        from itertools import chain
-
-        from easynetwork.tools._utils import open_listener_sockets_from_getaddrinfo_result
-
-        from ._utils import _ensure_resolved
 
         loop = asyncio.get_running_loop()
 
@@ -364,7 +331,7 @@ class AsyncioBackend(AbstractAsyncBackend):
             hosts = host
 
         infos: set[tuple[int, int, int, str, tuple[Any, ...]]] = set(
-            chain.from_iterable(
+            itertools.chain.from_iterable(
                 await asyncio.gather(
                     *[
                         _ensure_resolved(host, port, _socket.AF_UNSPEC, _socket.SOCK_STREAM, loop, flags=_socket.AI_PASSIVE)
@@ -381,8 +348,6 @@ class AsyncioBackend(AbstractAsyncBackend):
             reuse_port=reuse_port,
         )
 
-        from .stream.listener import ListenerSocketAdapter
-
         return [ListenerSocketAdapter(sock, loop, accepted_socket_factory) for sock in sockets]
 
     async def create_udp_endpoint(
@@ -391,9 +356,7 @@ class AsyncioBackend(AbstractAsyncBackend):
         local_address: tuple[str | None, int] | None = None,
         remote_address: tuple[str, int] | None = None,
         reuse_port: bool = False,
-    ) -> AbstractAsyncDatagramSocketAdapter:
-        from ._utils import create_datagram_socket
-
+    ) -> AsyncioTransportDatagramSocketAdapter | RawDatagramSocketAdapter:
         socket = await create_datagram_socket(
             loop=asyncio.get_running_loop(),
             local_address=local_address,
@@ -403,28 +366,23 @@ class AsyncioBackend(AbstractAsyncBackend):
 
         return await self.wrap_udp_socket(socket)
 
-    async def wrap_udp_socket(self, socket: _socket.socket) -> AbstractAsyncDatagramSocketAdapter:
+    async def wrap_udp_socket(self, socket: _socket.socket) -> AsyncioTransportDatagramSocketAdapter | RawDatagramSocketAdapter:
         assert socket is not None, "Expected 'socket' to be a socket.socket instance"
         socket.setblocking(False)
 
         if not self.__use_asyncio_transport:
-            from .datagram.socket import RawDatagramSocketAdapter
-
             return RawDatagramSocketAdapter(socket, asyncio.get_running_loop())
-
-        from .datagram.endpoint import create_datagram_endpoint
-        from .datagram.socket import AsyncioTransportDatagramSocketAdapter
 
         endpoint = await create_datagram_endpoint(socket=socket)
         return AsyncioTransportDatagramSocketAdapter(endpoint)
 
-    def create_lock(self) -> ILock:
+    def create_lock(self) -> asyncio.Lock:
         return asyncio.Lock()
 
-    def create_event(self) -> IEvent:
+    def create_event(self) -> asyncio.Event:
         return asyncio.Event()
 
-    def create_condition_var(self, lock: ILock | None = None) -> ICondition:
+    def create_condition_var(self, lock: ILock | None = None) -> asyncio.Condition:
         if lock is not None:
             assert isinstance(lock, asyncio.Lock)
 
@@ -445,9 +403,7 @@ class AsyncioBackend(AbstractAsyncBackend):
         finally:
             del future
 
-    def create_threads_portal(self) -> AbstractThreadsPortal:
-        from .threads import ThreadsPortal
-
+    def create_threads_portal(self) -> ThreadsPortal:
         return ThreadsPortal()
 
     async def wait_future(self, future: concurrent.futures.Future[_T_co]) -> _T_co:

--- a/src/easynetwork_asyncio/backend.py
+++ b/src/easynetwork_asyncio/backend.py
@@ -452,5 +452,7 @@ class AsyncioBackend(AbstractAsyncBackend):
         self._check_asyncio_transport("SSL/TLS")
 
     def __verify_ssl_context(self, ctx: _SSLContext) -> None:
-        if ssl is None or not isinstance(ctx, ssl.SSLContext):
+        if ssl is None:
+            raise RuntimeError("stdlib ssl module not available")
+        if not isinstance(ctx, ssl.SSLContext):
             raise ValueError(f"Expected a ssl.SSLContext instance, got {ctx!r}")

--- a/src/easynetwork_asyncio/datagram/socket.py
+++ b/src/easynetwork_asyncio/datagram/socket.py
@@ -10,13 +10,16 @@ from __future__ import annotations
 __all__ = ["AsyncioTransportDatagramSocketAdapter", "RawDatagramSocketAdapter"]
 
 import asyncio
+import socket as _socket
 from typing import TYPE_CHECKING, Any, final
 
 from easynetwork.api_async.backend.abc import AbstractAsyncDatagramSocketAdapter
+from easynetwork.tools.socket import MAX_DATAGRAM_BUFSIZE
+
+from ..socket import AsyncSocket
 
 if TYPE_CHECKING:
     import asyncio.trsock
-    import socket as _socket
 
     from _typeshed import ReadableBuffer
 
@@ -79,13 +82,9 @@ class RawDatagramSocketAdapter(AbstractAsyncDatagramSocketAdapter):
     ) -> None:
         super().__init__()
 
-        from socket import SOCK_DGRAM
-
-        from ..socket import AsyncSocket
-
         self.__socket: AsyncSocket = AsyncSocket(socket, loop)
 
-        assert socket.type == SOCK_DGRAM, "A 'SOCK_DGRAM' socket is expected"
+        assert socket.type == _socket.SOCK_DGRAM, "A 'SOCK_DGRAM' socket is expected"
 
     async def aclose(self) -> None:
         return await self.__socket.aclose()
@@ -103,8 +102,6 @@ class RawDatagramSocketAdapter(AbstractAsyncDatagramSocketAdapter):
             return None
 
     async def recvfrom(self) -> tuple[bytes, tuple[Any, ...]]:
-        from easynetwork.tools.socket import MAX_DATAGRAM_BUFSIZE
-
         return await self.__socket.recvfrom(MAX_DATAGRAM_BUFSIZE)
 
     async def sendto(self, data: ReadableBuffer, address: tuple[Any, ...] | None, /) -> None:

--- a/src/easynetwork_asyncio/stream/listener.py
+++ b/src/easynetwork_asyncio/stream/listener.py
@@ -19,6 +19,10 @@ from easynetwork.api_async.backend.abc import (
     AbstractAsyncListenerSocketAdapter,
     AbstractAsyncStreamSocketAdapter,
 )
+from easynetwork.tools.socket import MAX_STREAM_BUFSIZE
+
+from ..socket import AsyncSocket
+from .socket import AsyncioTransportStreamSocketAdapter, RawStreamSocketAdapter
 
 if TYPE_CHECKING:
     import asyncio.trsock
@@ -37,8 +41,6 @@ class ListenerSocketAdapter(AbstractAsyncListenerSocketAdapter):
         accepted_socket_factory: Callable[[_socket.socket, asyncio.AbstractEventLoop], AbstractAcceptedSocket],
     ) -> None:
         super().__init__()
-
-        from ..socket import AsyncSocket
 
         self.__socket: AsyncSocket = AsyncSocket(socket, loop)
         self.__accepted_socket_factory = accepted_socket_factory
@@ -107,13 +109,7 @@ class AcceptedSocket(_BaseAcceptedSocket):
     async def _make_socket_adapter(self, socket: _socket.socket) -> AbstractAsyncStreamSocketAdapter:
         loop = self.loop
         if not self.__use_asyncio_transport:
-            from .socket import RawStreamSocketAdapter
-
             return RawStreamSocketAdapter(socket, loop)
-
-        from easynetwork.tools.socket import MAX_STREAM_BUFSIZE
-
-        from .socket import AsyncioTransportStreamSocketAdapter
 
         reader = asyncio.streams.StreamReader(MAX_STREAM_BUFSIZE, loop)
         protocol = asyncio.streams.StreamReaderProtocol(reader, loop=loop)
@@ -144,10 +140,6 @@ class AcceptedSSLSocket(_BaseAcceptedSocket):
         self.__ssl_shutdown_timeout: float = float(ssl_shutdown_timeout)
 
     async def _make_socket_adapter(self, socket: _socket.socket) -> AbstractAsyncStreamSocketAdapter:
-        from easynetwork.tools.socket import MAX_STREAM_BUFSIZE
-
-        from .socket import AsyncioTransportStreamSocketAdapter
-
         loop = self.loop
         reader = asyncio.streams.StreamReader(MAX_STREAM_BUFSIZE, loop)
         protocol = asyncio.streams.StreamReaderProtocol(reader, loop=loop)

--- a/src/easynetwork_asyncio/stream/socket.py
+++ b/src/easynetwork_asyncio/stream/socket.py
@@ -10,14 +10,17 @@ from __future__ import annotations
 __all__ = ["AsyncioTransportStreamSocketAdapter", "RawStreamSocketAdapter"]
 
 import asyncio
+import errno
+import socket as _socket
 from typing import TYPE_CHECKING, Any, final
 
 from easynetwork.api_async.backend.abc import AbstractAsyncStreamSocketAdapter
 from easynetwork.tools._utils import error_from_errno as _error_from_errno
 
+from ..socket import AsyncSocket
+
 if TYPE_CHECKING:
     import asyncio.trsock
-    import socket as _socket
 
     from _typeshed import ReadableBuffer
 
@@ -43,8 +46,6 @@ class AsyncioTransportStreamSocketAdapter(AbstractAsyncStreamSocketAdapter):
         assert socket is not None, "Writer transport must be a socket transport"
         remote_address = writer.get_extra_info("peername")
         if remote_address is None:
-            import errno
-
             raise _error_from_errno(errno.ENOTCONN)
         self.__remote_addr: tuple[Any, ...] = tuple(remote_address)
 
@@ -102,13 +103,9 @@ class RawStreamSocketAdapter(AbstractAsyncStreamSocketAdapter):
     ) -> None:
         super().__init__()
 
-        from socket import SOCK_STREAM
-
-        from ..socket import AsyncSocket
-
         self.__socket: AsyncSocket = AsyncSocket(socket, loop)
 
-        assert socket.type == SOCK_STREAM, "A 'SOCK_STREAM' socket is expected"
+        assert socket.type == _socket.SOCK_STREAM, "A 'SOCK_STREAM' socket is expected"
 
         remote_address = socket.getpeername()
         self.__remote_addr: tuple[Any, ...] = tuple(remote_address)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,4 +22,5 @@ pytest_plugins = [
     f"{PYTEST_PLUGINS_PACKAGE}.asyncio_event_loop",
     f"{PYTEST_PLUGINS_PACKAGE}.extra_features",
     f"{PYTEST_PLUGINS_PACKAGE}.session_exit_code",
+    f"{PYTEST_PLUGINS_PACKAGE}.ssl_module",
 ]

--- a/tests/functional_test/test_communication/test_async/test_client/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_client/test_tcp.py
@@ -18,6 +18,7 @@ import pytest_asyncio
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("simulate_no_ssl_module")
 class TestAsyncTCPNetworkClient:
     @pytest.fixture
     @staticmethod
@@ -205,6 +206,7 @@ class TestAsyncTCPNetworkClient:
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("simulate_no_ssl_module")
 class TestAsyncTCPNetworkClientConnection:
     @pytest_asyncio.fixture(autouse=True)
     @staticmethod
@@ -525,3 +527,23 @@ class TestAsyncSSLOverTCPNetworkClient:
             assert not client_ssl_context.check_hostname  # It must be set to False if server_hostname is an empty string
             await client.send_packet("Test")
             assert await client.recv_packet() == "Test"
+
+    @pytest.mark.usefixtures("simulate_no_ssl_module")
+    async def test____dunder_init____no_ssl_module_available(
+        self,
+        remote_address: tuple[str, int],
+        stream_protocol: StreamProtocol[str, str],
+        backend_kwargs: dict[str, Any],
+        client_ssl_context: ssl.SSLContext,
+    ) -> None:
+        # Arrange
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match=r"^stdlib ssl module not available$"):
+            _ = AsyncTCPNetworkClient(
+                remote_address,
+                stream_protocol,
+                ssl=client_ssl_context,
+                server_hostname="test.example.com",
+                backend_kwargs=backend_kwargs,
+            )

--- a/tests/functional_test/test_communication/test_async/test_server/test_standalone.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_standalone.py
@@ -45,6 +45,7 @@ class BaseTestStandaloneNetworkServer:
 
             server.shutdown()
             assert not server.is_serving()
+            t.join()
 
     def test____is_serving____default_to_False(self, server: AbstractStandaloneNetworkServer) -> None:
         with server:
@@ -65,6 +66,7 @@ class BaseTestStandaloneNetworkServer:
 
             server.shutdown()
             assert not server.is_serving()
+            t.join()
 
     @pytest.mark.usefixtures("start_server")
     def test____server_close____while_server_is_running(self, server: AbstractStandaloneNetworkServer) -> None:

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -12,7 +12,7 @@ from socket import IPPROTO_TCP, TCP_NODELAY
 from typing import Any, AsyncGenerator, AsyncIterator, Awaitable, Callable, Sequence
 from weakref import WeakValueDictionary
 
-from easynetwork.api_async.backend.abc import AbstractAsyncBackend, AbstractAsyncListenerSocketAdapter
+from easynetwork.api_async.backend.abc import AbstractAsyncBackend
 from easynetwork.api_async.server.handler import AsyncBaseRequestHandler, AsyncClientInterface, AsyncStreamRequestHandler
 from easynetwork.api_async.server.tcp import AsyncTCPNetworkServer
 from easynetwork.exceptions import BaseProtocolParseError, ClientClosedError, StreamProtocolParseError
@@ -20,6 +20,7 @@ from easynetwork.protocol import StreamProtocol
 from easynetwork.tools.socket import SocketAddress
 from easynetwork_asyncio._utils import create_connection
 from easynetwork_asyncio.backend import AsyncioBackend
+from easynetwork_asyncio.stream.listener import ListenerSocketAdapter
 
 import pytest
 import pytest_asyncio
@@ -36,7 +37,7 @@ class NoListenerErrorBackend(AsyncioBackend):
         *,
         family: int = 0,
         reuse_port: bool = False,
-    ) -> Sequence[AbstractAsyncListenerSocketAdapter]:
+    ) -> Sequence[ListenerSocketAdapter]:
         return []
 
     async def create_ssl_over_tcp_listeners(
@@ -50,7 +51,7 @@ class NoListenerErrorBackend(AsyncioBackend):
         *,
         family: int = 0,
         reuse_port: bool = False,
-    ) -> Sequence[AbstractAsyncListenerSocketAdapter]:
+    ) -> Sequence[ListenerSocketAdapter]:
         return []
 
 

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -8,7 +8,6 @@ import contextlib
 import logging
 import math
 import ssl
-import ssl as _ssl
 from socket import IPPROTO_TCP, TCP_NODELAY
 from typing import Any, AsyncGenerator, AsyncIterator, Awaitable, Callable, Sequence
 from weakref import WeakValueDictionary
@@ -45,7 +44,7 @@ class NoListenerErrorBackend(AsyncioBackend):
         host: str | Sequence[str] | None,
         port: int,
         backlog: int,
-        ssl_context: _ssl.SSLContext,
+        ssl_context: ssl.SSLContext,
         ssl_handshake_timeout: float,
         ssl_shutdown_timeout: float,
         *,

--- a/tests/functional_test/test_communication/test_sync/test_client/test_tcp.py
+++ b/tests/functional_test/test_communication/test_sync/test_client/test_tcp.py
@@ -18,6 +18,7 @@ import pytest
 from .....tools import TimeTest
 
 
+@pytest.mark.usefixtures("simulate_no_ssl_module")
 class TestTCPNetworkClient:
     @pytest.fixture
     @staticmethod
@@ -224,6 +225,7 @@ class TCPServer(socketserver.TCPServer):
         return socket, client_address
 
 
+@pytest.mark.usefixtures("simulate_no_ssl_module")
 class TestTCPNetworkClientConnection:
     @pytest.fixture(autouse=True)
     @classmethod
@@ -339,3 +341,21 @@ class TestSSLOverTCPNetworkClient:
             assert not client_ssl_context.check_hostname  # It must be set to False if server_hostname is an empty string
             client.send_packet("Test")
             assert client.recv_packet() == "Test"
+
+    @pytest.mark.usefixtures("simulate_no_ssl_module")
+    def test____dunder_init____no_ssl_module(
+        self,
+        remote_address: tuple[str, int],
+        stream_protocol: StreamProtocol[str, str],
+        client_ssl_context: ssl.SSLContext,
+    ) -> None:
+        # Arrange
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match=r"^stdlib ssl module not available$"):
+            _ = TCPNetworkClient(
+                remote_address,
+                stream_protocol,
+                ssl=client_ssl_context,
+                server_hostname="test.example.com",
+            )

--- a/tests/functional_test/test_communication/test_sync/test_client/test_tcp.py
+++ b/tests/functional_test/test_communication/test_sync/test_client/test_tcp.py
@@ -233,7 +233,7 @@ class TestTCPNetworkClientConnection:
         from threading import Thread
 
         with TCPServer((localhost_ip, 0), socket_family) as server:
-            server_thread = Thread(target=server.serve_forever)
+            server_thread = Thread(target=server.serve_forever, daemon=True)
             server_thread.start()
             yield server
             server.shutdown()
@@ -270,7 +270,7 @@ class TestSSLOverTCPNetworkClient:
         from threading import Thread
 
         with TCPServer((localhost_ip, 0), socket_family, ssl_context=server_ssl_context) as server:
-            server_thread = Thread(target=server.serve_forever)
+            server_thread = Thread(target=server.serve_forever, daemon=True)
             server_thread.start()
             yield server
             server.shutdown()

--- a/tests/pytest_plugins/ssl_module.py
+++ b/tests/pytest_plugins/ssl_module.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import functools
+import importlib
+import ssl
+from typing import Any
+
+import pytest
+
+ALL_MODULES_WHICH_USE_SSL_MODULE: tuple[tuple[str, str], ...] = (
+    ("easynetwork.api_async.client.tcp", "_ssl_module"),
+    ("easynetwork.api_sync.client.tcp", "_ssl_module"),
+    ("easynetwork.tools._utils", "ssl"),
+    ("easynetwork_asyncio.backend", "ssl"),
+)
+
+
+@functools.cache
+def _verify_ssl_alias(module_name: str, alias_name: str) -> None:
+    module = importlib.import_module(module_name)
+    retrieved_ssl_module: Any = functools.reduce(getattr, filter(None, alias_name.split(".")), module)
+    assert retrieved_ssl_module is ssl, f"Alias name is invalid ({module_name}:{alias_name})"
+
+
+@pytest.fixture
+def simulate_no_ssl_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    for module_name, alias_name in ALL_MODULES_WHICH_USE_SSL_MODULE:
+        _verify_ssl_alias(module_name, alias_name)
+        monkeypatch.setattr(f"{module_name}.{alias_name}", None)

--- a/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
@@ -7,6 +7,7 @@ import contextlib
 import contextvars
 from typing import TYPE_CHECKING, Any, Callable, Sequence, cast
 
+from easynetwork.api_async.backend.abc import AbstractAsyncStreamSocketAdapter
 from easynetwork_asyncio import AsyncioBackend
 
 import pytest
@@ -125,7 +126,7 @@ class TestAsyncIOBackend:
         mock_asyncio_reader = mock_asyncio_stream_reader_factory()
         mock_asyncio_writer = mock_asyncio_stream_writer_factory()
         mock_StreamSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.socket.AsyncioTransportStreamSocketAdapter", return_value=mocker.sentinel.socket
+            "easynetwork_asyncio.backend.AsyncioTransportStreamSocketAdapter", return_value=mocker.sentinel.socket
         )
         mock_open_connection: AsyncMock = mocker.patch(
             "asyncio.open_connection",
@@ -143,6 +144,7 @@ class TestAsyncIOBackend:
             }
 
         # Act
+        socket: AbstractAsyncStreamSocketAdapter
         if ssl:
             socket = await backend.create_ssl_over_tcp_connection(
                 *remote_address,
@@ -187,7 +189,7 @@ class TestAsyncIOBackend:
         # Arrange
         from easynetwork.tools.socket import MAX_STREAM_BUFSIZE
 
-        mocker.patch("easynetwork_asyncio.stream.socket.AsyncioTransportStreamSocketAdapter", return_value=mocker.sentinel.socket)
+        mocker.patch("easynetwork_asyncio.backend.AsyncioTransportStreamSocketAdapter", return_value=mocker.sentinel.socket)
         mock_open_connection: AsyncMock = mocker.patch(
             "asyncio.open_connection",
             new_callable=mocker.AsyncMock,
@@ -245,7 +247,7 @@ class TestAsyncIOBackend:
         # Arrange
         from easynetwork.tools.socket import MAX_STREAM_BUFSIZE
 
-        mocker.patch("easynetwork_asyncio.stream.socket.AsyncioTransportStreamSocketAdapter", return_value=mocker.sentinel.socket)
+        mocker.patch("easynetwork_asyncio.backend.AsyncioTransportStreamSocketAdapter", return_value=mocker.sentinel.socket)
         mock_open_connection: AsyncMock = mocker.patch(
             "asyncio.open_connection",
             new_callable=mocker.AsyncMock,
@@ -300,7 +302,7 @@ class TestAsyncIOBackend:
     ) -> None:
         # Arrange
         mock_RawStreamSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.socket.RawStreamSocketAdapter", return_value=mocker.sentinel.socket
+            "easynetwork_asyncio.backend.RawStreamSocketAdapter", return_value=mocker.sentinel.socket
         )
         mock_asyncio_open_connection: AsyncMock = mocker.patch(
             "asyncio.open_connection",
@@ -308,7 +310,7 @@ class TestAsyncIOBackend:
             side_effect=AssertionError,
         )
         mock_own_create_connection: AsyncMock = mocker.patch(
-            "easynetwork_asyncio._utils.create_connection",
+            "easynetwork_asyncio.backend.create_connection",
             new_callable=mocker.AsyncMock,
             return_value=mock_tcp_socket,
         )
@@ -339,7 +341,7 @@ class TestAsyncIOBackend:
     ) -> None:
         # Arrange
         mock_RawStreamSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.socket.RawStreamSocketAdapter", side_effect=AssertionError
+            "easynetwork_asyncio.backend.RawStreamSocketAdapter", side_effect=AssertionError
         )
         mock_asyncio_open_connection: AsyncMock = mocker.patch(
             "asyncio.open_connection",
@@ -347,7 +349,7 @@ class TestAsyncIOBackend:
             side_effect=AssertionError,
         )
         mock_own_create_connection: AsyncMock = mocker.patch(
-            "easynetwork_asyncio._utils.create_connection",
+            "easynetwork_asyncio.backend.create_connection",
             new_callable=mocker.AsyncMock,
             side_effect=AssertionError,
         )
@@ -376,10 +378,10 @@ class TestAsyncIOBackend:
     ) -> None:
         # Arrange
         mock_AsyncioTransportStreamSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.socket.AsyncioTransportStreamSocketAdapter", side_effect=AssertionError
+            "easynetwork_asyncio.backend.AsyncioTransportStreamSocketAdapter", side_effect=AssertionError
         )
         mock_RawStreamSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.socket.RawStreamSocketAdapter", side_effect=AssertionError
+            "easynetwork_asyncio.backend.RawStreamSocketAdapter", side_effect=AssertionError
         )
         mock_asyncio_open_connection: AsyncMock = mocker.patch(
             "asyncio.open_connection",
@@ -387,7 +389,7 @@ class TestAsyncIOBackend:
             side_effect=AssertionError,
         )
         mock_own_create_connection: AsyncMock = mocker.patch(
-            "easynetwork_asyncio._utils.create_connection",
+            "easynetwork_asyncio.backend.create_connection",
             new_callable=mocker.AsyncMock,
             side_effect=AssertionError,
         )
@@ -420,7 +422,7 @@ class TestAsyncIOBackend:
     ) -> None:
         # Arrange
         mock_AsyncioTransportStreamSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.socket.AsyncioTransportStreamSocketAdapter", side_effect=AssertionError
+            "easynetwork_asyncio.backend.AsyncioTransportStreamSocketAdapter", side_effect=AssertionError
         )
         mock_asyncio_open_connection: AsyncMock = mocker.patch(
             "asyncio.open_connection",
@@ -460,11 +462,11 @@ class TestAsyncIOBackend:
         mock_asyncio_reader = mock_asyncio_stream_reader_factory()
         mock_asyncio_writer = mock_asyncio_stream_writer_factory()
         mock_AsyncioTransportStreamSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.socket.AsyncioTransportStreamSocketAdapter",
+            "easynetwork_asyncio.backend.AsyncioTransportStreamSocketAdapter",
             return_value=mocker.sentinel.socket,
         )
         mock_RawStreamSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.socket.RawStreamSocketAdapter",
+            "easynetwork_asyncio.backend.RawStreamSocketAdapter",
             return_value=mocker.sentinel.socket,
         )
         mock_open_connection: AsyncMock = mocker.patch(
@@ -507,7 +509,7 @@ class TestAsyncIOBackend:
         mock_asyncio_reader = mock_asyncio_stream_reader_factory()
         mock_asyncio_writer = mock_asyncio_stream_writer_factory()
         mock_AsyncioTransportStreamSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.socket.AsyncioTransportStreamSocketAdapter",
+            "easynetwork_asyncio.backend.AsyncioTransportStreamSocketAdapter",
             return_value=mocker.sentinel.socket,
         )
         mock_open_connection: AsyncMock = mocker.patch(
@@ -558,10 +560,10 @@ class TestAsyncIOBackend:
     ) -> None:
         # Arrange
         mock_AsyncioTransportStreamSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.socket.AsyncioTransportStreamSocketAdapter", side_effect=AssertionError
+            "easynetwork_asyncio.backend.AsyncioTransportStreamSocketAdapter", side_effect=AssertionError
         )
         mock_RawStreamSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.socket.RawStreamSocketAdapter", side_effect=AssertionError
+            "easynetwork_asyncio.backend.RawStreamSocketAdapter", side_effect=AssertionError
         )
         mock_asyncio_open_connection: AsyncMock = mocker.patch(
             "asyncio.open_connection",
@@ -569,7 +571,7 @@ class TestAsyncIOBackend:
             side_effect=AssertionError,
         )
         mock_own_create_connection: AsyncMock = mocker.patch(
-            "easynetwork_asyncio._utils.create_connection",
+            "easynetwork_asyncio.backend.create_connection",
             new_callable=mocker.AsyncMock,
             side_effect=AssertionError,
         )
@@ -599,7 +601,7 @@ class TestAsyncIOBackend:
     ) -> None:
         # Arrange
         mock_AsyncioTransportStreamSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.socket.AsyncioTransportStreamSocketAdapter", side_effect=AssertionError
+            "easynetwork_asyncio.backend.AsyncioTransportStreamSocketAdapter", side_effect=AssertionError
         )
         mock_asyncio_open_connection: AsyncMock = mocker.patch(
             "asyncio.open_connection",
@@ -665,11 +667,11 @@ class TestAsyncIOBackend:
             ),
         )
         mock_open_listeners = mocker.patch(
-            "easynetwork.tools._utils.open_listener_sockets_from_getaddrinfo_result",
+            "easynetwork_asyncio.backend.open_listener_sockets_from_getaddrinfo_result",
             return_value=[mock_tcp_socket],
         )
         mock_ListenerSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.listener.ListenerSocketAdapter", return_value=mocker.sentinel.listener_socket
+            "easynetwork_asyncio.backend.ListenerSocketAdapter", return_value=mocker.sentinel.listener_socket
         )
         expected_factory: partial_eq
         if use_ssl:
@@ -776,11 +778,11 @@ class TestAsyncIOBackend:
             ),
         )
         mock_open_listeners = mocker.patch(
-            "easynetwork.tools._utils.open_listener_sockets_from_getaddrinfo_result",
+            "easynetwork_asyncio.backend.open_listener_sockets_from_getaddrinfo_result",
             return_value=[mock_tcp_socket, mock_tcp_socket],
         )
         mock_ListenerSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.listener.ListenerSocketAdapter",
+            "easynetwork_asyncio.backend.ListenerSocketAdapter",
             return_value=mocker.sentinel.listener_socket,
         )
         expected_factory: partial_eq
@@ -889,11 +891,11 @@ class TestAsyncIOBackend:
             ),
         )
         mock_open_listeners = mocker.patch(
-            "easynetwork.tools._utils.open_listener_sockets_from_getaddrinfo_result",
+            "easynetwork_asyncio.backend.open_listener_sockets_from_getaddrinfo_result",
             return_value=[mock_tcp_socket, mock_tcp_socket],
         )
         mock_ListenerSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.listener.ListenerSocketAdapter",
+            "easynetwork_asyncio.backend.ListenerSocketAdapter",
             return_value=mocker.sentinel.listener_socket,
         )
         expected_factory: partial_eq
@@ -985,11 +987,11 @@ class TestAsyncIOBackend:
             ),
         )
         mock_open_listeners = mocker.patch(
-            "easynetwork.tools._utils.open_listener_sockets_from_getaddrinfo_result",
+            "easynetwork_asyncio.backend.open_listener_sockets_from_getaddrinfo_result",
             side_effect=AssertionError,
         )
         mock_ListenerSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.listener.ListenerSocketAdapter",
+            "easynetwork_asyncio.backend.ListenerSocketAdapter",
             side_effect=AssertionError,
         )
 
@@ -1046,11 +1048,11 @@ class TestAsyncIOBackend:
             ),
         )
         mock_open_listeners = mocker.patch(
-            "easynetwork.tools._utils.open_listener_sockets_from_getaddrinfo_result",
+            "easynetwork_asyncio.backend.open_listener_sockets_from_getaddrinfo_result",
             side_effect=AssertionError,
         )
         mock_ListenerSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.stream.listener.ListenerSocketAdapter",
+            "easynetwork_asyncio.backend.ListenerSocketAdapter",
             side_effect=AssertionError,
         )
 
@@ -1085,20 +1087,20 @@ class TestAsyncIOBackend:
     ) -> None:
         mock_endpoint = mock_datagram_endpoint_factory()
         mock_AsyncioTransportDatagramSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.datagram.socket.AsyncioTransportDatagramSocketAdapter",
+            "easynetwork_asyncio.backend.AsyncioTransportDatagramSocketAdapter",
             return_value=mocker.sentinel.socket,
         )
         mock_RawDatagramSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.datagram.socket.RawDatagramSocketAdapter",
+            "easynetwork_asyncio.backend.RawDatagramSocketAdapter",
             return_value=mocker.sentinel.socket,
         )
         mock_create_datagram_endpoint: AsyncMock = mocker.patch(
-            "easynetwork_asyncio.datagram.endpoint.create_datagram_endpoint",
+            "easynetwork_asyncio.backend.create_datagram_endpoint",
             new_callable=mocker.AsyncMock,
             return_value=mock_endpoint,
         )
         mock_create_datagram_socket: AsyncMock = mocker.patch(
-            "easynetwork_asyncio._utils.create_datagram_socket",
+            "easynetwork_asyncio.backend.create_datagram_socket",
             new_callable=mocker.AsyncMock,
             return_value=mock_udp_socket,
         )
@@ -1141,15 +1143,15 @@ class TestAsyncIOBackend:
         # Arrange
         mock_endpoint = mock_datagram_endpoint_factory()
         mock_AsyncioTransportDatagramSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.datagram.socket.AsyncioTransportDatagramSocketAdapter",
+            "easynetwork_asyncio.backend.AsyncioTransportDatagramSocketAdapter",
             return_value=mocker.sentinel.socket,
         )
         mock_RawDatagramSocketAdapter: MagicMock = mocker.patch(
-            "easynetwork_asyncio.datagram.socket.RawDatagramSocketAdapter",
+            "easynetwork_asyncio.backend.RawDatagramSocketAdapter",
             return_value=mocker.sentinel.socket,
         )
         mock_create_datagram_endpoint: AsyncMock = mocker.patch(
-            "easynetwork_asyncio.datagram.endpoint.create_datagram_endpoint",
+            "easynetwork_asyncio.backend.create_datagram_endpoint",
             new_callable=mocker.AsyncMock,
             return_value=mock_endpoint,
         )

--- a/tests/unit_test/test_async/test_asyncio_backend/test_datagram.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_datagram.py
@@ -832,7 +832,7 @@ class TestRawDatagramSocketAdapter(BaseTestSocket):
     @pytest.fixture(autouse=True)
     @staticmethod
     def mock_async_socket_cls(mock_async_socket: MagicMock, mocker: MockerFixture) -> MagicMock:
-        return mocker.patch("easynetwork_asyncio.socket.AsyncSocket", return_value=mock_async_socket)
+        return mocker.patch(f"{RawDatagramSocketAdapter.__module__}.AsyncSocket", return_value=mock_async_socket)
 
     @pytest.fixture
     @classmethod

--- a/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
@@ -58,13 +58,6 @@ class BaseTestTransportStreamSocket:
         return mock
 
 
-class BaseTestRawStreamSocket(BaseTestSocket):
-    @pytest.fixture(autouse=True)
-    @staticmethod
-    def mock_async_socket_cls(mock_async_socket: MagicMock, mocker: MockerFixture) -> MagicMock:
-        return mocker.patch("easynetwork_asyncio.socket.AsyncSocket", return_value=mock_async_socket)
-
-
 @pytest.mark.asyncio
 class TestTransportBasedStreamSocket(BaseTestTransportStreamSocket):
     @pytest.fixture
@@ -286,7 +279,12 @@ class TestTransportBasedStreamSocket(BaseTestTransportStreamSocket):
 
 
 @pytest.mark.asyncio
-class TestListenerSocketAdapter(BaseTestTransportStreamSocket, BaseTestRawStreamSocket):
+class TestListenerSocketAdapter(BaseTestTransportStreamSocket, BaseTestSocket):
+    @pytest.fixture(autouse=True)
+    @staticmethod
+    def mock_async_socket_cls(mock_async_socket: MagicMock, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch(f"{ListenerSocketAdapter.__module__}.AsyncSocket", return_value=mock_async_socket)
+
     @pytest.fixture
     @classmethod
     def mock_tcp_listener_socket(
@@ -402,7 +400,12 @@ class TestListenerSocketAdapter(BaseTestTransportStreamSocket, BaseTestRawStream
 
 
 @pytest.mark.asyncio
-class TestAcceptedSocket(BaseTestTransportStreamSocket, BaseTestRawStreamSocket):
+class TestAcceptedSocket(BaseTestTransportStreamSocket, BaseTestSocket):
+    @pytest.fixture(autouse=True)
+    @staticmethod
+    def mock_async_socket_cls(mock_async_socket: MagicMock, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch(f"{ListenerSocketAdapter.__module__}.AsyncSocket", return_value=mock_async_socket)
+
     @pytest.fixture(params=[False, True], ids=lambda boolean: f"use_asyncio_transport=={boolean}")
     @staticmethod
     def use_asyncio_transport(request: Any) -> bool:
@@ -412,7 +415,7 @@ class TestAcceptedSocket(BaseTestTransportStreamSocket, BaseTestRawStreamSocket)
     @staticmethod
     def mock_transport_stream_socket_adapter_cls(mock_stream_socket_adapter: MagicMock, mocker: MockerFixture) -> MagicMock:
         return mocker.patch(
-            "easynetwork_asyncio.stream.socket.AsyncioTransportStreamSocketAdapter",
+            f"{ListenerSocketAdapter.__module__}.AsyncioTransportStreamSocketAdapter",
             return_value=mock_stream_socket_adapter,
         )
 
@@ -420,7 +423,7 @@ class TestAcceptedSocket(BaseTestTransportStreamSocket, BaseTestRawStreamSocket)
     @staticmethod
     def mock_raw_stream_socket_adapter_cls(mock_stream_socket_adapter: MagicMock, mocker: MockerFixture) -> MagicMock:
         return mocker.patch(
-            "easynetwork_asyncio.stream.socket.RawStreamSocketAdapter",
+            f"{ListenerSocketAdapter.__module__}.RawStreamSocketAdapter",
             return_value=mock_stream_socket_adapter,
         )
 
@@ -551,7 +554,7 @@ class TestAcceptedSSLSocket(BaseTestTransportStreamSocket):
     @staticmethod
     def mock_transport_stream_socket_adapter_cls(mock_stream_socket_adapter: MagicMock, mocker: MockerFixture) -> MagicMock:
         return mocker.patch(
-            "easynetwork_asyncio.stream.socket.AsyncioTransportStreamSocketAdapter",
+            f"{ListenerSocketAdapter.__module__}.AsyncioTransportStreamSocketAdapter",
             return_value=mock_stream_socket_adapter,
         )
 
@@ -668,7 +671,12 @@ class TestAcceptedSSLSocket(BaseTestTransportStreamSocket):
 
 
 @pytest.mark.asyncio
-class TestRawStreamSocketAdapter(BaseTestRawStreamSocket):
+class TestRawStreamSocketAdapter(BaseTestSocket):
+    @pytest.fixture(autouse=True)
+    @staticmethod
+    def mock_async_socket_cls(mock_async_socket: MagicMock, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch(f"{RawStreamSocketAdapter.__module__}.AsyncSocket", return_value=mock_async_socket)
+
     @pytest.fixture
     @classmethod
     def mock_tcp_socket(cls, mock_tcp_socket: MagicMock) -> MagicMock:

--- a/tests/unit_test/test_serializers/test_base64.py
+++ b/tests/unit_test/test_serializers/test_base64.py
@@ -16,12 +16,12 @@ if TYPE_CHECKING:
 
 
 class TestBase64EncodedSerializer:
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     @staticmethod
     def mock_b64encode(mocker: MockerFixture) -> MagicMock:
         return mocker.patch("base64.urlsafe_b64encode", autospec=True)
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     @staticmethod
     def mock_b64decode(mocker: MockerFixture) -> MagicMock:
         return mocker.patch("base64.urlsafe_b64decode", autospec=True)

--- a/tests/unit_test/test_serializers/test_compressor.py
+++ b/tests/unit_test/test_serializers/test_compressor.py
@@ -374,12 +374,12 @@ class TestBZ2CompressorSerializer(BaseTestCompressorSerializerImplementation):
     def serializer_cls() -> type[BZ2CompressorSerializer[Any, Any]]:
         return BZ2CompressorSerializer
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     @staticmethod
     def mock_bz2_compressor_cls(mocker: MockerFixture) -> MagicMock:
         return mocker.patch("bz2.BZ2Compressor")
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     @staticmethod
     def mock_bz2_decompressor_cls(mocker: MockerFixture) -> MagicMock:
         return mocker.patch("bz2.BZ2Decompressor")

--- a/tests/unit_test/test_serializers/test_pickle.py
+++ b/tests/unit_test/test_serializers/test_pickle.py
@@ -108,7 +108,7 @@ class TestPickleSerializer(BaseSerializerConfigInstanceCheck):
     def pickler_optimize(request: Any) -> bool:
         return request.param
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     @staticmethod
     def mock_pickletools_optimize(mocker: MockerFixture) -> MagicMock:
         return mocker.patch("pickletools.optimize", autospec=True)

--- a/tests/unit_test/test_sync/test_client/test_tcp.py
+++ b/tests/unit_test/test_sync/test_client/test_tcp.py
@@ -6,8 +6,8 @@ import contextlib
 import errno
 import os
 from selectors import EVENT_READ, EVENT_WRITE
-from socket import AF_INET6, IPPROTO_TCP, SHUT_RDWR, SO_KEEPALIVE, TCP_NODELAY
-from ssl import SOL_SOCKET, SSLEOFError, SSLError, SSLErrorNumber, SSLWantReadError, SSLWantWriteError, SSLZeroReturnError
+from socket import AF_INET6, IPPROTO_TCP, SHUT_RDWR, SO_KEEPALIVE, SOL_SOCKET, TCP_NODELAY
+from ssl import SSLEOFError, SSLError, SSLErrorNumber, SSLWantReadError, SSLWantWriteError, SSLZeroReturnError
 from typing import TYPE_CHECKING, Any
 
 from easynetwork.api_sync.client.tcp import TCPNetworkClient

--- a/tests/unit_test/test_tools/test_utils.py
+++ b/tests/unit_test/test_tools/test_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import selectors
+import ssl
 from socket import (
     AF_INET,
     AF_INET6,
@@ -211,7 +212,6 @@ def test____check_socket_no_ssl____ssl_socket(mock_ssl_socket: MagicMock) -> Non
 
 def test____is_ssl_eof_error____SSLEOFError() -> None:
     # Arrange
-    import ssl
 
     # Act & Assert
     assert is_ssl_eof_error(ssl.SSLEOFError())
@@ -219,7 +219,6 @@ def test____is_ssl_eof_error____SSLEOFError() -> None:
 
 def test____is_ssl_eof_error____SSLError_with_specific_mnemonic() -> None:
     # Arrange
-    import ssl
 
     # Act & Assert
     assert is_ssl_eof_error(ssl.SSLError(ssl.SSL_ERROR_SSL, "UNEXPECTED_EOF_WHILE_READING"))

--- a/tests/unit_test/test_tools/test_utils.py
+++ b/tests/unit_test/test_tools/test_utils.py
@@ -194,6 +194,14 @@ def test____is_ssl_socket____ssl_socket(mock_ssl_socket: MagicMock) -> None:
     assert is_ssl_socket(mock_ssl_socket)
 
 
+@pytest.mark.usefixtures("simulate_no_ssl_module")
+def test____is_ssl_socket____no_ssl_module(mock_ssl_socket: MagicMock) -> None:
+    # Arrange
+
+    # Act & Assert
+    assert not is_ssl_socket(mock_ssl_socket)
+
+
 def test____check_socket_no_ssl____regular_socket(mock_socket_factory: Callable[[], MagicMock]) -> None:
     # Arrange
     mock_socket = mock_socket_factory()
@@ -229,6 +237,14 @@ def test____is_ssl_eof_error____OSError() -> None:
 
     # Act & Assert
     assert not is_ssl_eof_error(OSError())
+
+
+@pytest.mark.usefixtures("simulate_no_ssl_module")
+def test____is_ssl_eof_error____no_ssl_module() -> None:
+    # Arrange
+
+    # Act & Assert
+    assert not is_ssl_eof_error(ssl.SSLEOFError())
 
 
 @pytest.mark.parametrize(["event", "selector_event"], [("read", "EVENT_READ"), ("write", "EVENT_WRITE")])


### PR DESCRIPTION
### What's changed
- For most of the functions, lazy import statements have been removed
  - `importlib.metadata` is kept lazy imported: A lot of useless modules (such as `email` ??) would be imported by default
- In `easynetwork.serializers`:
  - `pickle` and `pickletools` modules are not imported until `PickleSerializer` is used
  - `struct` module is not imported until `AbstractStructSerializer` is used
  - `base64`, `binascii`, `hashlib` and `hmac` modules are not imported until `Base64EncodedSerializer` is used
  - `bz2` module is not imported until `BZ2CompressorSerializer` is used
  - `zlib` module is not imported until `ZlibCompressorSerializer` is used