### PR TITLE
Serializers: Global performance improvements

### DIFF
--- a/src/easynetwork/serializers/base_stream.py
+++ b/src/easynetwork/serializers/base_stream.py
@@ -194,10 +194,7 @@ class FileBasedPacketSerializer(AbstractPacketSerializer[_ST_contra, _DT_co]):
     def incremental_deserialize(self) -> Generator[None, bytes, tuple[_DT_co, bytes]]:
         with BytesIO() as buffer:
             while True:
-                while not (chunk := (yield)):
-                    continue
-                buffer.write(chunk)
-                del chunk
+                buffer.write((yield))
                 buffer.seek(0)
                 try:
                     packet: _DT_co = self.load_from_file(buffer)

--- a/src/easynetwork/serializers/json.py
+++ b/src/easynetwork/serializers/json.py
@@ -12,6 +12,7 @@ __all__ = [
     "JSONSerializer",
 ]
 
+import re
 import string
 from collections import Counter
 from dataclasses import asdict as dataclass_asdict, dataclass
@@ -27,6 +28,8 @@ _DT_co = TypeVar("_DT_co", covariant=True)
 
 _JSON_VALUE_BYTES: frozenset[int] = frozenset(bytes(string.digits + string.ascii_letters + string.punctuation, "ascii"))
 _ESCAPE_BYTE: int = b"\\"[0]
+
+_whitespaces_match: Callable[[bytes, int], re.Match[bytes]] = re.compile(rb"[ \t\n\r]*", re.MULTILINE | re.DOTALL).match  # type: ignore[assignment]
 
 
 @dataclass(kw_only=True)
@@ -51,10 +54,13 @@ class JSONDecoderConfig:
 
 
 class _JSONParser:
+    class _PlainValueError(Exception):
+        pass
+
     @staticmethod
-    def _escaped(partial_document: bytes) -> bool:
+    def _escaped(partial_document_view: memoryview) -> bool:
         escaped = False
-        for byte in reversed(partial_document):
+        for byte in reversed(partial_document_view):
             if byte == _ESCAPE_BYTE:
                 escaped = not escaped
             else:
@@ -64,57 +70,66 @@ class _JSONParser:
     @staticmethod
     def raw_parse() -> Generator[None, bytes, tuple[bytes, bytes]]:
         escaped = _JSONParser._escaped
+        split_partial_document = _JSONParser._split_partial_document
         enclosure_counter: Counter[bytes] = Counter()
-        partial_document: bytearray = bytearray()
+        partial_document: bytes = yield
         first_enclosure: bytes = b""
