### PR TITLE
Several API improvements

### DIFF
--- a/src/easynetwork/api_async/backend/abc.py
+++ b/src/easynetwork/api_async/backend/abc.py
@@ -23,6 +23,7 @@ __all__ = [
     "ILock",
 ]
 
+import math
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable, Coroutine, Sequence
 from contextlib import AbstractAsyncContextManager as AsyncContextManager
@@ -259,7 +260,7 @@ class AbstractTimeoutHandle(metaclass=ABCMeta):
 
     @deadline.deleter
     def deadline(self) -> None:
-        self.reschedule(float("+inf"))
+        self.reschedule(math.inf)
 
 
 class AbstractAsyncBackend(metaclass=ABCMeta):

--- a/src/easynetwork/api_async/client/abc.py
+++ b/src/easynetwork/api_async/client/abc.py
@@ -73,10 +73,9 @@ class AbstractAsyncNetworkClient(Generic[_SentPacketT, _ReceivedPacketT], metacl
         raise NotImplementedError
 
     async def iter_received_packets(self) -> AsyncIterator[_ReceivedPacketT]:
-        recv_packet = self.recv_packet
         while True:
             try:
-                packet = await recv_packet()
+                packet = await self.recv_packet()
             except OSError:
                 return
             yield packet

--- a/src/easynetwork/api_async/client/tcp.py
+++ b/src/easynetwork/api_async/client/tcp.py
@@ -277,10 +277,12 @@ class AsyncTCPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
                 backend = self.__backend
                 while True:
                     chunk: bytes = await socket.recv(bufsize)
-                    if not chunk:
-                        self.__eof_error(False)
-                    consumer.feed(chunk)
-                    del chunk
+                    try:
+                        if not chunk:
+                            self.__eof_error(False)
+                        consumer.feed(chunk)
+                    finally:
+                        del chunk
                     try:
                         return next_packet(consumer)
                     except StopIteration:

--- a/src/easynetwork/api_async/server/tcp.py
+++ b/src/easynetwork/api_async/server/tcp.py
@@ -11,6 +11,7 @@ import contextlib as _contextlib
 import errno as _errno
 import inspect
 import logging as _logging
+import math
 import os
 import weakref
 from collections import deque
@@ -265,7 +266,7 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         request_handler = self.__request_handler
         backend = self.__backend
         service_actions_interval = self.__service_actions_interval
-        if service_actions_interval == float("+inf"):
+        if math.isinf(service_actions_interval):
             return
         while True:
             await backend.sleep(service_actions_interval)
@@ -484,10 +485,10 @@ class _RequestReceiver(Generic[_RequestT, _ResponseT]):
             try:
                 data: bytes = await socket.recv(bufsize)
             except ConnectionError:
-                data = b""
-            if not data:  # Closed connection (EOF)
                 break
             try:
+                if not data:  # Closed connection (EOF)
+                    break
                 logger.debug("Received %d bytes from %s", len(data), client.address)
                 consumer.feed(data)
             finally:

--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -9,6 +9,7 @@ __all__ = ["AsyncUDPNetworkServer"]
 
 import contextlib as _contextlib
 import logging as _logging
+import math
 from collections import Counter, deque
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, final
@@ -220,7 +221,7 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         request_handler = self.__request_handler
         backend = self.__backend
         service_actions_interval = self.__service_actions_interval
-        if service_actions_interval == float("+inf"):
+        if math.isinf(service_actions_interval):
             return
         while True:
             await backend.sleep(service_actions_interval)
@@ -263,6 +264,7 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
                         try:
                             request: _RequestT = self.__protocol.build_packet_from_datagram(datagram)
                         except DatagramProtocolParseError as exc:
+                            exc.sender_address = client.address
                             self.__logger.debug("Malformed request sent by %s", client.address)
                             try:
                                 _recursively_clear_exception_traceback_frames(exc)

--- a/src/easynetwork/api_sync/client/abc.py
+++ b/src/easynetwork/api_sync/client/abc.py
@@ -50,21 +50,20 @@ class AbstractNetworkClient(Generic[_SentPacketT, _ReceivedPacketT], metaclass=A
         raise NotImplementedError
 
     @abstractmethod
-    def send_packet(self, packet: _SentPacketT) -> None:
+    def send_packet(self, packet: _SentPacketT, *, timeout: float | None = ...) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def recv_packet(self, timeout: float | None = ...) -> _ReceivedPacketT:
+    def recv_packet(self, *, timeout: float | None = ...) -> _ReceivedPacketT:
         raise NotImplementedError
 
-    def iter_received_packets(self, timeout: float | None = 0) -> Iterator[_ReceivedPacketT]:
+    def iter_received_packets(self, *, timeout: float | None = 0) -> Iterator[_ReceivedPacketT]:
         perf_counter = time.perf_counter
 
-        recv_packet = self.recv_packet
         while True:
             try:
                 _start = perf_counter()
-                packet = recv_packet(timeout)
+                packet = self.recv_packet(timeout=timeout)
                 _end = perf_counter()
             except OSError:
                 return

--- a/src/easynetwork/exceptions.py
+++ b/src/easynetwork/exceptions.py
@@ -17,7 +17,10 @@ __all__ = [
     "StreamProtocolParseError",
 ]
 
-from typing import Any, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
+
+if TYPE_CHECKING:
+    from .tools.socket import SocketAddress
 
 
 class ClientClosedError(ConnectionError):
@@ -61,7 +64,7 @@ class BaseProtocolParseError(Exception):
 
 
 class DatagramProtocolParseError(BaseProtocolParseError):
-    pass
+    sender_address: SocketAddress
 
 
 class StreamProtocolParseError(BaseProtocolParseError):

--- a/src/easynetwork_asyncio/tasks.py
+++ b/src/easynetwork_asyncio/tasks.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 __all__ = ["Task", "TaskGroup", "TimeoutHandle", "timeout", "timeout_at"]
 
 import asyncio
+import math
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, ParamSpec, Self, TypeVar, final
 
@@ -101,9 +102,6 @@ class TaskGroup(AbstractTaskGroup):
         return Task(self.__asyncio_tg.create_task(__coro_func(*args, **kwargs)))
 
 
-_inf = float("+inf")
-
-
 @final
 class TimeoutHandle(AbstractTimeoutHandle):
     __slots__ = ("__handle",)
@@ -131,11 +129,11 @@ class TimeoutHandle(AbstractTimeoutHandle):
 
     def when(self) -> float:
         deadline: float | None = self.__handle.when()
-        return deadline if deadline is not None else _inf
+        return deadline if deadline is not None else math.inf
 
     def reschedule(self, when: float) -> None:
         assert when is not None
-        return self.__handle.reschedule(when if when != _inf else None)
+        return self.__handle.reschedule(when if when != math.inf else None)
 
     def expired(self) -> bool:
         return self.__handle.expired()
@@ -143,9 +141,9 @@ class TimeoutHandle(AbstractTimeoutHandle):
 
 def timeout(delay: float) -> TimeoutHandle:
     assert delay is not None
-    return TimeoutHandle(asyncio.timeout(delay if delay != _inf else None))
+    return TimeoutHandle(asyncio.timeout(delay if delay != math.inf else None))
 
 
 def timeout_at(deadline: float) -> TimeoutHandle:
     assert deadline is not None
-    return TimeoutHandle(asyncio.timeout_at(deadline if deadline != _inf else None))
+    return TimeoutHandle(asyncio.timeout_at(deadline if deadline != math.inf else None))

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -144,6 +144,7 @@ class MyAsyncTCPRequestHandler(AsyncStreamRequestHandler[str, str]):
                 await client.send_packet(request.upper())
 
     async def bad_request(self, client: AsyncClientInterface[str], exc: BaseProtocolParseError) -> None:
+        assert isinstance(exc, StreamProtocolParseError)
         self.bad_request_received[client.address].append(exc)
         await client.send_packet("wrong encoding man.")
 

--- a/tests/functional_test/test_communication/test_async/test_server/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_udp.py
@@ -89,6 +89,8 @@ class MyAsyncUDPRequestHandler(AsyncBaseRequestHandler[str, str]):
                 await client.send_packet(request.upper())
 
     async def bad_request(self, client: AsyncClientInterface[str], exc: BaseProtocolParseError) -> None:
+        assert isinstance(exc, DatagramProtocolParseError)
+        assert exc.sender_address == client.address
         self.bad_request_received[client.address].append(exc)
         await client.send_packet("wrong encoding man.")
 

--- a/tests/unit_test/test_async/test_api/test_client/test_udp.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_udp.py
@@ -754,6 +754,7 @@ class TestAsyncUDPNetworkEndpoint(BaseTestClient):
         mock_datagram_socket_adapter.recvfrom.assert_awaited_once_with(MAX_DATAGRAM_BUFSIZE)
         mock_datagram_protocol.build_packet_from_datagram.assert_called_once_with(b"packet")
         assert exception is expected_error
+        assert (exception.sender_address.host, exception.sender_address.port) == sender_address
 
     @pytest.mark.usefixtures("setup_protocol_mock")
     async def test____recv_packet_from____closed_client_error(
@@ -846,6 +847,7 @@ class TestAsyncUDPNetworkEndpoint(BaseTestClient):
         mock_datagram_socket_adapter.recvfrom.assert_awaited_once_with(MAX_DATAGRAM_BUFSIZE)
         mock_datagram_protocol.build_packet_from_datagram.assert_called_once_with(b"packet")
         assert exception is expected_error
+        assert (exception.sender_address.host, exception.sender_address.port) == sender_address
 
     @pytest.mark.usefixtures("setup_protocol_mock")
     async def test____iter_received_packets_from____closed_client_during_iteration(

--- a/tests/unit_test/test_protocol.py
+++ b/tests/unit_test/test_protocol.py
@@ -143,6 +143,7 @@ class TestDatagramProtocol:
         assert exception.message == "Deserialization error"
         assert exception.error_info is mocker.sentinel.error_info
         assert exception.__cause__ is mock_serializer.deserialize.side_effect
+        assert not hasattr(exception, "sender_address")
 
     def test____build_packet_from_datagram____conversion_error(
         self,
@@ -169,6 +170,7 @@ class TestDatagramProtocol:
         assert exception.message == "Conversion error"
         assert exception.error_info is mocker.sentinel.error_info
         assert exception.__cause__ is mock_convert_func.side_effect
+        assert not hasattr(exception, "sender_address")
 
 
 class TestStreamProtocol:

--- a/tests/unit_test/test_sync/test_client/test_abc.py
+++ b/tests/unit_test/test_sync/test_client/test_abc.py
@@ -32,7 +32,7 @@ class MockClient(AbstractNetworkClient[Any, Any]):
     def get_remote_address(self) -> SocketAddress:
         raise NotImplementedError
 
-    def send_packet(self, packet: Any) -> None:
+    def send_packet(self, *args: Any, **kwargs: Any) -> None:
         raise NotImplementedError
 
     def recv_packet(self, timeout: float | None = None) -> Any:


### PR DESCRIPTION
## What's changed
- Synchronous clients:
  - Added `timeout` parameter to `send_packet()` method
  - `timeout` parameter is now keyword-only for all methods
- Added `DatagramProtocolParseError.sender_address` attribute
- Minor fixes