### PR TITLE
Removed deprecated imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,11 @@ ci:
   skip: [mypy]
 
 repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.9.0
+    hooks:
+      - id: pyupgrade
+        args: ['--py311-plus']
   - repo: local
     hooks:
       - id: mypy

--- a/src/easynetwork/__init__.py
+++ b/src/easynetwork/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/__init__.py
+++ b/src/easynetwork/api_async/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/backend/__init__.py
+++ b/src/easynetwork/api_async/backend/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/backend/abc.py
+++ b/src/easynetwork/api_async/backend/abc.py
@@ -24,20 +24,8 @@ __all__ = [
 ]
 
 from abc import ABCMeta, abstractmethod
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    AsyncContextManager,
-    Callable,
-    Coroutine,
-    Generic,
-    NoReturn,
-    ParamSpec,
-    Protocol,
-    Self,
-    Sequence,
-    TypeVar,
-)
+from collections.abc import Callable, Coroutine, Sequence
+from typing import TYPE_CHECKING, Any, AsyncContextManager, Generic, NoReturn, ParamSpec, Protocol, Self, TypeVar
 
 if TYPE_CHECKING:
     import concurrent.futures

--- a/src/easynetwork/api_async/backend/abc.py
+++ b/src/easynetwork/api_async/backend/abc.py
@@ -25,7 +25,8 @@ __all__ = [
 
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable, Coroutine, Sequence
-from typing import TYPE_CHECKING, Any, AsyncContextManager, Generic, NoReturn, ParamSpec, Protocol, Self, TypeVar
+from contextlib import AbstractAsyncContextManager as AsyncContextManager
+from typing import TYPE_CHECKING, Any, Generic, NoReturn, ParamSpec, Protocol, Self, TypeVar
 
 if TYPE_CHECKING:
     import concurrent.futures

--- a/src/easynetwork/api_async/backend/abc.py
+++ b/src/easynetwork/api_async/backend/abc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/backend/factory.py
+++ b/src/easynetwork/api_async/backend/factory.py
@@ -12,8 +12,9 @@ __all__ = ["AsyncBackendFactory"]
 import functools
 import inspect
 from collections import Counter
+from collections.abc import Mapping
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Final, Mapping, final
+from typing import TYPE_CHECKING, Any, Final, final
 
 from .abc import AbstractAsyncBackend
 from .sniffio import current_async_library as _sniffio_current_async_library
@@ -146,7 +147,7 @@ class AsyncBackendFactory:
         entry_points = get_all_entry_points(group=AsyncBackendFactory.GROUP_NAME)
         duplicate_counter: Counter[str] = Counter([ep.name for ep in entry_points])
 
-        if duplicates := set(name for name in duplicate_counter if duplicate_counter[name] > 1):
+        if duplicates := {name for name in duplicate_counter if duplicate_counter[name] > 1}:
             raise TypeError(f"Conflicting backend name caught: {', '.join(map(repr, sorted(duplicates)))}")
 
         backends: dict[str, EntryPoint] = {ep.name: ep for ep in entry_points}

--- a/src/easynetwork/api_async/backend/factory.py
+++ b/src/easynetwork/api_async/backend/factory.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/backend/futures.py
+++ b/src/easynetwork/api_async/backend/futures.py
@@ -11,7 +11,8 @@ __all__ = ["AsyncExecutor", "AsyncThreadPoolExecutor"]
 
 import concurrent.futures
 import contextvars
-from typing import TYPE_CHECKING, Any, Callable, ParamSpec, Self, TypeVar, overload
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, ParamSpec, Self, TypeVar, overload
 
 from .sniffio import current_async_library_cvar as _sniffio_current_async_library_cvar
 

--- a/src/easynetwork/api_async/backend/futures.py
+++ b/src/easynetwork/api_async/backend/futures.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/backend/sniffio.py
+++ b/src/easynetwork/api_async/backend/sniffio.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/backend/tasks.py
+++ b/src/easynetwork/api_async/backend/tasks.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 __all__ = ["SingleTaskRunner"]
 
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Generic, ParamSpec, TypeVar
+from collections.abc import Callable, Coroutine
+from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar
 
 if TYPE_CHECKING:
     from .abc import AbstractAsyncBackend, AbstractTask

--- a/src/easynetwork/api_async/backend/tasks.py
+++ b/src/easynetwork/api_async/backend/tasks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/client/__init__.py
+++ b/src/easynetwork/api_async/client/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/client/abc.py
+++ b/src/easynetwork/api_async/client/abc.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 __all__ = ["AbstractAsyncNetworkClient"]
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, AsyncIterator, Generic, Self, TypeVar
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar
 
 from ...tools.socket import SocketAddress
 

--- a/src/easynetwork/api_async/client/abc.py
+++ b/src/easynetwork/api_async/client/abc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/client/tcp.py
+++ b/src/easynetwork/api_async/client/tcp.py
@@ -10,21 +10,8 @@ __all__ = ["AsyncTCPNetworkClient"]
 import contextlib as _contextlib
 import errno as _errno
 import socket as _socket
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Generic,
-    Iterator,
-    Literal,
-    Mapping,
-    NoReturn,
-    TypedDict,
-    TypeVar,
-    cast,
-    final,
-    overload,
-)
+from collections.abc import Callable, Iterator, Mapping
+from typing import TYPE_CHECKING, Any, Generic, Literal, NoReturn, TypedDict, TypeVar, cast, final, overload
 
 try:
     import ssl as _ssl

--- a/src/easynetwork/api_async/client/tcp.py
+++ b/src/easynetwork/api_async/client/tcp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/client/udp.py
+++ b/src/easynetwork/api_async/client/udp.py
@@ -9,7 +9,8 @@ __all__ = ["AsyncUDPNetworkClient", "AsyncUDPNetworkEndpoint"]
 
 import errno as _errno
 import socket as _socket
-from typing import TYPE_CHECKING, Any, AsyncIterator, Generic, Mapping, Self, TypedDict, TypeVar, final, overload
+from collections.abc import AsyncIterator, Mapping
+from typing import TYPE_CHECKING, Any, Generic, Self, TypedDict, TypeVar, final, overload
 
 from ...exceptions import ClientClosedError, DatagramProtocolParseError
 from ...protocol import DatagramProtocol

--- a/src/easynetwork/api_async/client/udp.py
+++ b/src/easynetwork/api_async/client/udp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/server/__init__.py
+++ b/src/easynetwork/api_async/server/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/server/abc.py
+++ b/src/easynetwork/api_async/server/abc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/server/handler.py
+++ b/src/easynetwork/api_async/server/handler.py
@@ -12,7 +12,8 @@ __all__ = [
 ]
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Coroutine, Generic, TypeVar, final
+from collections.abc import AsyncGenerator, Callable, Coroutine
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, final
 
 if TYPE_CHECKING:
     from ...exceptions import BaseProtocolParseError