-        while True:
-            while not (chunk := (yield)):  # Skip empty bytes
-                continue
-            char: bytes
-            for nb_chars, char in enumerate(iter_bytes(chunk), start=1):
-                match char:
-                    case b'"' if not escaped(partial_document):
-                        enclosure_counter[b'"'] = 0 if enclosure_counter[b'"'] == 1 else 1
-                    case _ if enclosure_counter[b'"'] > 0:
-                        partial_document.extend(char)
-                        continue
-                    case b"{" | b"[":
-                        enclosure_counter[char] += 1
-                    case b"}":
-                        enclosure_counter[b"{"] -= 1
-                    case b"]":
-                        enclosure_counter[b"["] -= 1
-                    case b" " | b"\t" | b"\n" | b"\r":  # Optimization: Skip spaces
-                        continue
-                    case _ if len(enclosure_counter) == 0:  # No enclosure, only value
-                        assert len(partial_document) == 0, f"{partial_document=!r}"
-                        partial_document.extend(chunk[nb_chars - 1 :] if nb_chars > 1 else chunk)
-                        del chunk
-                        return (yield from _JSONParser._raw_parse_plain_value(partial_document))
-                    case _:  # JSON syntax character, quickly go to next character
-                        partial_document.extend(char)
-                        continue
-                assert len(enclosure_counter) > 0
-                partial_document.extend(char)
-                if not first_enclosure:
-                    first_enclosure = next(iter(enclosure_counter))
-                if enclosure_counter[first_enclosure] <= 0:  # 1st found is closed
-                    return bytes(partial_document), chunk[nb_chars:]
+        start: int = 0
+        try:
+            while True:
+                with memoryview(partial_document) as partial_document_view:
+                    for nb_chars, char in enumerate(iter_bytes(partial_document_view[start:]), start=start + 1):
+                        match char:
+                            case b'"' if not escaped(partial_document_view[: nb_chars - 1]):
+                                enclosure_counter[b'"'] = 0 if enclosure_counter[b'"'] == 1 else 1
+                            case _ if enclosure_counter[b'"'] > 0:  # We are within a JSON string, move on.
+                                continue
+                            case b"{" | b"[":
+                                enclosure_counter[char] += 1
+                            case b"}":
+                                enclosure_counter[b"{"] -= 1
+                            case b"]":
+                                enclosure_counter[b"["] -= 1
+                            case b" " | b"\t" | b"\n" | b"\r":  # Optimization: Skip spaces
+                                continue
+                            case _ if len(enclosure_counter) == 0:  # No enclosure, only value
+                                partial_document = partial_document[nb_chars - 1 :] if nb_chars > 1 else partial_document
+                                del char, nb_chars
+                                raise _JSONParser._PlainValueError
+                            case _:  # JSON character, quickly go to next character
+                                continue
+                        assert len(enclosure_counter) > 0
+                        if not first_enclosure:
+                            first_enclosure = next(iter(enclosure_counter))
+                        if enclosure_counter[first_enclosure] <= 0:  # 1st found is closed
+                            return split_partial_document(partial_document, nb_chars)
 
-            # Delete chunk before restart (yield)
-            del chunk
+                    # partial_document not complete
+                    start = partial_document_view.nbytes
+
+                # yield out of view scope
+                partial_document += yield
+
+        except _JSONParser._PlainValueError:
+            pass
+
+        # The document is a plain value (null, true, false, or a number)
+
+        del enclosure_counter, first_enclosure
+
+        while (nprint_idx := next((idx for idx, byte in enumerate(partial_document) if byte not in _JSON_VALUE_BYTES), -1)) < 0:
+            partial_document += yield
+
+        return split_partial_document(partial_document, nprint_idx)
 
     @staticmethod
-    def _raw_parse_plain_value(plain_value: bytearray) -> Generator[None, bytes, tuple[bytes, bytes]]:
-        chunk: bytes
-        while (non_printable_idx := next((idx for idx, byte in enumerate(plain_value) if byte not in _JSON_VALUE_BYTES), -1)) < 0:
-            while not (chunk := (yield)):
-                continue
-            plain_value.extend(chunk)
-            del chunk
-        remaining = bytes(plain_value[non_printable_idx:])
-        del plain_value[non_printable_idx:]
-        return bytes(plain_value), remaining
+    def _split_partial_document(partial_document: bytes, index: int) -> tuple[bytes, bytes]:
+        index = _whitespaces_match(partial_document, index).end()
+        if index == len(partial_document):
+            # The following bytes are only spaces
+            # Do not slice the document, the trailing spaces will be ignored by JSONDecoder
+            return partial_document, b""
+        return partial_document[:index], partial_document[index:]
 
 
 class JSONSerializer(AbstractIncrementalPacketSerializer[_ST_contra, _DT_co]):
@@ -169,6 +184,8 @@ class JSONSerializer(AbstractIncrementalPacketSerializer[_ST_contra, _DT_co]):
             document: str = data.decode(self.__encoding, self.__unicode_errors)
         except UnicodeError as exc:
             raise DeserializeError(f"Unicode decode error: {exc}", error_info={"data": data}) from exc
+        finally:
+            del data
         try:
             packet: _DT_co = self.__decoder.decode(document)
         except self.__decoder_error_cls as exc:
