### PR TITLE
Servers: `service_actions_interval` set to 1sec by default

### DIFF
--- a/src/easynetwork/api_async/server/tcp.py
+++ b/src/easynetwork/api_async/server/tcp.py
@@ -138,7 +138,7 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             raise ValueError("'max_recv_size' must be a strictly positive integer")
 
         if service_actions_interval is None:
-            service_actions_interval = 0.1
+            service_actions_interval = 1.0
 
         assert isinstance(protocol, StreamProtocol)
 

--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -88,7 +88,7 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         )
 
         if service_actions_interval is None:
-            service_actions_interval = 0.1
+            service_actions_interval = 1.0
 
         self.__service_actions_interval: float = max(service_actions_interval, 0)
         self.__backend: AbstractAsyncBackend = backend


### PR DESCRIPTION
## What's changed
- In `AsyncTCPNetworkServer` and `AsyncUDPNetworkServer`:
  - `service_actions_interval` defaults to 1s instead of 100ms