--- a/src/easynetwork/api_async/server/handler.py
+++ b/src/easynetwork/api_async/server/handler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/server/standalone.py
+++ b/src/easynetwork/api_async/server/standalone.py
@@ -16,7 +16,8 @@ import contextlib as _contextlib
 import threading as _threading
 import time
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Generic, Mapping, Self, Sequence, TypeVar
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar
 
 from ...exceptions import ServerAlreadyRunning
 from ...tools.socket import SocketAddress, SocketProxy

--- a/src/easynetwork/api_async/server/standalone.py
+++ b/src/easynetwork/api_async/server/standalone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/server/tcp.py
+++ b/src/easynetwork/api_async/server/tcp.py
@@ -14,19 +14,8 @@ import logging as _logging
 import os
 import weakref
 from collections import deque
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    AsyncGenerator,
-    AsyncIterator,
-    Callable,
-    Generic,
-    Iterator,
-    Mapping,
-    Sequence,
-    TypeVar,
-    final,
-)
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, final
 
 from ...exceptions import ClientClosedError, ServerAlreadyRunning, ServerClosedError, StreamProtocolParseError
 from ...protocol import StreamProtocol

--- a/src/easynetwork/api_async/server/tcp.py
+++ b/src/easynetwork/api_async/server/tcp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -10,7 +10,8 @@ __all__ = ["AsyncUDPNetworkServer"]
 import contextlib as _contextlib
 import logging as _logging
 from collections import Counter, deque
-from typing import TYPE_CHECKING, Any, AsyncGenerator, AsyncIterator, Callable, Generic, Iterator, Mapping, TypeVar, final
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterator, Mapping
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, final
 from weakref import WeakValueDictionary
 
 from ...exceptions import ClientClosedError, DatagramProtocolParseError, ServerAlreadyRunning, ServerClosedError

--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_sync/__init__.py
+++ b/src/easynetwork/api_sync/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_sync/client/__init__.py
+++ b/src/easynetwork/api_sync/client/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_sync/client/abc.py
+++ b/src/easynetwork/api_sync/client/abc.py
@@ -9,7 +9,8 @@ __all__ = ["AbstractNetworkClient"]
 
 import time
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Generic, Iterator, Self, TypeVar
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar
 
 from ...tools.socket import SocketAddress
 

--- a/src/easynetwork/api_sync/client/abc.py
+++ b/src/easynetwork/api_sync/client/abc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_sync/client/tcp.py
+++ b/src/easynetwork/api_sync/client/tcp.py
@@ -11,8 +11,9 @@ import contextlib as _contextlib
 import errno as _errno
 import socket as _socket
 import threading
+from collections.abc import Callable, Iterator
 from time import perf_counter as _time_perf_counter
-from typing import TYPE_CHECKING, Any, Callable, Generic, Iterator, Literal, NoReturn, TypeGuard, TypeVar, cast, final, overload
+from typing import TYPE_CHECKING, Any, Generic, Literal, NoReturn, TypeGuard, TypeVar, cast, final, overload
 
 try:
     import ssl

--- a/src/easynetwork/api_sync/client/tcp.py
+++ b/src/easynetwork/api_sync/client/tcp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/api_sync/client/udp.py
+++ b/src/easynetwork/api_sync/client/udp.py
@@ -12,8 +12,9 @@ import errno as _errno
 import socket as _socket
 import threading
 import time
+from collections.abc import Iterator
 from operator import itemgetter as _itemgetter
-from typing import TYPE_CHECKING, Any, Generic, Iterator, Self, TypeVar, final, overload
+from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar, final, overload
 
 from ...exceptions import ClientClosedError, DatagramProtocolParseError
 from ...protocol import DatagramProtocol

--- a/src/easynetwork/api_sync/client/udp.py
+++ b/src/easynetwork/api_sync/client/udp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/converter.py
+++ b/src/easynetwork/converter.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 __all__ = ["AbstractPacketConverter", "AbstractPacketConverterComposite", "RequestResponseConverterBuilder"]
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, Generic, TypeVar, final
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar, final
 
 _SentDTOPacketT = TypeVar("_SentDTOPacketT")
 _ReceivedDTOPacketT = TypeVar("_ReceivedDTOPacketT")

--- a/src/easynetwork/converter.py
+++ b/src/easynetwork/converter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/exceptions.py
+++ b/src/easynetwork/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/protocol.py
+++ b/src/easynetwork/protocol.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/protocol.py
+++ b/src/easynetwork/protocol.py
@@ -10,7 +10,8 @@ __all__ = [
     "StreamProtocol",
 ]
 
