### PR TITLE
Synchronous clients: `timeout` parameter is now used for lock acquisition

### DIFF
--- a/src/easynetwork/api_sync/client/tcp.py
+++ b/src/easynetwork/api_sync/client/tcp.py
@@ -33,6 +33,7 @@ from ...tools._utils import (
     concatenate_chunks as _concatenate_chunks,
     error_from_errno as _error_from_errno,
     is_ssl_eof_error as _is_ssl_eof_error,
+    lock_with_timeout as _lock_with_timeout,
     replace_kwargs as _replace_kwargs,
     retry_socket_method as _retry_socket_method,
     retry_ssl_socket_method as _retry_ssl_socket_method,
@@ -282,7 +283,10 @@ class TCPNetworkClient(AbstractNetworkClient[_SentPacketT, _ReceivedPacketT], Ge
                     socket.close()
 
     def send_packet(self, packet: _SentPacketT, *, timeout: float | None = None) -> None:
-        with self.__send_lock.get(), self.__convert_socket_error():
+        with (
+            _lock_with_timeout(self.__send_lock.get(), timeout, error_message="send_packet() timed out") as timeout,
+            self.__convert_socket_error(),
+        ):
             socket = self.__ensure_connected()
             data: bytes = _concatenate_chunks(self.__producer(packet))
             buffer = memoryview(data)
@@ -312,7 +316,10 @@ class TCPNetworkClient(AbstractNetworkClient[_SentPacketT, _ReceivedPacketT], Ge
                 del buffer, data
 
     def recv_packet(self, *, timeout: float | None = None) -> _ReceivedPacketT:
-        with self.__receive_lock.get(), self.__convert_socket_error():
+        with (
+            _lock_with_timeout(self.__receive_lock.get(), timeout, error_message="recv_packet() timed out") as timeout,
+            self.__convert_socket_error(),
+        ):
             consumer = self.__consumer
             try:
                 return next(consumer)  # If there is enough data from last call to create a packet, return immediately

--- a/src/easynetwork/api_sync/client/udp.py
+++ b/src/easynetwork/api_sync/client/udp.py
@@ -25,6 +25,7 @@ from ...tools._utils import (
     check_socket_no_ssl as _check_socket_no_ssl,
     ensure_datagram_socket_bound as _ensure_datagram_socket_bound,
     error_from_errno as _error_from_errno,
+    lock_with_timeout as _lock_with_timeout,
     retry_socket_method as _retry_socket_method,
     set_reuseport as _set_reuseport,
     validate_timeout_delay as _validate_timeout_delay,
@@ -182,7 +183,10 @@ class UDPNetworkEndpoint(Generic[_SentPacketT, _ReceivedPacketT]):
         *,
         timeout: float | None = None,
     ) -> None:
-        with self.__send_lock.get(), self.__convert_socket_error():
+        with (
+            _lock_with_timeout(self.__send_lock.get(), timeout, error_message="send_packet() timed out") as timeout,
+            self.__convert_socket_error(),
+        ):
             if (socket := self.__socket) is None:
                 raise ClientClosedError("Closed client")
             if (remote_addr := self.__peer) is not None:
@@ -206,7 +210,10 @@ class UDPNetworkEndpoint(Generic[_SentPacketT, _ReceivedPacketT]):
                 del data
 
     def recv_packet_from(self, *, timeout: float | None = None) -> tuple[_ReceivedPacketT, SocketAddress]:
-        with self.__receive_lock.get(), self.__convert_socket_error():
+        with (
+            _lock_with_timeout(self.__receive_lock.get(), timeout, error_message="recv_packet() timed out") as timeout,
+            self.__convert_socket_error(),
+        ):
             if (socket := self.__socket) is None:
                 raise ClientClosedError("Closed client")
             retry_interval: float | None = self.__retry_interval

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -9,6 +9,7 @@ __all__ = [
     "error_from_errno",
     "is_ssl_eof_error",
     "is_ssl_socket",
+    "lock_with_timeout",
     "open_listener_sockets_from_getaddrinfo_result",
     "replace_kwargs",
     "retry_socket_method",
@@ -26,6 +27,7 @@ import errno as _errno
 import os
 import selectors as _selectors
 import socket as _socket
+import threading
 import time
 import traceback
 from collections.abc import Callable, Iterable, Iterator
@@ -363,3 +365,26 @@ def recursively_clear_exception_traceback_frames(exc: BaseException) -> None:
         recursively_clear_exception_traceback_frames(exc.__context__)
     if exc.__cause__ is not exc.__context__ and exc.__cause__ is not None:
         recursively_clear_exception_traceback_frames(exc.__cause__)
+
+
+@contextlib.contextmanager
+def lock_with_timeout(
+    lock: threading.RLock | threading.Lock,
+    timeout: float | None,
+    *,
+    error_message: str = "timed out",
+) -> Iterator[float | None]:
+    if timeout is None:
+        with lock:
+            yield None
+        return
+    timeout = validate_timeout_delay(timeout, positive_check=False)
+    _start = time.perf_counter()
+    if not lock.acquire(True, timeout if timeout > 0 else 0.0):
+        raise TimeoutError(error_message)
+    try:
+        _end = time.perf_counter()
+        timeout -= _end - _start
+        yield timeout if timeout > 0 else 0.0
+    finally:
+        lock.release()

--- a/tests/functional_test/test_communication/test_sync/test_client/test_tcp.py
+++ b/tests/functional_test/test_communication/test_sync/test_client/test_tcp.py
@@ -135,7 +135,7 @@ class TestTCPNetworkClient:
                 f.add_done_callback(lambda _: schedule_send(chunks))
 
         schedule_send([b"A", b"B", b"C", b"D", b"E", b"F\n"])
-        with pytest.raises(TimeoutError), TimeTest(0.4, approx=1e-1):
+        with TimeTest(0.4, approx=1e-1), pytest.raises(TimeoutError):
             client.recv_packet(timeout=0.4)
         assert client.recv_packet(timeout=None) == "ABCDEF"
 

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -31,6 +31,10 @@ class TimeTest:
         self.start_time = self._perf_counter()
         return self
 
-    def __exit__(self, *args: Any) -> None:
+    def __exit__(self, exc_type: type[Exception] | None, exc_value: Exception | None, exc_tb: Any) -> None:
+        if exc_type is not None:
+            # If an exception occurred, we cannot say if this respects the execution timeout
+            return
+        assert self.start_time >= 0
         end_time = self._perf_counter()
         assert end_time - self.start_time == pytest.approx(self.expected_time, rel=self.approx)

--- a/tests/unit_test/_utils.py
+++ b/tests/unit_test/_utils.py
@@ -19,7 +19,7 @@ class DummyLock:
     def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None) -> None:
         self.release()
 
-    def acquire(self, blocking: bool = True, timeout: float = 0) -> bool:
+    def acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
         return True
 
     def release(self) -> None:

--- a/tests/unit_test/test_async/conftest.py
+++ b/tests/unit_test/test_async/conftest.py
@@ -22,11 +22,11 @@ class FakeCancellation(BaseException):
     pass
 
 
-@pytest.fixture(scope="package", autouse=True)
-def __mute_socket_getaddrinfo(package_mocker: MockerFixture) -> None:
+@pytest.fixture(scope="module", autouse=True)
+def __mute_socket_getaddrinfo(module_mocker: MockerFixture) -> None:
     from socket import EAI_NONAME, gaierror
 
-    package_mocker.patch("socket.getaddrinfo", autospec=True, side_effect=gaierror(EAI_NONAME, "Name or service not known"))
+    module_mocker.patch("socket.getaddrinfo", autospec=True, side_effect=gaierror(EAI_NONAME, "Name or service not known"))
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit_test/test_sync/conftest.py
+++ b/tests/unit_test/test_sync/conftest.py
@@ -8,10 +8,10 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
-@pytest.fixture(scope="package", autouse=True)
-def dummy_lock_cls(package_mocker: MockerFixture) -> Any:
+@pytest.fixture(scope="module", autouse=True)
+def dummy_lock_cls(module_mocker: MockerFixture) -> Any:
     from .._utils import DummyLock
 
-    package_mocker.patch("threading.Lock", new=DummyLock)
-    package_mocker.patch("threading.RLock", new=DummyLock)
+    module_mocker.patch("threading.Lock", new=DummyLock)
+    module_mocker.patch("threading.RLock", new=DummyLock)
     return DummyLock

--- a/tests/unit_test/test_sync/test_client/base.py
+++ b/tests/unit_test/test_sync/test_client/base.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import contextlib
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
 
 from ...base import BaseTestSocket
 
@@ -15,3 +17,9 @@ class BaseTestClient(BaseTestSocket):
     def selector_timeout_after_n_calls(mock_selector_select: MagicMock, mocker: MockerFixture, nb_calls: int) -> None:
         key = mocker.sentinel.key
         mock_selector_select.side_effect = [[key] for _ in range(nb_calls)] + [[]]
+
+
+@contextlib.contextmanager
+def dummy_lock_with_timeout(lock: Any, timeout: float | None, *args: Any, **kwargs: Any) -> Iterator[float | None]:
+    with lock:
+        yield timeout

--- a/tests/unit_test/test_sync/test_client/test_tcp.py
+++ b/tests/unit_test/test_sync/test_client/test_tcp.py
@@ -27,12 +27,19 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 from ...base import UNSUPPORTED_FAMILIES
-from .base import BaseTestClient
+from .base import BaseTestClient, dummy_lock_with_timeout
 
 
 @pytest.fixture(autouse=True)
 def remove_ssl_OP_IGNORE_UNEXPECTED_EOF(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delattr("ssl.OP_IGNORE_UNEXPECTED_EOF", raising=False)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def patch_lock_with_timeout(module_mocker: MockerFixture) -> None:
+    module = TCPNetworkClient.__module__
+
+    module_mocker.patch(f"{module}._lock_with_timeout", new=dummy_lock_with_timeout)
 
 
 class TestTCPNetworkClient(BaseTestClient):

--- a/tests/unit_test/test_sync/test_client/test_udp.py
+++ b/tests/unit_test/test_sync/test_client/test_udp.py
@@ -19,7 +19,14 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 from ...base import UNSUPPORTED_FAMILIES
-from .base import BaseTestClient
+from .base import BaseTestClient, dummy_lock_with_timeout
+
+
+@pytest.fixture(autouse=True, scope="module")
+def patch_lock_with_timeout(module_mocker: MockerFixture) -> None:
+    module = UDPNetworkEndpoint.__module__
+
+    module_mocker.patch(f"{module}._lock_with_timeout", new=dummy_lock_with_timeout)
 
 
 class TestUDPNetworkEndpoint(BaseTestClient):

--- a/tests/unit_test/test_tools/test_lock.py
+++ b/tests/unit_test/test_tools/test_lock.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 
 from easynetwork.tools.lock import ForkSafeLock
 
+import pytest
+
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
@@ -14,7 +16,17 @@ if TYPE_CHECKING:
 
 
 class TestForkSafeLock:
-    def test____dunder_init____create_threading_RLock_by_default(self) -> None:
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def RLock() -> type[threading.RLock]:
+        return type(threading.RLock())
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def Lock() -> type[threading.Lock]:
+        return type(threading.Lock())
+
+    def test____dunder_init____create_threading_RLock_by_default(self, RLock: type[threading.RLock]) -> None:
         # Arrange
         safe_lock = ForkSafeLock()
 
@@ -22,9 +34,9 @@ class TestForkSafeLock:
         lock = safe_lock.get()
 
         # Assert
-        assert isinstance(lock, threading.RLock)
+        assert isinstance(lock, RLock)
 
-    def test____dunder_init____custom_lock_factory(self, mocker: MockerFixture) -> None:
+    def test____dunder_init____custom_lock_factory(self, mocker: MockerFixture, Lock: type[threading.Lock]) -> None:
         # Arrange
         lock_factory: MagicMock = mocker.MagicMock(side_effect=threading.Lock)
         safe_lock: ForkSafeLock[threading.Lock] = ForkSafeLock(lock_factory)
@@ -34,7 +46,7 @@ class TestForkSafeLock:
 
         # Assert
         lock_factory.assert_called_once_with()
-        assert isinstance(lock, threading.Lock)
+        assert isinstance(lock, Lock)
 
     def test____get____always_return_the_same_lock_object(self, mocker: MockerFixture) -> None:
         # Arrange


### PR DESCRIPTION
## What's changed
For `TCPNetworkClient`, `UDPNetworkEndpoint` and `UDPNetworkClient`:
- The `timeout` parameter is used for `threading.Lock.acquire()` and the caller is no longer stuck because an other thread took the lock
- The waiting time for lock acquisition is deduced from the timeout given for the operation
  - For example, if `recv_packet(timeout=3)` took 1 second to acquire the lock, the socket operation timeout is 2 seconds