@@ -188,6 +205,7 @@ class JSONSerializer(AbstractIncrementalPacketSerializer[_ST_contra, _DT_co]):
         complete_document, remaining_data = yield from _JSONParser.raw_parse()
 
         if not complete_document:
+            # If this condition is verified, decoder.decode() will most likely raise JSONDecodeError
             complete_document = remaining_data
             remaining_data = b""
 
@@ -200,8 +218,10 @@ class JSONSerializer(AbstractIncrementalPacketSerializer[_ST_contra, _DT_co]):
                 remaining_data=remaining_data,
                 error_info={"data": complete_document},
             ) from exc
+        finally:
+            del complete_document
         try:
-            packet, end = self.__decoder.raw_decode(document)
+            packet = self.__decoder.decode(document)
         except self.__decoder_error_cls as exc:
             raise IncrementalDeserializeError(
                 f"JSON decode error: {exc}",
@@ -213,8 +233,4 @@ class JSONSerializer(AbstractIncrementalPacketSerializer[_ST_contra, _DT_co]):
                     "colno": exc.colno,
                 },
             ) from exc
-        try:
-            remaining_data = document[end:].encode(self.__encoding, self.__unicode_errors) + remaining_data
-        except UnicodeError:  # pragma: no cover  # Should not happen but it must not pass
-            pass
-        return packet, remaining_data.lstrip(b" \t\n\r")  # Optimization: Skip leading spaces
+        return packet, remaining_data

--- a/src/easynetwork/serializers/wrapper/base64.py
+++ b/src/easynetwork/serializers/wrapper/base64.py
@@ -11,7 +11,7 @@ __all__ = [
 ]
 
 import os
-from typing import Callable, TypeVar, assert_never, final
+from typing import Callable, Literal, TypeVar, assert_never, final
 
 from ...exceptions import DeserializeError
 from ..abc import AbstractPacketSerializer
@@ -28,6 +28,7 @@ class Base64EncodedSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co])
         self,
         serializer: AbstractPacketSerializer[_ST_contra, _DT_co],
         *,
+        alphabet: Literal["standard", "urlsafe"] = "urlsafe",
         checksum: bool | str | bytes = False,
         separator: bytes = b"\r\n",
     ) -> None:
@@ -56,8 +57,16 @@ class Base64EncodedSerializer(AutoSeparatedPacketSerializer[_ST_contra, _DT_co])
             case _:  # pragma: no cover
                 assert_never(checksum)
 
-        self.__encode = base64.urlsafe_b64encode
-        self.__decode = base64.urlsafe_b64decode
+        match alphabet:
+            case "standard":
+                self.__encode = base64.standard_b64encode
+                self.__decode = base64.standard_b64decode
+            case "urlsafe":
+                self.__encode = base64.urlsafe_b64encode
+                self.__decode = base64.urlsafe_b64decode
+            case _:  # pragma: no cover
+                assert_never(alphabet)
+
         self.__decode_error_cls = binascii.Error
         self.__compare_digest = compare_digest
 