-from typing import Any, Generator, Generic, TypeVar, overload
+from collections.abc import Generator
+from typing import Any, Generic, TypeVar, overload
 
 from .converter import AbstractPacketConverterComposite
 from .exceptions import (

--- a/src/easynetwork/serializers/__init__.py
+++ b/src/easynetwork/serializers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/serializers/abc.py
+++ b/src/easynetwork/serializers/abc.py
@@ -11,7 +11,8 @@ __all__ = [
 ]
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, Generator, Generic, TypeVar
+from collections.abc import Generator
+from typing import Any, Generic, TypeVar
 
 from ..exceptions import DeserializeError
 from ..tools._utils import concatenate_chunks as _concatenate_chunks

--- a/src/easynetwork/serializers/abc.py
+++ b/src/easynetwork/serializers/abc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/serializers/base_stream.py
+++ b/src/easynetwork/serializers/base_stream.py
@@ -12,8 +12,9 @@ __all__ = [
 ]
 
 from abc import abstractmethod
+from collections.abc import Generator
 from io import BytesIO
-from typing import IO, Any, Generator, TypeVar, final
+from typing import IO, Any, TypeVar, final
 
 from ..exceptions import DeserializeError, IncrementalDeserializeError
 from .abc import AbstractIncrementalPacketSerializer, AbstractPacketSerializer

--- a/src/easynetwork/serializers/base_stream.py
+++ b/src/easynetwork/serializers/base_stream.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/serializers/cbor.py
+++ b/src/easynetwork/serializers/cbor.py
@@ -11,9 +11,10 @@ __all__ = [
     "CBORSerializer",
 ]
 
+from collections.abc import Callable
 from dataclasses import asdict as dataclass_asdict, dataclass
 from functools import partial
-from typing import IO, TYPE_CHECKING, Any, Callable, TypeVar, final
+from typing import IO, TYPE_CHECKING, Any, TypeVar, final
 
 from .base_stream import FileBasedPacketSerializer
 

--- a/src/easynetwork/serializers/cbor.py
+++ b/src/easynetwork/serializers/cbor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/serializers/json.py
+++ b/src/easynetwork/serializers/json.py
@@ -14,8 +14,9 @@ __all__ = [
 import re
 import string
 from collections import Counter
+from collections.abc import Callable, Generator
 from dataclasses import asdict as dataclass_asdict, dataclass
-from typing import Any, Callable, Generator, TypeVar, final
+from typing import Any, TypeVar, final
 
 from ..exceptions import DeserializeError, IncrementalDeserializeError
 from ..tools._utils import iter_bytes

--- a/src/easynetwork/serializers/json.py
+++ b/src/easynetwork/serializers/json.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/serializers/line.py
+++ b/src/easynetwork/serializers/line.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/serializers/msgpack.py
+++ b/src/easynetwork/serializers/msgpack.py
@@ -11,9 +11,10 @@ __all__ = [
     "MessageUnpackerConfig",
 ]
 
+from collections.abc import Callable
 from dataclasses import asdict as dataclass_asdict, dataclass, field
 from functools import partial
-from typing import Any, Callable, TypeVar, final
+from typing import Any, TypeVar, final
 
 from ..exceptions import DeserializeError
 from .abc import AbstractPacketSerializer

--- a/src/easynetwork/serializers/msgpack.py
+++ b/src/easynetwork/serializers/msgpack.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/serializers/pickle.py
+++ b/src/easynetwork/serializers/pickle.py
@@ -11,10 +11,11 @@ __all__ = [
     "UnpicklerConfig",
 ]
 
+from collections.abc import Callable
 from dataclasses import asdict as dataclass_asdict, dataclass, field
 from functools import partial
 from io import BytesIO
-from typing import IO, TYPE_CHECKING, Callable, TypeVar, final
+from typing import IO, TYPE_CHECKING, TypeVar, final
 
 from ..exceptions import DeserializeError
 from .abc import AbstractPacketSerializer

--- a/src/easynetwork/serializers/pickle.py
+++ b/src/easynetwork/serializers/pickle.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/serializers/struct.py
+++ b/src/easynetwork/serializers/struct.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 __all__ = ["AbstractStructSerializer", "NamedTupleStructSerializer"]
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Generic, Iterable, NamedTuple, TypeVar, final
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeVar, final
 
 from ..exceptions import DeserializeError
 from .base_stream import FixedSizePacketSerializer

--- a/src/easynetwork/serializers/struct.py
+++ b/src/easynetwork/serializers/struct.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/serializers/wrapper/__init__.py
+++ b/src/easynetwork/serializers/wrapper/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/serializers/wrapper/base64.py
+++ b/src/easynetwork/serializers/wrapper/base64.py
@@ -10,7 +10,8 @@ __all__ = [
 ]
 
 import os
-from typing import Callable, Literal, TypeVar, assert_never, final
+from collections.abc import Callable
+from typing import Literal, TypeVar, assert_never, final
 
 from ...exceptions import DeserializeError
 from ..abc import AbstractPacketSerializer

--- a/src/easynetwork/serializers/wrapper/base64.py
+++ b/src/easynetwork/serializers/wrapper/base64.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/serializers/wrapper/compressor.py
+++ b/src/easynetwork/serializers/wrapper/compressor.py
@@ -13,7 +13,8 @@ __all__ = [
 
 import abc
 from collections import deque
-from typing import Final, Generator, Protocol, TypeVar, final
+from collections.abc import Generator
+from typing import Final, Protocol, TypeVar, final
 
 from ...exceptions import DeserializeError, IncrementalDeserializeError
 from ..abc import AbstractIncrementalPacketSerializer, AbstractPacketSerializer

--- a/src/easynetwork/serializers/wrapper/compressor.py
+++ b/src/easynetwork/serializers/wrapper/compressor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/serializers/wrapper/encryptor.py
+++ b/src/easynetwork/serializers/wrapper/encryptor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/tools/__init__.py
+++ b/src/easynetwork/tools/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 __all__ = [

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -27,7 +27,8 @@ import selectors as _selectors
 import socket as _socket
 import time
 import traceback
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Literal, ParamSpec, TypeGuard, TypeVar, assert_never
+from collections.abc import Callable, Iterable, Iterator
+from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypeGuard, TypeVar, assert_never
 
 try:
     import ssl as _ssl
@@ -312,7 +313,7 @@ def open_listener_sockets_from_getaddrinfo_result(
             except OSError as exc:
                 errors.append(
                     OSError(
-                        exc.errno, "error while attempting to bind on address %r: %s" % (sa, exc.strerror.lower())
+                        exc.errno, f"error while attempting to bind on address {sa!r}: {exc.strerror.lower()}"
                     ).with_traceback(exc.__traceback__)
                 )
                 continue

--- a/src/easynetwork/tools/lock.py
+++ b/src/easynetwork/tools/lock.py
@@ -11,7 +11,8 @@ __all__ = ["ForkSafeLock"]
 
 import os
 import threading
-from typing import Callable, Generic, TypeVar, cast, overload
+from collections.abc import Callable
+from typing import Generic, TypeVar, cast, overload
 
 _L = TypeVar("_L", bound="threading.RLock | threading.Lock")
 

--- a/src/easynetwork/tools/lock.py
+++ b/src/easynetwork/tools/lock.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/tools/socket.py
+++ b/src/easynetwork/tools/socket.py
@@ -25,21 +25,9 @@ import contextlib
 import errno as _errno
 import functools
 import socket as _socket
+from collections.abc import Callable
 from enum import IntEnum, unique
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Final,
-    Literal,
-    NamedTuple,
-    ParamSpec,
-    Protocol,
-    TypeAlias,
-    TypeVar,
-    final,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, ParamSpec, Protocol, TypeAlias, TypeVar, final, overload
 
 if TYPE_CHECKING:
     import threading as _threading

--- a/src/easynetwork/tools/socket.py
+++ b/src/easynetwork/tools/socket.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork/tools/stream.py
+++ b/src/easynetwork/tools/stream.py
@@ -11,7 +11,8 @@ __all__ = [
 ]
 
 from collections import deque
-from typing import Any, Generator, Generic, Iterator, TypeVar, final
+from collections.abc import Generator, Iterator
+from typing import Any, Generic, TypeVar, final
 
 from ..exceptions import StreamProtocolParseError
 from ..protocol import StreamProtocol

--- a/src/easynetwork/tools/stream.py
+++ b/src/easynetwork/tools/stream.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork_asyncio/__init__.py
+++ b/src/easynetwork_asyncio/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork_asyncio/_utils.py
+++ b/src/easynetwork_asyncio/_utils.py
@@ -10,7 +10,8 @@ __all__ = ["create_connection", "create_datagram_socket"]
 
 import asyncio
 import socket as _socket
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from easynetwork.tools._utils import set_reuseport as _set_reuseport
 

--- a/src/easynetwork_asyncio/_utils.py
+++ b/src/easynetwork_asyncio/_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork_asyncio/backend.py
+++ b/src/easynetwork_asyncio/backend.py
@@ -17,7 +17,8 @@ import os
 import socket as _socket
 import sys
 from collections.abc import Callable, Coroutine, Sequence
-from typing import TYPE_CHECKING, Any, AsyncContextManager, NoReturn, ParamSpec, TypeVar
+from contextlib import AbstractAsyncContextManager as AsyncContextManager
+from typing import TYPE_CHECKING, Any, NoReturn, ParamSpec, TypeVar
 
 try:
     import ssl as _ssl

--- a/src/easynetwork_asyncio/backend.py
+++ b/src/easynetwork_asyncio/backend.py
@@ -16,7 +16,8 @@ import itertools
 import os
 import socket as _socket
 import sys
-from typing import TYPE_CHECKING, Any, AsyncContextManager, Callable, Coroutine, NoReturn, ParamSpec, Sequence, TypeVar
+from collections.abc import Callable, Coroutine, Sequence
+from typing import TYPE_CHECKING, Any, AsyncContextManager, NoReturn, ParamSpec, TypeVar
 
 try:
     import ssl as _ssl

--- a/src/easynetwork_asyncio/backend.py
+++ b/src/easynetwork_asyncio/backend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork_asyncio/datagram/__init__.py
+++ b/src/easynetwork_asyncio/datagram/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork_asyncio/datagram/endpoint.py
+++ b/src/easynetwork_asyncio/datagram/endpoint.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork_asyncio/datagram/socket.py
+++ b/src/easynetwork_asyncio/datagram/socket.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork_asyncio/socket.py
+++ b/src/easynetwork_asyncio/socket.py
@@ -12,7 +12,8 @@ import asyncio
 import asyncio.trsock
 import contextlib
 import errno as _errno
-from typing import TYPE_CHECKING, Any, Iterator, Literal, Self, TypeAlias
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Literal, Self, TypeAlias
 from weakref import WeakSet
 
 from easynetwork.tools._utils import check_socket_no_ssl as _check_socket_no_ssl, error_from_errno as _error_from_errno

--- a/src/easynetwork_asyncio/socket.py
+++ b/src/easynetwork_asyncio/socket.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork_asyncio/stream/__init__.py
+++ b/src/easynetwork_asyncio/stream/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork_asyncio/stream/listener.py
+++ b/src/easynetwork_asyncio/stream/listener.py
@@ -11,7 +11,8 @@ __all__ = ["ListenerSocketAdapter"]
 import asyncio
 import asyncio.streams
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, final
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, final
 
 from easynetwork.api_async.backend.abc import (
     AbstractAcceptedSocket,

--- a/src/easynetwork_asyncio/stream/listener.py
+++ b/src/easynetwork_asyncio/stream/listener.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork_asyncio/stream/socket.py
+++ b/src/easynetwork_asyncio/stream/socket.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork_asyncio/tasks.py
+++ b/src/easynetwork_asyncio/tasks.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 __all__ = ["Task", "TaskGroup", "TimeoutHandle", "timeout", "timeout_at"]
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, ParamSpec, Self, TypeVar, final
+from collections.abc import Callable, Coroutine
+from typing import TYPE_CHECKING, Any, ParamSpec, Self, TypeVar, final
 
 from easynetwork.api_async.backend.abc import AbstractTask, AbstractTaskGroup, AbstractTimeoutHandle
 

--- a/src/easynetwork_asyncio/tasks.py
+++ b/src/easynetwork_asyncio/tasks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/src/easynetwork_asyncio/threads.py
+++ b/src/easynetwork_asyncio/threads.py
@@ -11,7 +11,8 @@ __all__ = ["ThreadsPortal"]
 import asyncio
 import concurrent.futures
 import contextvars
-from typing import Any, Callable, Coroutine, ParamSpec, TypeVar, final
+from collections.abc import Callable, Coroutine
+from typing import Any, ParamSpec, TypeVar, final
 
 from easynetwork.api_async.backend.abc import AbstractThreadsPortal
 from easynetwork.api_async.backend.sniffio import current_async_library_cvar as _sniffio_current_async_library_cvar

--- a/src/easynetwork_asyncio/threads.py
+++ b/src/easynetwork_asyncio/threads.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
 #
 #

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import os

--- a/tests/functional_test/conftest.py
+++ b/tests/functional_test/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import pathlib

--- a/tests/functional_test/test_async/test_backend/test_asyncio_backend.py
+++ b/tests/functional_test/test_async/test_backend/test_asyncio_backend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/functional_test/test_async/test_backend/test_backend_factory.py
+++ b/tests/functional_test/test_async/test_backend/test_backend_factory.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterator
+from collections.abc import Iterator
 
 from easynetwork.api_async.backend.factory import AsyncBackendFactory
 

--- a/tests/functional_test/test_async/test_backend/test_backend_factory.py
+++ b/tests/functional_test/test_async/test_backend/test_backend_factory.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import Iterator

--- a/tests/functional_test/test_async/test_backend/test_futures.py
+++ b/tests/functional_test/test_async/test_backend/test_futures.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/functional_test/test_async/test_backend/test_futures.py
+++ b/tests/functional_test/test_async/test_backend/test_futures.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import time
-from typing import AsyncIterator
+from collections.abc import AsyncIterator
 
 from easynetwork.api_async.backend.abc import AbstractAsyncBackend
 from easynetwork.api_async.backend.factory import AsyncBackendFactory

--- a/tests/functional_test/test_async/test_backend/test_tasks.py
+++ b/tests/functional_test/test_async/test_backend/test_tasks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/functional_test/test_communication/conftest.py
+++ b/tests/functional_test/test_communication/conftest.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import ssl
+from collections.abc import Callable, Iterator
 from contextlib import ExitStack
 from functools import partial
 from socket import AF_INET, AF_INET6, SOCK_DGRAM, SOCK_STREAM, has_ipv6 as HAS_IPV6, socket as Socket
-from typing import Any, Callable, Iterator
+from typing import Any
 
 from easynetwork.protocol import DatagramProtocol, StreamProtocol
 

--- a/tests/functional_test/test_communication/conftest.py
+++ b/tests/functional_test/test_communication/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import ssl

--- a/tests/functional_test/test_communication/serializer.py
+++ b/tests/functional_test/test_communication/serializer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Generator
+from collections.abc import Generator
 
 from easynetwork.exceptions import DeserializeError, IncrementalDeserializeError
 from easynetwork.serializers.abc import AbstractIncrementalPacketSerializer

--- a/tests/functional_test/test_communication/test_async/_utils.py
+++ b/tests/functional_test/test_communication/test_async/_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/functional_test/test_communication/test_async/_utils.py
+++ b/tests/functional_test/test_communication/test_async/_utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Awaitable, Callable, TypeVar
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
 
 _T = TypeVar("_T")
 

--- a/tests/functional_test/test_communication/test_async/test_client/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_client/test_tcp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/functional_test/test_communication/test_async/test_client/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_client/test_tcp.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import ssl
+from collections.abc import AsyncIterator
 from socket import AF_INET, IPPROTO_TCP, SHUT_WR, TCP_NODELAY, socket as Socket
-from typing import Any, AsyncIterator
+from typing import Any
 
 from easynetwork.api_async.client.tcp import AsyncTCPNetworkClient
 from easynetwork.exceptions import ClientClosedError, StreamProtocolParseError

--- a/tests/functional_test/test_communication/test_async/test_client/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_client/test_udp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/functional_test/test_communication/test_async/test_client/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_client/test_udp.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from collections.abc import AsyncIterator, Awaitable, Callable
 from socket import AF_INET, socket as Socket
-from typing import Any, AsyncIterator, Awaitable, Callable
+from typing import Any
 
 from easynetwork.api_async.client.udp import AsyncUDPNetworkClient, AsyncUDPNetworkEndpoint
 from easynetwork.exceptions import ClientClosedError, DatagramProtocolParseError

--- a/tests/functional_test/test_communication/test_async/test_server/base.py
+++ b/tests/functional_test/test_communication/test_async/test_server/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/functional_test/test_communication/test_async/test_server/base.py
+++ b/tests/functional_test/test_communication/test_async/test_server/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from typing import AsyncIterator
+from collections.abc import AsyncIterator
 
 from easynetwork.api_async.server.abc import AbstractAsyncNetworkServer
 from easynetwork.exceptions import ServerAlreadyRunning, ServerClosedError

--- a/tests/functional_test/test_communication/test_async/test_server/test_standalone.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_standalone.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/functional_test/test_communication/test_async/test_server/test_standalone.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_standalone.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
-from typing import AsyncGenerator, Callable, Iterator
+from collections.abc import AsyncGenerator, Callable, Iterator
 
 from easynetwork.api_async.server.handler import AsyncBaseRequestHandler, AsyncClientInterface
 from easynetwork.api_async.server.standalone import (

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -6,8 +6,9 @@ import contextlib
 import logging
 import math
 import ssl
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Sequence
 from socket import IPPROTO_TCP, TCP_NODELAY
-from typing import Any, AsyncGenerator, AsyncIterator, Awaitable, Callable, Sequence
+from typing import Any
 from weakref import WeakValueDictionary
 
 from easynetwork.api_async.backend.abc import AbstractAsyncBackend

--- a/tests/functional_test/test_communication/test_async/test_server/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_udp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/functional_test/test_communication/test_async/test_server/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_udp.py
@@ -5,7 +5,8 @@ import collections
 import contextlib
 import logging
 import math
-from typing import Any, AsyncGenerator, AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
+from typing import Any
 
 from easynetwork.api_async.backend.abc import AbstractAsyncBackend
 from easynetwork.api_async.server.handler import AsyncBaseRequestHandler, AsyncClientInterface

--- a/tests/functional_test/test_communication/test_sync/conftest.py
+++ b/tests/functional_test/test_communication/test_sync/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import time

--- a/tests/functional_test/test_communication/test_sync/conftest.py
+++ b/tests/functional_test/test_communication/test_sync/conftest.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Callable, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Any, Callable, Iterator
+from typing import Any
 
 import pytest
 

--- a/tests/functional_test/test_communication/test_sync/test_client/test_tcp.py
+++ b/tests/functional_test/test_communication/test_sync/test_client/test_tcp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import socketserver

--- a/tests/functional_test/test_communication/test_sync/test_client/test_tcp.py
+++ b/tests/functional_test/test_communication/test_sync/test_client/test_tcp.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import socketserver
 import ssl
+from collections.abc import Callable, Iterator
 from concurrent.futures import Future
 from socket import AF_INET, IPPROTO_TCP, SHUT_WR, TCP_NODELAY, socket as Socket
-from typing import Any, Callable, Iterator
+from typing import Any
 
 from easynetwork.api_sync.client.tcp import TCPNetworkClient
 from easynetwork.exceptions import ClientClosedError, StreamProtocolParseError

--- a/tests/functional_test/test_communication/test_sync/test_client/test_udp.py
+++ b/tests/functional_test/test_communication/test_sync/test_client/test_udp.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Iterator
 from socket import AF_INET, socket as Socket
-from typing import Any, Callable, Iterator
+from typing import Any
 
 from easynetwork.api_sync.client.udp import UDPNetworkClient, UDPNetworkEndpoint
 from easynetwork.exceptions import ClientClosedError, DatagramProtocolParseError

--- a/tests/functional_test/test_communication/test_sync/test_client/test_udp.py
+++ b/tests/functional_test/test_communication/test_sync/test_client/test_udp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from socket import AF_INET, socket as Socket

--- a/tests/functional_test/test_concurrency/conftest.py
+++ b/tests/functional_test/test_concurrency/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import threading

--- a/tests/functional_test/test_concurrency/conftest.py
+++ b/tests/functional_test/test_concurrency/conftest.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import threading
-from typing import AsyncGenerator, Iterator, Literal
+from collections.abc import AsyncGenerator, Iterator
+from typing import Literal
 
 from easynetwork.api_async.server.handler import AsyncBaseRequestHandler, AsyncClientInterface
 from easynetwork.api_async.server.standalone import (

--- a/tests/functional_test/test_concurrency/test_sync/conftest.py
+++ b/tests/functional_test/test_concurrency/test_sync/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import Iterator, Literal

--- a/tests/functional_test/test_concurrency/test_sync/conftest.py
+++ b/tests/functional_test/test_concurrency/test_sync/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Iterator, Literal
+from collections.abc import Iterator
+from typing import Literal
 
 from easynetwork.api_sync.client import AbstractNetworkClient, TCPNetworkClient, UDPNetworkClient
 from easynetwork.protocol import DatagramProtocol, StreamProtocol

--- a/tests/functional_test/test_concurrency/test_sync/test_threaded_client.py
+++ b/tests/functional_test/test_concurrency/test_sync/test_threaded_client.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import time

--- a/tests/functional_test/test_concurrency/test_sync/test_threaded_client.py
+++ b/tests/functional_test/test_concurrency/test_sync/test_threaded_client.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
-from typing import Iterator, TypeAlias
+from typing import TypeAlias
 
 from easynetwork.api_sync.client.abc import AbstractNetworkClient
 

--- a/tests/functional_test/test_serializers/__init__.py
+++ b/tests/functional_test/test_serializers/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import pytest

--- a/tests/functional_test/test_serializers/base.py
+++ b/tests/functional_test/test_serializers/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*
-
 from __future__ import annotations
 
 import random

--- a/tests/functional_test/test_serializers/base.py
+++ b/tests/functional_test/test_serializers/base.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import random
 from abc import ABCMeta
-from typing import Any, Callable, final
+from collections.abc import Callable
+from typing import Any, final
 
 from easynetwork.exceptions import DeserializeError, IncrementalDeserializeError
 from easynetwork.serializers.abc import AbstractIncrementalPacketSerializer, AbstractPacketSerializer

--- a/tests/functional_test/test_serializers/conftest.py
+++ b/tests/functional_test/test_serializers/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import pytest

--- a/tests/functional_test/test_serializers/samples/json.py
+++ b/tests/functional_test/test_serializers/samples/json.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import Any

--- a/tests/functional_test/test_serializers/samples/pickle.py
+++ b/tests/functional_test/test_serializers/samples/pickle.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from pickle import STOP as STOP_OPCODE

--- a/tests/functional_test/test_serializers/test_base64.py
+++ b/tests/functional_test/test_serializers/test_base64.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # mypy: disable_error_code=override
 
 from __future__ import annotations

--- a/tests/functional_test/test_serializers/test_cbor.py
+++ b/tests/functional_test/test_serializers/test_cbor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # mypy: disable_error_code=override
 
 from __future__ import annotations

--- a/tests/functional_test/test_serializers/test_compressors.py
+++ b/tests/functional_test/test_serializers/test_compressors.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # mypy: disable_error_code=override
 
 from __future__ import annotations

--- a/tests/functional_test/test_serializers/test_encryptor.py
+++ b/tests/functional_test/test_serializers/test_encryptor.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, final
+from collections.abc import Callable
+from typing import Any, final
 
 from easynetwork.serializers.wrapper.encryptor import EncryptorSerializer
 

--- a/tests/functional_test/test_serializers/test_encryptor.py
+++ b/tests/functional_test/test_serializers/test_encryptor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # mypy: disable_error_code=override
 
 from __future__ import annotations

--- a/tests/functional_test/test_serializers/test_json.py
+++ b/tests/functional_test/test_serializers/test_json.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # mypy: disable-error-code=override
 
 from __future__ import annotations

--- a/tests/functional_test/test_serializers/test_line.py
+++ b/tests/functional_test/test_serializers/test_line.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # mypy: disable_error_code=override
 
 from __future__ import annotations

--- a/tests/functional_test/test_serializers/test_msgpack.py
+++ b/tests/functional_test/test_serializers/test_msgpack.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # mypy: disable_error_code=override
 
 from __future__ import annotations

--- a/tests/functional_test/test_serializers/test_namedtuple.py
+++ b/tests/functional_test/test_serializers/test_namedtuple.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # mypy: disable_error_code=override
 
 from __future__ import annotations

--- a/tests/functional_test/test_serializers/test_pickle.py
+++ b/tests/functional_test/test_serializers/test_pickle.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*
-
 from __future__ import annotations
 
 import dataclasses

--- a/tests/other_test/test_import.py
+++ b/tests/other_test/test_import.py
@@ -42,7 +42,7 @@ def _catch_star_imports_within_packages() -> dict[str, list[str]]:
     all_packages: dict[str, list[str]] = {}
     for package_name in ALL_EASYNETWORK_PACKAGES:
         package_file = inspect.getfile(import_module(package_name))
-        with open(package_file, "r") as package_fp:
+        with open(package_file) as package_fp:
             package_source = package_fp.read()
         tree = ast.parse(package_source, package_file)
         start_import_modules: list[str] = []

--- a/tests/other_test/test_import.py
+++ b/tests/other_test/test_import.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from functools import cache

--- a/tests/other_test/test_project_metadata.py
+++ b/tests/other_test/test_project_metadata.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import importlib.metadata as importlib_metadata

--- a/tests/pytest_plugins/asyncio_event_loop.py
+++ b/tests/pytest_plugins/asyncio_event_loop.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/pytest_plugins/extra_features.py
+++ b/tests/pytest_plugins/extra_features.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import functools

--- a/tests/pytest_plugins/extra_features.py
+++ b/tests/pytest_plugins/extra_features.py
@@ -22,9 +22,9 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 def _get_markers_starting_with_prefix(item: pytest.Item, prefix: str, *, remove: bool) -> set[str]:
-    markers = set(mark.name for mark in item.iter_markers() if mark.name.startswith(prefix))
+    markers = {mark.name for mark in item.iter_markers() if mark.name.startswith(prefix)}
     if remove:
-        markers = set(m.removeprefix(prefix) for m in markers)
+        markers = {m.removeprefix(prefix) for m in markers}
     return markers
 
 

--- a/tests/pytest_plugins/session_exit_code.py
+++ b/tests/pytest_plugins/session_exit_code.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import pytest

--- a/tests/pytest_plugins/ssl_module.py
+++ b/tests/pytest_plugins/ssl_module.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import functools

--- a/tests/scripts/async_client_test.py
+++ b/tests/scripts/async_client_test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
-from typing import Callable
+from collections.abc import Callable
 
 from easynetwork.api_async.client import AbstractAsyncNetworkClient, AsyncTCPNetworkClient, AsyncUDPNetworkClient
 from easynetwork.protocol import DatagramProtocol, StreamProtocol

--- a/tests/scripts/async_server_test.py
+++ b/tests/scripts/async_server_test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import logging
-from typing import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator, Callable
 
 from easynetwork.api_async.server.handler import AsyncBaseRequestHandler, AsyncClientInterface
 from easynetwork.api_async.server.standalone import (

--- a/tests/scripts/threaded_client_test.py
+++ b/tests/scripts/threaded_client_test.py
@@ -4,7 +4,7 @@ import argparse
 import concurrent.futures
 import logging
 import time
-from typing import Callable
+from collections.abc import Callable
 
 from easynetwork.api_sync.client import AbstractNetworkClient, TCPNetworkClient, UDPNetworkClient
 from easynetwork.protocol import DatagramProtocol, StreamProtocol

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import time

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Generator, TypeVar, final
+from collections.abc import Generator
+from typing import Any, TypeVar, final
 
 import pytest
 

--- a/tests/unit_test/_utils.py
+++ b/tests/unit_test/_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import functools

--- a/tests/unit_test/base.py
+++ b/tests/unit_test/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from socket import AF_INET6

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import pathlib
+from collections.abc import Callable
 from socket import AF_INET, IPPROTO_TCP, IPPROTO_UDP, SOCK_DGRAM, SOCK_STREAM, socket as Socket
 from ssl import SSLContext, SSLSocket
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from easynetwork.converter import AbstractPacketConverterComposite
 from easynetwork.protocol import DatagramProtocol, StreamProtocol

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import pathlib

--- a/tests/unit_test/test_async/base.py
+++ b/tests/unit_test/test_async/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from socket import AF_INET6

--- a/tests/unit_test/test_async/conftest.py
+++ b/tests/unit_test/test_async/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit_test/test_async/conftest.py
+++ b/tests/unit_test/test_async/conftest.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from easynetwork.api_async.backend.abc import (
     AbstractAsyncBackend,

--- a/tests/unit_test/test_async/test_api/conftest.py
+++ b/tests/unit_test/test_async/test_api/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
+++ b/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Coroutine, Sequence
 from socket import socket as Socket
-from typing import Any, AsyncContextManager, Callable, Coroutine, NoReturn, Sequence, final
+from typing import Any, AsyncContextManager, NoReturn, final
 
 from easynetwork.api_async.backend.abc import (
     AbstractAsyncBackend,

--- a/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
+++ b/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from socket import socket as Socket

--- a/tests/unit_test/test_async/test_api/test_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_api/test_backend/test_backend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit_test/test_async/test_api/test_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_api/test_backend/test_backend.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Coroutine, Iterator
 from socket import socket as Socket
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Coroutine, Iterator, Literal, assert_never, final
+from typing import TYPE_CHECKING, Any, Literal, assert_never, final
 
 from easynetwork.api_async.backend.abc import AbstractAsyncBackend
 from easynetwork.api_async.backend.factory import AsyncBackendFactory
@@ -339,7 +340,7 @@ class TestAsyncBackendFactory:
 
         # Act & Assert
         with pytest.raises(
-            TypeError, match=r"^Invalid backend class \(not a subclass of %r\): %r$" % (default_backend_cls, MockBackend)
+            TypeError, match=rf"^Invalid backend class \(not a subclass of {default_backend_cls!r}\): {MockBackend!r}$"
         ):
             AsyncBackendFactory.extend(backend_name, MockBackend)
 

--- a/tests/unit_test/test_async/test_api/test_backend/test_futures.py
+++ b/tests/unit_test/test_async/test_api/test_backend/test_futures.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import concurrent.futures

--- a/tests/unit_test/test_async/test_api/test_client/base.py
+++ b/tests/unit_test/test_async/test_api/test_client/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from ...base import BaseTestAsyncSocketAdapter

--- a/tests/unit_test/test_async/test_api/test_client/test_abc.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_abc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, final

--- a/tests/unit_test/test_async/test_api/test_client/test_tcp.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_tcp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import errno

--- a/tests/unit_test/test_async/test_api/test_client/test_udp.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_udp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from socket import AF_INET6

--- a/tests/unit_test/test_async/test_api/test_server/test_handler.py
+++ b/tests/unit_test/test_async/test_api/test_server/test_handler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # mypy: disable_error_code=func-returns-value
 
 from __future__ import annotations

--- a/tests/unit_test/test_async/test_api/test_server/test_handler.py
+++ b/tests/unit_test/test_async/test_api/test_server/test_handler.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Any, AsyncGenerator
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any
 
 from easynetwork.api_async.server.handler import AsyncBaseRequestHandler, AsyncClientInterface, AsyncStreamRequestHandler
 from easynetwork.exceptions import BaseProtocolParseError

--- a/tests/unit_test/test_async/test_asyncio_backend/conftest.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit_test/test_async/test_asyncio_backend/conftest.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/conftest.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from easynetwork_asyncio.datagram.endpoint import DatagramEndpoint
 from easynetwork_asyncio.socket import AsyncSocket

--- a/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import contextvars
-from typing import TYPE_CHECKING, Any, Callable, Sequence, cast
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any, cast
 
 from easynetwork.api_async.backend.abc import AbstractAsyncStreamSocketAdapter
 from easynetwork_asyncio import AsyncioBackend

--- a/tests/unit_test/test_async/test_asyncio_backend/test_datagram.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_datagram.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit_test/test_async/test_asyncio_backend/test_datagram.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_datagram.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from easynetwork_asyncio.datagram.endpoint import DatagramEndpoint, DatagramEndpointProtocol, create_datagram_endpoint
 from easynetwork_asyncio.datagram.socket import AsyncioTransportDatagramSocketAdapter, RawDatagramSocketAdapter

--- a/tests/unit_test/test_async/test_asyncio_backend/test_socket.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_socket.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # mypy: disable_error_code=override
 
 from __future__ import annotations

--- a/tests/unit_test/test_async/test_asyncio_backend/test_socket.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_socket.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from collections.abc import Callable, Coroutine, Iterator
 from socket import socket as Socket
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Iterator, final
+from typing import TYPE_CHECKING, Any, final
 
 from easynetwork_asyncio.socket import AsyncSocket
 

--- a/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import asyncio.trsock
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from easynetwork.api_async.backend.abc import AbstractAcceptedSocket
 from easynetwork_asyncio.stream.listener import AcceptedSocket, AcceptedSSLSocket, ListenerSocketAdapter

--- a/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # mypy: disable_error_code=override
 
 from __future__ import annotations

--- a/tests/unit_test/test_async/test_asyncio_backend/test_tasks.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_tasks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit_test/test_async/test_asyncio_backend/test_threads.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_threads.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit_test/test_async/test_asyncio_backend/test_utils.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit_test/test_async/test_asyncio_backend/test_utils.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import asyncio.trsock
 import errno
+from collections.abc import Callable, Sequence
 from socket import (
     AF_INET,
     AF_INET6,
@@ -19,7 +20,7 @@ from socket import (
     SOL_SOCKET,
     gaierror,
 )
-from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, assert_never
+from typing import TYPE_CHECKING, Any, Literal, assert_never
 
 from easynetwork.tools._utils import error_from_errno
 from easynetwork_asyncio._utils import _ensure_resolved, create_connection, create_datagram_socket

--- a/tests/unit_test/test_converter.py
+++ b/tests/unit_test/test_converter.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable

--- a/tests/unit_test/test_converter.py
+++ b/tests/unit_test/test_converter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from easynetwork.converter import AbstractPacketConverterComposite, PacketConverterComposite, RequestResponseConverterBuilder
 

--- a/tests/unit_test/test_protocol.py
+++ b/tests/unit_test/test_protocol.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Generator

--- a/tests/unit_test/test_protocol.py
+++ b/tests/unit_test/test_protocol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generator
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any
 
 from easynetwork.exceptions import (
     DatagramProtocolParseError,

--- a/tests/unit_test/test_serializers/__init__.py
+++ b/tests/unit_test/test_serializers/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import pytest

--- a/tests/unit_test/test_serializers/base.py
+++ b/tests/unit_test/test_serializers/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*
-
 from __future__ import annotations
 
 from typing import Any, Callable

--- a/tests/unit_test/test_serializers/base.py
+++ b/tests/unit_test/test_serializers/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 

--- a/tests/unit_test/test_serializers/conftest.py
+++ b/tests/unit_test/test_serializers/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import pathlib

--- a/tests/unit_test/test_serializers/test_abc.py
+++ b/tests/unit_test/test_serializers/test_abc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*
-
 from __future__ import annotations
 
 import contextlib

--- a/tests/unit_test/test_serializers/test_abc.py
+++ b/tests/unit_test/test_serializers/test_abc.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import contextlib
 import random
-from typing import IO, TYPE_CHECKING, Any, Generator, final
+from collections.abc import Generator
+from typing import IO, TYPE_CHECKING, Any, final
 
 from easynetwork.exceptions import DeserializeError, IncrementalDeserializeError
 from easynetwork.serializers.abc import AbstractIncrementalPacketSerializer
@@ -788,7 +789,7 @@ class TestFileBasedPacketSerializer:
     ) -> None:
         # Arrange
         def side_effect(file: IO[bytes]) -> Any:
-            if len((data := file.read(4))) < 4:
+            if len(data := file.read(4)) < 4:
                 assert data == b"data"[: len(data)]
                 raise EOFError
             assert data == b"data"
@@ -829,7 +830,7 @@ class TestFileBasedPacketSerializer:
             pass
 
         def side_effect(file: IO[bytes]) -> Any:
-            if len((data := file.read(4))) < 4:
+            if len(data := file.read(4)) < 4:
                 assert data == b"data"[: len(data)]
                 raise MyFileAPIEOFError
             assert data.startswith(b"data")

--- a/tests/unit_test/test_serializers/test_base64.py
+++ b/tests/unit_test/test_serializers/test_base64.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal

--- a/tests/unit_test/test_serializers/test_cbor.py
+++ b/tests/unit_test/test_serializers/test_cbor.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, final

--- a/tests/unit_test/test_serializers/test_compressor.py
+++ b/tests/unit_test/test_serializers/test_compressor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterator
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
 
 from easynetwork.exceptions import DeserializeError, IncrementalDeserializeError
 from easynetwork.serializers.wrapper.compressor import (

--- a/tests/unit_test/test_serializers/test_compressor.py
+++ b/tests/unit_test/test_serializers/test_compressor.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Iterator

--- a/tests/unit_test/test_serializers/test_encryptor.py
+++ b/tests/unit_test/test_serializers/test_encryptor.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/tests/unit_test/test_serializers/test_json.py
+++ b/tests/unit_test/test_serializers/test_json.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generator
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any
 
 from easynetwork.exceptions import DeserializeError, IncrementalDeserializeError
 from easynetwork.serializers.json import JSONDecoderConfig, JSONEncoderConfig, JSONSerializer, _JSONParser

--- a/tests/unit_test/test_serializers/test_json.py
+++ b/tests/unit_test/test_serializers/test_json.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Generator

--- a/tests/unit_test/test_serializers/test_line.py
+++ b/tests/unit_test/test_serializers/test_line.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*
-
 from __future__ import annotations
 
 from typing import Literal

--- a/tests/unit_test/test_serializers/test_msgpack.py
+++ b/tests/unit_test/test_serializers/test_msgpack.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, final

--- a/tests/unit_test/test_serializers/test_pickle.py
+++ b/tests/unit_test/test_serializers/test_pickle.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*
-
 from __future__ import annotations
 
 import pickle

--- a/tests/unit_test/test_serializers/test_struct.py
+++ b/tests/unit_test/test_serializers/test_struct.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import collections
-from typing import TYPE_CHECKING, Any, Iterable, final
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, final
 
 from easynetwork.exceptions import DeserializeError
 from easynetwork.serializers.struct import _ENDIANNESS_CHARACTERS, AbstractStructSerializer, NamedTupleStructSerializer
@@ -224,7 +225,7 @@ class TestNamedTupleStructSerializer(BaseTestStructBasedSerializer):
         field_formats[field] += endianness
 
         # Act & Assert
-        with pytest.raises(ValueError, match=r"^{!r}: Invalid field format$".format(field)):
+        with pytest.raises(ValueError, match=rf"^{field!r}: Invalid field format$"):
             _ = NamedTupleStructSerializer(namedtuple_cls, field_formats)
 
         mock_struct_cls.assert_not_called()
@@ -241,7 +242,7 @@ class TestNamedTupleStructSerializer(BaseTestStructBasedSerializer):
         del field_formats[field]
 
         # Act & Assert
-        with pytest.raises(KeyError, match=r"^{!r}$".format(field)):
+        with pytest.raises(KeyError, match=rf"^{field!r}$"):
             _ = NamedTupleStructSerializer(namedtuple_cls, field_formats)
 
         mock_struct_cls.assert_not_called()
@@ -260,7 +261,7 @@ class TestNamedTupleStructSerializer(BaseTestStructBasedSerializer):
         field_formats[field] = format
 
         # Act & Assert
-        with pytest.raises(ValueError, match=r"^{!r}: Invalid field format$".format(field)):
+        with pytest.raises(ValueError, match=rf"^{field!r}: Invalid field format$"):
             _ = NamedTupleStructSerializer(namedtuple_cls, field_formats)
 
         mock_struct_cls.assert_not_called()
@@ -279,7 +280,7 @@ class TestNamedTupleStructSerializer(BaseTestStructBasedSerializer):
         field_formats[field] = format
 
         # Act & Assert
-        with pytest.raises(ValueError, match=r"^{!r}: Invalid field format$".format(field)):
+        with pytest.raises(ValueError, match=rf"^{field!r}: Invalid field format$"):
             _ = NamedTupleStructSerializer(namedtuple_cls, field_formats)
 
         mock_struct_cls.assert_not_called()
@@ -298,7 +299,7 @@ class TestNamedTupleStructSerializer(BaseTestStructBasedSerializer):
         field_formats[field] = format
 
         # Act & Assert
-        with pytest.raises(ValueError, match=r"^{!r}: Invalid field format$".format(field)):
+        with pytest.raises(ValueError, match=rf"^{field!r}: Invalid field format$"):
             _ = NamedTupleStructSerializer(namedtuple_cls, field_formats)
 
         mock_struct_cls.assert_not_called()

--- a/tests/unit_test/test_serializers/test_struct.py
+++ b/tests/unit_test/test_serializers/test_struct.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import collections

--- a/tests/unit_test/test_sync/conftest.py
+++ b/tests/unit_test/test_sync/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/tests/unit_test/test_sync/test_client/base.py
+++ b/tests/unit_test/test_sync/test_client/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/unit_test/test_sync/test_client/conftest.py
+++ b/tests/unit_test/test_sync/test_client/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from selectors import BaseSelector

--- a/tests/unit_test/test_sync/test_client/test_abc.py
+++ b/tests/unit_test/test_sync/test_client/test_abc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from collections import deque

--- a/tests/unit_test/test_sync/test_client/test_tcp.py
+++ b/tests/unit_test/test_sync/test_client/test_tcp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import contextlib

--- a/tests/unit_test/test_sync/test_client/test_udp.py
+++ b/tests/unit_test/test_sync/test_client/test_udp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import errno

--- a/tests/unit_test/test_tools/test_lock.py
+++ b/tests/unit_test/test_tools/test_lock.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import os

--- a/tests/unit_test/test_tools/test_socket.py
+++ b/tests/unit_test/test_tools/test_socket.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import socket
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from easynetwork.tools.socket import (
     AddressFamily,

--- a/tests/unit_test/test_tools/test_socket.py
+++ b/tests/unit_test/test_tools/test_socket.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import socket

--- a/tests/unit_test/test_tools/test_stream.py
+++ b/tests/unit_test/test_tools/test_stream.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generator
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any
 
 from easynetwork.tools.stream import StreamDataConsumer, StreamDataProducer
 

--- a/tests/unit_test/test_tools/test_stream.py
+++ b/tests/unit_test/test_tools/test_stream.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Generator

--- a/tests/unit_test/test_tools/test_utils.py
+++ b/tests/unit_test/test_tools/test_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import selectors
 import ssl
+from collections.abc import Callable, Sequence
 from socket import (
     AF_INET,
     AF_INET6,
@@ -16,7 +17,7 @@ from socket import (
     SOL_SOCKET,
     TCP_NODELAY,
 )
-from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from easynetwork.tools._utils import (
     check_real_socket_state,

--- a/tests/unit_test/test_tools/test_utils.py
+++ b/tests/unit_test/test_tools/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
## What's changed
- Added `pyupgrade` to `.pre-commit-config.yaml`
- Removed encoding pragmas (`# -*- coding: utf-8 -*-`)
- Replaced deprecated imports in `typing` module