### PR TITLE
Fixed TCP server issues after calling `listener.accept()` in specific cases

### DIFF
--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -23,6 +23,7 @@ from ...protocol import DatagramProtocol
 from ...tools._utils import (
     check_real_socket_state as _check_real_socket_state,
     recursively_clear_exception_traceback_frames as _recursively_clear_exception_traceback_frames,
+    remove_traceback_frames_in_place as _remove_traceback_frames_in_place,
 )
 from ...tools.socket import MAX_DATAGRAM_BUFSIZE, SocketAddress, SocketProxy, new_socket_address
 from ..backend.factory import AsyncBackendFactory
@@ -133,7 +134,8 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             socket, self.__socket = self.__socket, None
             if socket is None:
                 return
-            await socket.aclose()
+            with _contextlib.suppress(OSError):
+                await socket.aclose()
 
     async def shutdown(self) -> None:
         self.__stop_mainloop()
@@ -360,7 +362,8 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
     def __suppress_and_log_remaining_exception(self, client_address: SocketAddress) -> Iterator[None]:
         try:
             yield
-        except Exception:
+        except Exception as exc:
+            _remove_traceback_frames_in_place(exc, 1)  # Removes the 'yield' frame just above
             self.__logger.error("-" * 40)
             self.__logger.exception("Exception occurred during processing of request from %s", client_address)
             self.__logger.error("-" * 40)

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -7,14 +7,17 @@ __all__ = [
     "concatenate_chunks",
     "ensure_datagram_socket_bound",
     "error_from_errno",
+    "get_socket_linger_struct",
     "is_ssl_eof_error",
     "is_ssl_socket",
     "lock_with_timeout",
     "open_listener_sockets_from_getaddrinfo_result",
+    "remove_traceback_frames_in_place",
     "replace_kwargs",
     "retry_socket_method",
     "retry_ssl_socket_method",
     "set_reuseport",
+    "set_socket_linger",
     "set_tcp_nodelay",
     "transform_future_exception",
     "validate_timeout_delay",
@@ -32,6 +35,7 @@ import time
 import traceback
 from collections.abc import Callable, Iterable, Iterator
 from math import isinf, isnan
+from struct import Struct
 from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypeGuard, TypeVar, assert_never
 
 try:
@@ -291,6 +295,27 @@ def set_tcp_keepalive(sock: SupportsSocketOptions) -> None:
         pass
 
 
+if os.name == "nt":  # Windows
+    # https://learn.microsoft.com/en-us/windows/win32/api/winsock2/ns-winsock2-linger
+    # linger struct uses unsigned short ints
+    _linger_struct = Struct("@HH")
+else:  # Unix/macOS
+    # https://manpages.debian.org/bookworm/manpages/socket.7.en.html#SO_LINGER
+    # linger struct uses signed ints
+    _linger_struct = Struct("@ii")
+
+
+def get_socket_linger_struct() -> Struct:
+    return _linger_struct
+
+
+def set_socket_linger(sock: SupportsSocketOptions, timeout: int | None) -> None:
+    if timeout is None:
+        sock.setsockopt(_socket.SOL_SOCKET, _socket.SO_LINGER, _linger_struct.pack(False, 0))
+    else:
+        sock.setsockopt(_socket.SOL_SOCKET, _socket.SO_LINGER, _linger_struct.pack(True, timeout))
+
+
 def open_listener_sockets_from_getaddrinfo_result(
     infos: Iterable[tuple[int, int, int, str, tuple[Any, ...]]],
     *,
@@ -365,6 +390,13 @@ def recursively_clear_exception_traceback_frames(exc: BaseException) -> None:
         recursively_clear_exception_traceback_frames(exc.__context__)
     if exc.__cause__ is not exc.__context__ and exc.__cause__ is not None:
         recursively_clear_exception_traceback_frames(exc.__cause__)
+
+
+def remove_traceback_frames_in_place(exc: BaseException, n: int) -> None:
+    for _ in range(n):
+        if exc.__traceback__ is None:
+            break
+        exc.__traceback__ = exc.__traceback__.tb_next
 
 
 @contextlib.contextmanager

--- a/src/easynetwork_asyncio/datagram/socket.py
+++ b/src/easynetwork_asyncio/datagram/socket.py
@@ -26,7 +26,10 @@ if TYPE_CHECKING:
 
 @final
 class AsyncioTransportDatagramSocketAdapter(AbstractAsyncDatagramSocketAdapter):
-    __slots__ = ("__endpoint",)
+    __slots__ = (
+        "__endpoint",
+        "__socket",
+    )
 
     def __init__(self, endpoint: DatagramEndpoint) -> None:
         super().__init__()
@@ -34,6 +37,8 @@ class AsyncioTransportDatagramSocketAdapter(AbstractAsyncDatagramSocketAdapter):
 
         socket: asyncio.trsock.TransportSocket | None = endpoint.get_extra_info("socket")
         assert socket is not None, "transport must be a socket transport"
+
+        self.__socket: asyncio.trsock.TransportSocket = socket
 
     async def aclose(self) -> None:
         try:
@@ -62,8 +67,7 @@ class AsyncioTransportDatagramSocketAdapter(AbstractAsyncDatagramSocketAdapter):
         await self.__endpoint.sendto(memoryview(data), address)
 
     def socket(self) -> asyncio.trsock.TransportSocket:
-        socket: asyncio.trsock.TransportSocket = self.__endpoint.get_extra_info("socket")
-        return socket
+        return self.__socket
 
 
 @final

--- a/src/easynetwork_asyncio/stream/socket.py
+++ b/src/easynetwork_asyncio/stream/socket.py
@@ -29,7 +29,7 @@ class AsyncioTransportStreamSocketAdapter(AbstractAsyncStreamSocketAdapter):
     __slots__ = (
         "__reader",
         "__writer",
-        "__remote_addr",
+        "__socket",
     )
 
     def __init__(
@@ -43,10 +43,7 @@ class AsyncioTransportStreamSocketAdapter(AbstractAsyncStreamSocketAdapter):
 
         socket: asyncio.trsock.TransportSocket | None = writer.get_extra_info("socket")
         assert socket is not None, "Writer transport must be a socket transport"
-        remote_address = writer.get_extra_info("peername")
-        if remote_address is None:
-            raise _error_from_errno(errno.ENOTCONN)
-        self.__remote_addr: tuple[Any, ...] = tuple(remote_address)
+        self.__socket: asyncio.trsock.TransportSocket = socket
 
     async def aclose(self) -> None:
         try:
@@ -64,7 +61,10 @@ class AsyncioTransportStreamSocketAdapter(AbstractAsyncStreamSocketAdapter):
         return self.__writer.get_extra_info("sockname")
 
     def get_remote_address(self) -> tuple[Any, ...]:
-        return self.__remote_addr
+        remote_address: tuple[Any, ...] | None = self.__writer.get_extra_info("peername")
+        if remote_address is None:
+            raise _error_from_errno(errno.ENOTCONN)
+        return remote_address
 
     async def recv(self, bufsize: int, /) -> bytes:
         if bufsize < 0:
@@ -78,8 +78,7 @@ class AsyncioTransportStreamSocketAdapter(AbstractAsyncStreamSocketAdapter):
         await self.__writer.drain()
 
     def socket(self) -> asyncio.trsock.TransportSocket:
-        socket: asyncio.trsock.TransportSocket = self.__writer.get_extra_info("socket")
-        return socket
+        return self.__socket
 
 
 @final

--- a/tests/functional_test/test_communication/conftest.py
+++ b/tests/functional_test/test_communication/conftest.py
@@ -24,7 +24,12 @@ _SUPPORTED_FAMILIES = tuple(_FAMILY_TO_LOCALHOST)
 
 @pytest.fixture(params=_SUPPORTED_FAMILIES, ids=lambda f: str(getattr(f, "name", f)))
 def socket_family(request: Any) -> int:
-    return request.param
+    family: str | int = request.param
+    if isinstance(family, str):
+        import socket as _socket
+
+        family = _socket.AddressFamily(getattr(_socket, family))
+    return family
 
 
 @pytest.fixture


### PR DESCRIPTION
## What's changed - TCP server
- If the remote client closes the connection immediately after a connection attempt, the server emits a warning instead of having an `OSError` traceback.
In practice, this should never happen, unless the server is the target of a DOS attack.
- The server now resets the connection (and so causes a `ECONNRESET` error for the remote side) in the following cases:
  - The request handler did not `yield` at all
  - There has been an uncaught `OSError` exception
  - `AsyncClientInterface.aclose()` did not close the socket at task tear-down