### PR TITLE
Updated CI/CD configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,7 @@ updates:
       day: "sunday"
     commit-message:
       prefix: "[dependabot]"
+    labels:
+      - "integration"
     reviewers:
       - "francis-clairicia"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    authors:
+      - pre-commit-ci  # autoupdate PRs: Only affects development
+      - dependabot  # dependabot is configured to check github actions' pinned version in workflows
+  categories:
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Features/Improvement
+      labels:
+        - enhancement
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - development

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,4 +50,4 @@ jobs:
         with:
           python-version: '3.11'
       - name: Launch checks
-        run: tox run-parallel -f mypy
+        run: tox run -f mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,8 @@ minimum_pre_commit_version: '2.20.0'
 
 ci:
   skip: [mypy]
+  autoupdate_branch: 'pre-commit/autoupdate'
+  autoupdate_schedule: quarterly
 
 repos:
   - repo: https://github.com/asottile/pyupgrade


### PR DESCRIPTION
## What's changed
### pre-commit.ci
- `pre-commit autoupdate` will be run quarterly
- `pre-commit autoupdate` modifications will be committed to `pre-commit/autoupdate` branch

### dependabot
- `dependabot` PRs now have `integration` label

### Github workflows
- `Lint` workflow: `mypy` testenvs are not run in parallel

### Automated release note generator
- Added `.github/release.yml` configuration