--- a/src/easynetwork/serializers/wrapper/compressor.py
+++ b/src/easynetwork/serializers/wrapper/compressor.py
@@ -109,8 +109,7 @@ class AbstractCompressorSerializer(AbstractIncrementalPacketSerializer[_ST_contr
         results: deque[bytes] = deque()
         decompressor: DecompressorInterface = self.new_decompressor_stream()
         while not decompressor.eof:
-            while not (chunk := (yield)):
-                continue
+            chunk: bytes = yield
             try:
                 chunk = decompressor.decompress(chunk)
             except self.__expected_error as exc:

--- a/src/easynetwork/serializers/wrapper/compressor.py
+++ b/src/easynetwork/serializers/wrapper/compressor.py
@@ -96,10 +96,10 @@ class AbstractCompressorSerializer(AbstractIncrementalPacketSerializer[_ST_contr
                 "Compressed data ended before the end-of-stream marker was reached",
                 error_info={"already_decompressed_data": data},
             )
-        if unused_data := decompressor.unused_data:
+        if decompressor.unused_data:
             raise DeserializeError(
                 "Trailing data error",
-                error_info={"decompressed_data": data, "extra": unused_data},
+                error_info={"decompressed_data": data, "extra": decompressor.unused_data},
             )
         del decompressor
         return self.__serializer.deserialize(data)
@@ -107,7 +107,7 @@ class AbstractCompressorSerializer(AbstractIncrementalPacketSerializer[_ST_contr
     @final
     def incremental_deserialize(self) -> Generator[None, bytes, tuple[_DT_co, bytes]]:
         results: deque[bytes] = deque()
-        decompressor = self.new_decompressor_stream()
+        decompressor: DecompressorInterface = self.new_decompressor_stream()
         while not decompressor.eof:
             while not (chunk := (yield)):
                 continue

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -29,8 +29,7 @@ import selectors as _selectors
 import socket as _socket
 import time
 import traceback
-from struct import unpack
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, ParamSpec, TypeGuard, TypeVar, assert_never
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Literal, ParamSpec, TypeGuard, TypeVar, assert_never
 
 try:
     import ssl as _ssl
@@ -230,8 +229,8 @@ def concatenate_chunks(chunks_iterable: Iterable[bytes]) -> bytes:
     return b"".join(chunks_iterable)
 
 
-def iter_bytes(b: bytes | bytearray) -> Iterable[bytes]:
-    return unpack(f"{len(b)}c", b)
+def iter_bytes(b: bytes | bytearray | memoryview) -> Iterator[bytes]:
+    return map(int.to_bytes, b)
 
 
 def ensure_datagram_socket_bound(sock: _socket.socket) -> None:

--- a/src/easynetwork/tools/stream.py
+++ b/src/easynetwork/tools/stream.py
@@ -64,7 +64,7 @@ class StreamDataProducer(Generic[_SentPacketT]):
             except StopIteration:
                 pass
             else:
-                assert isinstance(chunk, (bytes, bytearray))
+                assert type(chunk) is bytes, repr(chunk)
                 self.__g = generator
                 return chunk
             finally:
@@ -132,18 +132,21 @@ class StreamDataConsumer(Generic[_ReceivedPacketT]):
         except StopIteration as exc:
             packet, remaining = exc.value
         except StreamProtocolParseError as exc:
-            self.__b, exc.remaining_data = bytes(exc.remaining_data), b""
+            remaining, exc.remaining_data = exc.remaining_data, b""
+            assert type(remaining) is bytes, repr(remaining)
+            self.__b = remaining
             raise
         else:
             self.__c = consumer
             raise StopIteration
         finally:
             del consumer, chunk
-        self.__b = bytes(remaining)
+        assert type(remaining) is bytes, repr(remaining)
+        self.__b = remaining
         return packet
 
     def feed(self, chunk: bytes) -> None:
-        assert isinstance(chunk, (bytes, bytearray))
+        assert type(chunk) is bytes, repr(chunk)
         if not chunk:
             return
         self.__b += chunk

--- a/src/easynetwork/tools/stream.py
+++ b/src/easynetwork/tools/stream.py
@@ -151,8 +151,8 @@ class StreamDataConsumer(Generic[_ReceivedPacketT]):
             return
         self.__b += chunk
 
-    def get_buffer(self) -> bytes:
-        return self.__b
+    def get_buffer(self) -> memoryview:
+        return memoryview(self.__b)
 
     def clear(self) -> None:
         self.__b = b""

--- a/tests/functional_test/test_communication/serializer.py
+++ b/tests/functional_test/test_communication/serializer.py
@@ -38,9 +38,9 @@ class StringSerializer(AbstractIncrementalPacketSerializer[str, str]):
             raise DeserializeError(str(exc)) from exc
 
     def incremental_deserialize(self) -> Generator[None, bytes, tuple[str, bytes]]:
-        buffer: bytearray = bytearray()
+        buffer = b""
         while True:
-            buffer.extend((yield))
+            buffer += yield
             if b"\n" not in buffer:
                 continue
             data, buffer = buffer.split(b"\n", 1)

--- a/tests/functional_test/test_serializers/base.py
+++ b/tests/functional_test/test_serializers/base.py
@@ -65,7 +65,7 @@ class BaseTestSerializer(metaclass=ABCMeta):
         data = serializer_for_serialization.serialize(packet_to_serialize)
 
         # Assert
-        assert isinstance(data, (bytes, bytearray))
+        assert isinstance(data, bytes)
         if callable(expected_complete_data):
             expected_complete_data(data)
         else:
@@ -158,7 +158,7 @@ class BaseTestIncrementalSerializer(BaseTestSerializer):
         packet, remaining_data = send_return(consumer, complete_data_for_incremental_deserialize)
 
         # Assert
-        assert isinstance(remaining_data, (bytes, bytearray))
+        assert isinstance(remaining_data, bytes)
         assert remaining_data == b""
         assert type(packet) is type(packet_to_serialize)
         assert packet == packet_to_serialize
@@ -179,7 +179,7 @@ class BaseTestIncrementalSerializer(BaseTestSerializer):
         packet, remaining_data = send_return(consumer, complete_data_for_incremental_deserialize + incremental_extra_data)
 
         # Assert
-        assert isinstance(remaining_data, (bytes, bytearray))
+        assert isinstance(remaining_data, bytes)
         assert remaining_data == incremental_extra_data
         assert type(packet) is type(packet_to_serialize)
         assert packet == packet_to_serialize
@@ -213,7 +213,7 @@ class BaseTestIncrementalSerializer(BaseTestSerializer):
         packet, remaining_data = exc_info.value.value
 
         # Assert
-        assert isinstance(remaining_data, (bytes, bytearray))
+        assert isinstance(remaining_data, bytes)
         assert remaining_data == b""
         assert type(packet) is type(packet_to_serialize)
         assert packet == packet_to_serialize

--- a/tests/functional_test/test_serializers/base.py
+++ b/tests/functional_test/test_serializers/base.py
@@ -184,11 +184,9 @@ class BaseTestIncrementalSerializer(BaseTestSerializer):
         assert type(packet) is type(packet_to_serialize)
         assert packet == packet_to_serialize
 
-    @pytest.mark.parametrize("empty_bytes_before", [False, True], ids=lambda boolean: f"empty_bytes_before=={boolean}")
     def test____incremental_deserialize____give_chunk_byte_per_byte(
         self,
         serializer_for_deserialization: AbstractIncrementalPacketSerializer[Any, Any],
-        empty_bytes_before: bool,
         complete_data_for_incremental_deserialize: bytes,
         packet_to_serialize: Any,
     ) -> None:
@@ -203,11 +201,6 @@ class BaseTestIncrementalSerializer(BaseTestSerializer):
             # However, the remaining data returned should be empty
             for chunk in iter_bytes(complete_data_for_incremental_deserialize):
                 assert len(chunk) == 1
-                if empty_bytes_before:
-                    try:
-                        consumer.send(b"")
-                    except StopIteration:
-                        raise RuntimeError("consumer stopped when sending empty bytes")
                 consumer.send(chunk)
 
         packet, remaining_data = exc_info.value.value

--- a/tests/functional_test/test_serializers/samples/json.py
+++ b/tests/functional_test/test_serializers/samples/json.py
@@ -18,6 +18,7 @@ SAMPLES: list[tuple[Any, str]] = [
     ("", "empty string"),
     ("non-empty", "non-empty string"),
     ("non-empty with é", "non-empty with unicode"),
+    ("\\", "escape character"),
     ([], "empty list"),
     ({}, "empty dict"),
     ([1, 2, 3], "non-empty list"),

--- a/tests/functional_test/test_serializers/test_pickle.py
+++ b/tests/functional_test/test_serializers/test_pickle.py
@@ -48,7 +48,7 @@ class TestPickleSerializer(BaseTestSerializer):
     @pytest.fixture(scope="class")
     @staticmethod
     def serializer_for_serialization(pickler_config: PicklerConfig, pickler_optimize: bool) -> PickleSerializer[Any, Any]:
-        return PickleSerializer(pickler_config=pickler_config, optimize=pickler_optimize)
+        return PickleSerializer(pickler_config=pickler_config, pickler_optimize=pickler_optimize)
 
     @pytest.fixture(scope="class")
     @staticmethod

--- a/tests/unit_test/test_serializers/test_compressor.py
+++ b/tests/unit_test/test_serializers/test_compressor.py
@@ -238,7 +238,7 @@ class TestAbstractCompressorSerializer:
         mock_serializer_new_decompressor_stream.assert_called_once_with()
         mock_decompressor_stream.decompress.assert_called_once_with(mocker.sentinel.data)
         mock_decompressor_stream_eof.assert_called_once()
-        mock_decompressor_stream_unused_data.assert_called_once()
+        assert mock_decompressor_stream_unused_data.call_count == 2
         mock_serializer.deserialize.assert_not_called()
         assert exception.error_info == {"decompressed_data": mocker.sentinel.decompressed_data, "extra": b"some extra data"}
 

--- a/tests/unit_test/test_serializers/test_pickle.py
+++ b/tests/unit_test/test_serializers/test_pickle.py
@@ -125,7 +125,10 @@ class TestPickleSerializer(BaseSerializerConfigInstanceCheck):
     ) -> None:
         # Arrange
         mock_pickletools_optimize.return_value = b"optimized pickle"
-        serializer: PickleSerializer[Any, Any] = PickleSerializer(pickler_config=pickler_config, optimize=pickler_optimize)
+        serializer: PickleSerializer[Any, Any] = PickleSerializer(
+            pickler_config=pickler_config,
+            pickler_optimize=pickler_optimize,
+        )
 
         # Act
         data: bytes = serializer.serialize(mocker.sentinel.packet)
@@ -158,7 +161,10 @@ class TestPickleSerializer(BaseSerializerConfigInstanceCheck):
         # Arrange
         mock_other_pickler_cls: MagicMock = mocker.stub()
         mock_other_pickler: MagicMock = mock_other_pickler_cls.return_value
-        serializer: PickleSerializer[Any, Any] = PickleSerializer(pickler_cls=mock_other_pickler_cls, optimize=pickler_optimize)
+        serializer: PickleSerializer[Any, Any] = PickleSerializer(
+            pickler_cls=mock_other_pickler_cls,
+            pickler_optimize=pickler_optimize,
+        )
         del mock_pickler.dump
 
         # Act


### PR DESCRIPTION
## What's changed
### BREAKING CHANGES
- Serializers returning `bytearray` instances is no longer supported. A serializer must return/yield `bytes` instances only.

### Memory consumption improvement
Previously, `bytearray` was used for buffers in order to handle incoming data. This method caused a mandatory duplication of all data received, and multiplied memory consumption by 2 (or even 3).

Now, `incremental_deserialize()` generators adopt the "zero copy" method: If the bytes returned by the first `yield` meet expectations, this instance will directly be used for de-serialization without previous copy.

This modification affects the following classes:
- `JSONSerializer`
- `base_stream` classes (and subsequently all their subclasses):
  - `AutoSeparatedPacketSerializer`
  - `FixedSizePacketSerializer`

Alongside this, other small improvements have been made to certain serializers.

### API update
- `PickleSerializer`: `optimize` parameter renamed to `pickler_optimize`
- `Base64EncodedSerializer`: Added `alphabet` parameter (defaulting to `urlsafe`)
  - Set it to `standard` to use `standard_b64encode` and `standard_b64decode` functions