### PR TITLE
`time.perf_counter()` is now used instead of `time.monotonic()`

### DIFF
--- a/src/easynetwork/api_async/server/standalone.py
+++ b/src/easynetwork/api_async/server/standalone.py
@@ -111,11 +111,11 @@ class _BaseStandaloneNetworkServerImpl(AbstractStandaloneNetworkServer):
                 if timeout is None:
                     portal.run_coroutine(self.__server.shutdown)
                 else:
-                    _start = time.monotonic()
+                    _start = time.perf_counter()
                     try:
                         portal.run_coroutine(self.__do_shutdown_with_timeout, timeout)
                     finally:
-                        timeout -= time.monotonic() - _start
+                        timeout -= time.perf_counter() - _start
         self.__is_shutdown.wait(timeout)
 
     async def __do_shutdown_with_timeout(self, timeout_delay: float) -> None:
@@ -307,12 +307,12 @@ class StandaloneNetworkServerThread(_threading.Thread, Generic[_ServerT]):
         return self.__server.serve_forever(is_up_event=self.__is_up_event)
 
     def join(self, timeout: float | None = None) -> None:
-        _start = time.monotonic()
+        _start = time.perf_counter()
         try:
             if self.is_alive():
                 self.__server.shutdown(timeout=timeout)
         finally:
-            _end = time.monotonic()
+            _end = time.perf_counter()
             if timeout is not None:
                 timeout -= _end - _start
             super().join(timeout=timeout)

