### PR TITLE
Fixed concurrency infinite loop

### DIFF
--- a/src/easynetwork/api_sync/client/tcp.py
+++ b/src/easynetwork/api_sync/client/tcp.py
@@ -121,7 +121,7 @@ class TCPNetworkClient(AbstractNetworkClient[_SentPacketT, _ReceivedPacketT], Ge
         ssl_handshake_timeout: float | None = None,
         ssl_shutdown_timeout: float | None = None,
         max_recv_size: int | None = None,
-        retry_interval: float = float("+inf"),
+        retry_interval: float = 1.0,
         **kwargs: Any,
     ) -> None:
         self.__socket: _socket.socket | None = None  # If any exception occurs, the client will already be in a closed state

--- a/src/easynetwork/api_sync/client/tcp.py
+++ b/src/easynetwork/api_sync/client/tcp.py
@@ -261,7 +261,8 @@ class TCPNetworkClient(AbstractNetworkClient[_SentPacketT, _ReceivedPacketT], Ge
             try:
                 if not self.__eof_reached and self.__is_ssl_socket(socket):
                     with self.__convert_ssl_eof_error(), _contextlib.suppress(TimeoutError):
-                        socket = _retry_ssl_socket_method(socket, self.__ssl_shutdown_timeout, None, socket.unwrap)
+                        retry_interval: float = self.__retry_interval
+                        socket = _retry_ssl_socket_method(socket, self.__ssl_shutdown_timeout, retry_interval, socket.unwrap)
             except ConnectionError:
                 # It is normal if there was connection errors during operations. But do not propagate this exception,
                 # as we will never reuse this socket

--- a/src/easynetwork/api_sync/client/udp.py
+++ b/src/easynetwork/api_sync/client/udp.py
@@ -80,7 +80,7 @@ class UDPNetworkEndpoint(Generic[_SentPacketT, _ReceivedPacketT]):
         self,
         /,
         protocol: DatagramProtocol[_SentPacketT, _ReceivedPacketT],
-        retry_interval: float = 1,
+        retry_interval: float = 1.0,
         **kwargs: Any,
     ) -> None:
         self.__socket: _socket.socket | None = None  # If any exception occurs, the client will already be in a closed state

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -132,6 +132,7 @@ def _retry_impl(
     callback: Callable[[], _R],
 ) -> _R:
     assert socket.gettimeout() == 0, "The socket must be non-blocking"
