### PR TITLE
Standalone servers improvements

### DIFF
--- a/src/easynetwork/api_async/server/__init__.py
+++ b/src/easynetwork/api_async/server/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "AsyncStreamRequestHandler",
     "AsyncTCPNetworkServer",
     "AsyncUDPNetworkServer",
+    "StandaloneNetworkServerThread",
     "StandaloneTCPNetworkServer",
     "StandaloneUDPNetworkServer",
 ]

--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -14,7 +14,7 @@ from collections import Counter, deque
 from typing import TYPE_CHECKING, Any, AsyncGenerator, AsyncIterator, Callable, Generic, Iterator, Mapping, TypeVar, final
 from weakref import WeakValueDictionary
 
-from ...exceptions import ClientClosedError, DatagramProtocolParseError
+from ...exceptions import ClientClosedError, DatagramProtocolParseError, ServerAlreadyRunning, ServerClosedError
 from ...protocol import DatagramProtocol
 from ...tools._utils import (
     check_real_socket_state as _check_real_socket_state,
@@ -141,7 +141,7 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
 
     async def serve_forever(self, *, is_up_event: IEvent | None = None) -> None:
         if not self.__is_shutdown.is_set():
-            raise RuntimeError("Server is already running")
+            raise ServerAlreadyRunning("Server is already running")
 
         async with _contextlib.AsyncExitStack() as server_exit_stack:
             # Wake up server
@@ -155,7 +155,7 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             # Bind and activate
             assert self.__socket is None
             if self.__socket_factory is None:
-                raise RuntimeError("Closed server")
+                raise ServerClosedError("Closed server")
             self.__socket = await self.__socket_factory.run()
             self.__socket_factory = None
             ###################

--- a/src/easynetwork/exceptions.py
+++ b/src/easynetwork/exceptions.py
@@ -13,6 +13,8 @@ __all__ = [
     "DeserializeError",
     "IncrementalDeserializeError",
     "PacketConversionError",
+    "ServerAlreadyRunning",
+    "ServerClosedError",
     "StreamProtocolParseError",
 ]
 
@@ -21,6 +23,14 @@ from typing import Any, Literal, TypeAlias
 
 class ClientClosedError(ConnectionError):
     """Error raised when trying to do an operation on a closed client"""
+
+
+class ServerClosedError(RuntimeError):
+    """Error raised when trying to do an operation on a closed server"""
+
+
+class ServerAlreadyRunning(RuntimeError):
+    """Error raised if serve_forever() is called twice"""
 
 
 class DeserializeError(Exception):

--- a/tests/functional_test/test_communication/test_async/test_server/base.py
+++ b/tests/functional_test/test_communication/test_async/test_server/base.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import AsyncIterator
 
 from easynetwork.api_async.server.abc import AbstractAsyncNetworkServer
+from easynetwork.exceptions import ServerAlreadyRunning, ServerClosedError
 
 import pytest
 import pytest_asyncio
@@ -16,19 +18,23 @@ class BaseTestAsyncServer:
     @pytest_asyncio.fixture  # DO NOT SET autouse=True
     @staticmethod
     async def run_server(server: AbstractAsyncNetworkServer) -> AsyncIterator[asyncio.Event]:
+        async def serve_forever(server: AbstractAsyncNetworkServer, event: asyncio.Event) -> None:
+            with contextlib.suppress(ServerClosedError):
+                await server.serve_forever(is_up_event=event)
+
         event = asyncio.Event()
         async with asyncio.TaskGroup() as tg:
-            _ = tg.create_task(server.serve_forever(is_up_event=event))
+            _ = tg.create_task(serve_forever(server, event))
             await asyncio.sleep(0)
             yield event
             await server.shutdown()
 
     @pytest.mark.usefixtures("run_server")
     async def test____serve_forever____error_already_running(self, server: AbstractAsyncNetworkServer) -> None:
-        with pytest.raises(RuntimeError, match=r"^Server is already running$"):
+        with pytest.raises(ServerAlreadyRunning):
             await server.serve_forever()
 
     async def test____serve_forever____error_closed_server(self, server: AbstractAsyncNetworkServer) -> None:
         await server.server_close()
-        with pytest.raises(RuntimeError, match=r"^Closed server"):
+        with pytest.raises(ServerClosedError):
             await server.serve_forever()

--- a/tests/functional_test/test_communication/test_async/test_server/test_standalone.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_standalone.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import threading
+import time
 from typing import AsyncGenerator, Callable, Iterator
 
 from easynetwork.api_async.server.handler import AsyncBaseRequestHandler, AsyncClientInterface
@@ -66,6 +68,19 @@ class BaseTestStandaloneNetworkServer:
     def test____serve_forever____error_server_already_running(self, server: AbstractStandaloneNetworkServer) -> None:
         with pytest.raises(ServerAlreadyRunning):
             server.serve_forever()
+
+    def test____serve_forever____without_is_up_event(self, server: AbstractStandaloneNetworkServer) -> None:
+        with server:
+            t = threading.Thread(target=server.serve_forever, daemon=True)
+            t.start()
+
+            time.sleep(1)
+            if not server.is_serving():
+                pytest.fail("Timeout error")
+
+            server.shutdown()
+            assert not server.is_serving()
+            t.join()
 
     def test____server_thread____several_join(
         self,


### PR DESCRIPTION
### What's changed
- For standalone server classes:
  - Added `timeout` parameter to `shutdown()`
  - Fixed `server_close()` race condition error when this method is called during `serve_forever()` teardown
- Added `StandaloneNetworkServerThread` class: A helper to start and manage a standalone server in a separate thread

### Miscellaneous
- Added `ServerAlreadyRunning` and `ServerClosedError` exceptions