--- a/src/easynetwork/api_sync/client/abc.py
+++ b/src/easynetwork/api_sync/client/abc.py
@@ -58,14 +58,14 @@ class AbstractNetworkClient(Generic[_SentPacketT, _ReceivedPacketT], metaclass=A
         raise NotImplementedError
 
     def iter_received_packets(self, timeout: float | None = 0) -> Iterator[_ReceivedPacketT]:
-        monotonic = time.monotonic
+        perf_counter = time.perf_counter
 
         recv_packet = self.recv_packet
         while True:
             try:
-                _start = monotonic()
+                _start = perf_counter()
                 packet = recv_packet(timeout)
-                _end = monotonic()
+                _end = perf_counter()
             except OSError:
                 return
             yield packet

--- a/src/easynetwork/api_sync/client/tcp.py
+++ b/src/easynetwork/api_sync/client/tcp.py
@@ -12,7 +12,7 @@ import contextlib as _contextlib
 import errno as _errno
 import socket as _socket
 import threading
-from time import perf_counter as _time_monotonic
+from time import perf_counter as _time_perf_counter
 from typing import TYPE_CHECKING, Any, Callable, Generic, Iterator, Literal, NoReturn, TypeGuard, TypeVar, cast, final, overload
 
 try:
@@ -311,7 +311,7 @@ class TCPNetworkClient(AbstractNetworkClient[_SentPacketT, _ReceivedPacketT], Ge
                 pass
             socket = self.__ensure_connected()
             bufsize: int = self.__max_recv_size
-            perf_counter = _time_monotonic  # pull function to local namespace
+            perf_counter = _time_perf_counter  # pull function to local namespace
             retry_interval: float = self.__retry_interval
             _is_ssl_socket = self.__is_ssl_socket
 

--- a/src/easynetwork/api_sync/client/tcp.py
+++ b/src/easynetwork/api_sync/client/tcp.py
@@ -12,7 +12,7 @@ import contextlib as _contextlib
 import errno as _errno
 import socket as _socket
 import threading
-from time import monotonic as _time_monotonic
+from time import perf_counter as _time_monotonic
 from typing import TYPE_CHECKING, Any, Callable, Generic, Iterator, Literal, NoReturn, TypeGuard, TypeVar, cast, final, overload
 
 try:
@@ -311,19 +311,19 @@ class TCPNetworkClient(AbstractNetworkClient[_SentPacketT, _ReceivedPacketT], Ge
                 pass
             socket = self.__ensure_connected()
             bufsize: int = self.__max_recv_size
-            monotonic = _time_monotonic  # pull function to local namespace
+            perf_counter = _time_monotonic  # pull function to local namespace
             retry_interval: float = self.__retry_interval
             _is_ssl_socket = self.__is_ssl_socket
 
             while True:
                 try:
-                    _start = monotonic()
+                    _start = perf_counter()
                     chunk: bytes
                     if _is_ssl_socket(socket):
                         chunk = _retry_ssl_socket_method(socket, timeout, retry_interval, socket.recv, bufsize)
                     else:
                         chunk = _retry_socket_method(socket, timeout, retry_interval, "read", socket.recv, bufsize)
-                    _end = monotonic()
+                    _end = perf_counter()
                 except TimeoutError as exc:
                     if timeout is None:  # pragma: no cover
                         raise RuntimeError("socket.recv() timed out with timeout=None ?") from exc

--- a/src/easynetwork/api_sync/client/udp.py
+++ b/src/easynetwork/api_sync/client/udp.py
@@ -220,15 +220,15 @@ class UDPNetworkEndpoint(Generic[_SentPacketT, _ReceivedPacketT]):
                 del data
 
     def iter_received_packets_from(self, timeout: float | None = 0) -> Iterator[tuple[_ReceivedPacketT, SocketAddress]]:
-        monotonic = time.monotonic
+        perf_counter = time.perf_counter
 
         recv_packet_from = self.recv_packet_from
 
         while True:
             try:
-                _start = monotonic()
+                _start = perf_counter()
                 packet_tuple = recv_packet_from(timeout=timeout)
-                _end = monotonic()
+                _end = perf_counter()
             except OSError:
                 return
             yield packet_tuple

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -134,7 +134,7 @@ def _retry_impl(
     assert socket.gettimeout() == 0, "The socket must be non-blocking"
     assert retry_interval is None or retry_interval > 0, "retry_interval must be a strictly positive float or None"
 
-    monotonic = time.monotonic  # pull function to local namespace
+    perf_counter = time.perf_counter  # pull function to local namespace
     event: Literal["read", "write"]
     if timeout == float("+inf"):
         timeout = None
@@ -155,11 +155,11 @@ def _retry_impl(
         else:
             is_retry_interval = True
             wait_time = retry_interval
-        _start = monotonic()
+        _start = perf_counter()
         if not wait_socket_available(socket, wait_time, event):
             if not is_retry_interval:
                 break
-        _end = monotonic()
+        _end = perf_counter()
         if timeout is not None:
             timeout -= _end - _start
     raise error_from_errno(_errno.ETIMEDOUT)

--- a/tests/functional_test/test_communication/test_sync/conftest.py
+++ b/tests/functional_test/test_communication/test_sync/conftest.py
@@ -14,16 +14,16 @@ def schedule_call_in_thread_with_future(
     request: pytest.FixtureRequest,
 ) -> Iterator[Callable[[float, Callable[[], Any]], Future[Any]]]:
     with ThreadPoolExecutor(thread_name_prefix=f"pytest-easynetwork_{request.node.name}") as executor:
-        monotonic = time.monotonic
+        perf_counter = time.perf_counter
 
         def task(time_to_sleep: float, callback: Callable[[], Any], submit_timestamp: float) -> None:
-            time_to_sleep -= monotonic() - submit_timestamp
+            time_to_sleep -= perf_counter() - submit_timestamp
             if time_to_sleep > 0:
                 time.sleep(time_to_sleep)
             callback()
 
         def schedule_call(time_to_sleep: float, callback: Callable[[], Any]) -> Future[Any]:
-            return executor.submit(task, time_to_sleep, callback, monotonic())
+            return executor.submit(task, time_to_sleep, callback, perf_counter())
 
         yield schedule_call
 

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -24,14 +24,14 @@ class TimeTest:
         self.expected_time: float = expected_time
         self.approx: float | None = approx
         self.start_time: float = -1
-        self._monotonic = time.perf_counter
+        self._perf_counter = time.perf_counter
 
     def __enter__(self) -> TimeTest:
         if self.start_time >= 0:
             raise TypeError("Not reentrant context manager")
-        self.start_time = self._monotonic()
+        self.start_time = self._perf_counter()
         return self
 
     def __exit__(self, *args: Any) -> None:
-        end_time = self._monotonic()
+        end_time = self._perf_counter()
         assert end_time - self.start_time == pytest.approx(self.expected_time, rel=self.approx)

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -24,7 +24,7 @@ class TimeTest:
         self.expected_time: float = expected_time
         self.approx: float | None = approx
         self.start_time: float = -1
-        self._monotonic = time.monotonic
+        self._monotonic = time.perf_counter
 
     def __enter__(self) -> TimeTest:
         if self.start_time >= 0:

--- a/tests/unit_test/test_sync/test_client/test_abc.py
+++ b/tests/unit_test/test_sync/test_client/test_abc.py
@@ -62,7 +62,7 @@ class TestAbstractNetworkClient:
     ) -> None:
         # Arrange
         now: float = 798546132
-        mocker.patch("time.monotonic", return_value=now)
+        mocker.patch("time.perf_counter", return_value=now)
         received_packets_queue = deque([mocker.sentinel.packet_a, mocker.sentinel.packet_b, mocker.sentinel.packet_c])
 
         def side_effect(timeout: Any) -> Any:
@@ -91,7 +91,7 @@ class TestAbstractNetworkClient:
     ) -> None:
         # Arrange
         now: float = 798546132
-        mocker.patch("time.monotonic", return_value=now)
+        mocker.patch("time.perf_counter", return_value=now)
         client = MockClient(mocker)
         client.mock_recv_packet.side_effect = [mocker.sentinel.packet_a, error]
 


### PR DESCRIPTION
### What's changed
Delta time computations now use [`time.perf_counter()`](https://docs.python.org/3/library/time.html#time.perf_counter)

According to my tests, and several articles (the most valuable is [this one](https://www.webucator.com/article/python-clocks-explained/)), `time.perf_counter()` gives a more precise result and is less CPU-intensive