+    assert retry_interval is None or retry_interval > 0, "retry_interval must be a strictly positive float or None"
 
     monotonic = time.monotonic  # pull function to local namespace
     event: Literal["read", "write"]

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -180,7 +180,7 @@ def retry_socket_method(
     def callback() -> _R:
         try:
             return socket_method(*args, **kwargs)
-        except BlockingIOError:
+        except (BlockingIOError, TimeoutError, InterruptedError):
             raise _WouldBlock(event) from None
 
     return _retry_impl(socket, timeout, retry_interval, callback)

--- a/src/easynetwork_asyncio/threads.py
+++ b/src/easynetwork_asyncio/threads.py
@@ -93,10 +93,10 @@ class ThreadsPortal(AbstractThreadsPortal):
     def __get_result(future: concurrent.futures.Future[_T]) -> _T:
         try:
             return future.result()
-        except concurrent.futures.CancelledError as exc:
+        except concurrent.futures.CancelledError:
             if not future.cancelled():  # raised from future.exception()
                 raise
-            raise asyncio.CancelledError() from exc
+            raise asyncio.CancelledError() from None
         finally:
             del future
 

--- a/tests/functional_test/test_concurrency/test_sync/conftest.py
+++ b/tests/functional_test/test_concurrency/test_sync/conftest.py
@@ -15,9 +15,9 @@ def _build_client(ipproto: Literal["TCP", "UDP"], server_address: tuple[str, int
     serializer = StringLineSerializer()
     match ipproto:
         case "TCP":
-            return TCPNetworkClient(server_address, StreamProtocol(serializer))
+            return TCPNetworkClient(server_address, StreamProtocol(serializer), retry_interval=1.0)
         case "UDP":
-            return UDPNetworkClient(server_address, DatagramProtocol(serializer))
+            return UDPNetworkClient(server_address, DatagramProtocol(serializer), retry_interval=1.0)
         case _:
             pytest.fail("Invalid ipproto")
 

--- a/tests/functional_test/test_concurrency/test_sync/conftest.py
+++ b/tests/functional_test/test_concurrency/test_sync/conftest.py
@@ -13,6 +13,7 @@ import pytest
 
 def _build_client(ipproto: Literal["TCP", "UDP"], server_address: tuple[str, int]) -> AbstractNetworkClient[str, str]:
     serializer = StringLineSerializer()
+    # The retry interval is already at 1 second by default but we enfore it for the tests
     match ipproto:
         case "TCP":
             return TCPNetworkClient(server_address, StreamProtocol(serializer), retry_interval=1.0)

--- a/tests/functional_test/test_concurrency/test_sync/test_threaded_client.py
+++ b/tests/functional_test/test_concurrency/test_sync/test_threaded_client.py
@@ -23,16 +23,15 @@ def executor(client: ClientType) -> Iterator[ThreadPoolExecutor]:
 
 
 def test____recv_packet____in_a_background_thread(executor: ThreadPoolExecutor, client: ClientType) -> None:
-    recv_packet = executor.submit(client.recv_packet, timeout=None)
+    recv_packet = executor.submit(client.recv_packet, timeout=30)  # Ensure this thread does not stuck the executor shutdown
     while not recv_packet.running():
         time.sleep(0.1)
 
     client.send_packet("Hello world!")
-    assert recv_packet.result() == "Hello world!"
+    assert recv_packet.result(timeout=30) == "Hello world!"
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(raises=TimeoutError, reason="This test fails sometimes, do not know why")
 def test____recv_packet____close_while_waiting(executor: ThreadPoolExecutor, client: ClientType) -> None:
     recv_packet = executor.submit(client.recv_packet, timeout=3)
     while not recv_packet.running():

--- a/tests/unit_test/test_sync/test_client/test_tcp.py
+++ b/tests/unit_test/test_sync/test_client/test_tcp.py
@@ -837,6 +837,7 @@ class TestTCPNetworkClient(BaseTestClient):
         self,
         ssl_handshake_timeout: float | None,
         use_socket: bool,
+        retry_interval: float,
         would_block_exception: Exception,
         would_block_event: int,
         remote_address: tuple[str, int],
@@ -861,6 +862,7 @@ class TestTCPNetworkClient(BaseTestClient):
                     ssl=mock_ssl_context,
                     server_hostname=server_hostname,
                     ssl_handshake_timeout=ssl_handshake_timeout,
+                    retry_interval=retry_interval,
                 )
             else:
                 _ = TCPNetworkClient(
@@ -869,6 +871,7 @@ class TestTCPNetworkClient(BaseTestClient):
                     ssl=mock_ssl_context,
                     server_hostname=server_hostname,
                     ssl_handshake_timeout=ssl_handshake_timeout,
+                    retry_interval=retry_interval,
                 )
 
         # Assert


### PR DESCRIPTION
### What's changed
- Added `retry_interval` (in seconds) parameter to TCPNetworkClient (default to 1 second) ( c.f. #70 )
  - At object construction, in SSL context, the constructor now retries after (at most) the given seconds to call `socket.do_handshake()` until success
    - This does not impact the `ssl_handshake_timeout` parameter
    - If the socket have been closed between attempts, `ConnectionAbortedError` is raised
  - `send_packet()` now retries after (at most) the given seconds to call `socket.sendto()` until success
    - If the socket have been closed between attempts, `ConnectionAbortedError` is raised
  - `recv_packet()` now retries after (at most) the given seconds to call `socket.recvfrom()` until success
    - This does not impact the `timeout` parameter
    - If the socket have been closed between attempts, `ConnectionAbortedError` is raised
  - `close()`, in SSL context, now retries after (at most) the given seconds to call `socket.unwrap()` until success
    - This does not impact the `ssl_shutdown_timeout` parameter
    - If the socket have been closed between attempts, it is silently ignored
  - If `retry_interval==math.inf`, this feature is disabled
- Fixed tests which blocks indefinitely

### Miscellaneous
- `TCPNetworkClient`: Avoid `isinstance(sock, ssl.SSLSocket)` at each call of `send_packet()` or `recv_packet()`
- Fixed race condition in standalone servers implementation: `shutdown()` could raise `CancelledError`