### PR TITLE
Improved writing operations when sending a packet over TCP

### DIFF
--- a/src/easynetwork/api_async/backend/abc.py
+++ b/src/easynetwork/api_async/backend/abc.py
@@ -26,7 +26,7 @@ __all__ = [
 import contextvars
 import math
 from abc import ABCMeta, abstractmethod
-from collections.abc import Callable, Coroutine, Sequence
+from collections.abc import Callable, Coroutine, Iterable, Sequence
 from contextlib import AbstractAsyncContextManager as AsyncContextManager
 from typing import TYPE_CHECKING, Any, Generic, NoReturn, ParamSpec, Protocol, Self, TypeVar
 
@@ -35,8 +35,6 @@ if TYPE_CHECKING:
     import socket as _socket
     import ssl as _ssl
     from types import TracebackType
-
-    from _typeshed import ReadableBuffer
 
     from ...tools.socket import ISocket
 
@@ -211,8 +209,11 @@ class AbstractAsyncStreamSocketAdapter(AbstractAsyncBaseSocketAdapter):
         raise NotImplementedError
 
     @abstractmethod
-    async def sendall(self, __data: ReadableBuffer, /) -> None:
+    async def sendall(self, __data: bytes, /) -> None:
         raise NotImplementedError
+
+    async def sendall_fromiter(self, iterable_of_data: Iterable[bytes], /) -> None:
+        await self.sendall(b"".join(iterable_of_data))
 
 
 class AbstractAsyncDatagramSocketAdapter(AbstractAsyncBaseSocketAdapter):
@@ -227,7 +228,7 @@ class AbstractAsyncDatagramSocketAdapter(AbstractAsyncBaseSocketAdapter):
         raise NotImplementedError
 
     @abstractmethod
-    async def sendto(self, __data: ReadableBuffer, __address: tuple[Any, ...] | None, /) -> None:
+    async def sendto(self, __data: bytes, __address: tuple[Any, ...] | None, /) -> None:
         raise NotImplementedError
 
 

--- a/src/easynetwork/api_async/client/tcp.py
+++ b/src/easynetwork/api_async/client/tcp.py
@@ -27,7 +27,6 @@ from ...tools._utils import (
     check_real_socket_state as _check_real_socket_state,
     check_socket_family as _check_socket_family,
     check_socket_no_ssl as _check_socket_no_ssl,
-    concatenate_chunks as _concatenate_chunks,
     error_from_errno as _error_from_errno,
     set_tcp_keepalive as _set_tcp_keepalive,
     set_tcp_nodelay as _set_tcp_nodelay,
@@ -268,7 +267,7 @@ class AsyncTCPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
         async with self.__send_lock:
             with self.__convert_socket_error():
                 socket = await self.__ensure_connected()
-                await socket.sendall(_concatenate_chunks(self.__producer(packet)))
+                await socket.sendall_fromiter(self.__producer(packet))
                 _check_real_socket_state(self.socket)
 
     async def recv_packet(self) -> _ReceivedPacketT:

--- a/src/easynetwork/api_sync/client/tcp.py
+++ b/src/easynetwork/api_sync/client/tcp.py
@@ -30,7 +30,6 @@ from ...tools._utils import (
     check_real_socket_state as _check_real_socket_state,
     check_socket_family as _check_socket_family,
     check_socket_no_ssl as _check_socket_no_ssl,
-    concatenate_chunks as _concatenate_chunks,
     error_from_errno as _error_from_errno,
     is_ssl_eof_error as _is_ssl_eof_error,
     lock_with_timeout as _lock_with_timeout,
@@ -288,13 +287,13 @@ class TCPNetworkClient(AbstractNetworkClient[_SentPacketT, _ReceivedPacketT], Ge
             self.__convert_socket_error(),
         ):
             socket = self.__ensure_connected()
-            data: bytes = _concatenate_chunks(self.__producer(packet))
+            data: bytes = b"".join(self.__producer(packet))
             buffer = memoryview(data)
             assert buffer.itemsize == 1
             perf_counter = time.perf_counter  # pull function to local namespace
             retry_interval: float | None = self.__retry_interval
             try:
-                remaining: int = len(data)
+                remaining: int = buffer.nbytes
                 while remaining > 0:
                     sent: int
                     try:

--- a/src/easynetwork/serializers/abc.py
+++ b/src/easynetwork/serializers/abc.py
@@ -15,7 +15,6 @@ from collections.abc import Generator
 from typing import Any, Generic, TypeVar
 
 from ..exceptions import DeserializeError
-from ..tools._utils import concatenate_chunks as _concatenate_chunks
 
 _ST_contra = TypeVar("_ST_contra", contravariant=True)
 _DT_co = TypeVar("_DT_co", covariant=True)
@@ -48,7 +47,7 @@ class AbstractIncrementalPacketSerializer(AbstractPacketSerializer[_ST_contra, _
         raise NotImplementedError
 
     def serialize(self, packet: _ST_contra) -> bytes:
-        return _concatenate_chunks(self.incremental_serialize(packet))
+        return b"".join(self.incremental_serialize(packet))
 
     def deserialize(self, data: bytes) -> _DT_co:
         consumer: Generator[None, bytes, tuple[_DT_co, bytes]] = self.incremental_deserialize()

--- a/src/easynetwork/serializers/base_stream.py
+++ b/src/easynetwork/serializers/base_stream.py
@@ -189,16 +189,19 @@ class FileBasedPacketSerializer(AbstractPacketSerializer[_ST_contra, _DT_co]):
     def incremental_serialize(self, packet: _ST_contra) -> Generator[bytes, None, None]:
         with BytesIO() as buffer:
             self.dump_to_file(packet, buffer)
+            if buffer.getbuffer().nbytes == 0:
+                return
             data = buffer.getvalue()
-        if data:
-            yield data
+        yield data
 
     @final
     def incremental_deserialize(self) -> Generator[None, bytes, tuple[_DT_co, bytes]]:
-        with BytesIO() as buffer:
+        with BytesIO((yield)) as buffer:
+            initial: bool = True
             while True:
-                buffer.write((yield))
-                buffer.seek(0)
+                if not initial:
+                    buffer.write((yield))
+                    buffer.seek(0)
                 try:
                     packet: _DT_co = self.load_from_file(buffer)
                 except EOFError:
@@ -214,3 +217,5 @@ class FileBasedPacketSerializer(AbstractPacketSerializer[_ST_contra, _DT_co]):
                     ) from exc
                 else:
                     return packet, buffer.read()
+                finally:
+                    initial = False

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -4,7 +4,6 @@ __all__ = [
     "check_real_socket_state",
     "check_socket_family",
     "check_socket_no_ssl",
-    "concatenate_chunks",
     "ensure_datagram_socket_bound",
     "error_from_errno",
     "get_socket_linger_struct",
@@ -246,10 +245,6 @@ def is_ssl_eof_error(exc: BaseException) -> TypeGuard[_SSLError]:
             # project.
             return True
     return False
-
-
-def concatenate_chunks(chunks_iterable: Iterable[bytes]) -> bytes:
-    return b"".join(chunks_iterable)
 
 
 def iter_bytes(b: bytes | bytearray | memoryview) -> Iterator[bytes]:

--- a/src/easynetwork_asyncio/datagram/socket.py
+++ b/src/easynetwork_asyncio/datagram/socket.py
@@ -19,8 +19,6 @@ from ..socket import AsyncSocket
 if TYPE_CHECKING:
     import asyncio.trsock
 
-    from _typeshed import ReadableBuffer
-
     from .endpoint import DatagramEndpoint
 
 
@@ -63,8 +61,8 @@ class AsyncioTransportDatagramSocketAdapter(AbstractAsyncDatagramSocketAdapter):
             data = data[:bufsize]
         return data, address
 
-    async def sendto(self, data: ReadableBuffer, address: tuple[Any, ...] | None, /) -> None:
-        await self.__endpoint.sendto(memoryview(data), address)
+    async def sendto(self, data: bytes, address: tuple[Any, ...] | None, /) -> None:
+        await self.__endpoint.sendto(data, address)
 
     def socket(self) -> asyncio.trsock.TransportSocket:
         return self.__socket
@@ -103,7 +101,7 @@ class RawDatagramSocketAdapter(AbstractAsyncDatagramSocketAdapter):
     async def recvfrom(self, bufsize: int, /) -> tuple[bytes, tuple[Any, ...]]:
         return await self.__socket.recvfrom(bufsize)
 
-    async def sendto(self, data: ReadableBuffer, address: tuple[Any, ...] | None, /) -> None:
+    async def sendto(self, data: bytes, address: tuple[Any, ...] | None, /) -> None:
         if address is None:
             await self.__socket.sendall(data)
         else:

--- a/tests/unit_test/test_async/conftest.py
+++ b/tests/unit_test/test_async/conftest.py
@@ -55,6 +55,7 @@ def mock_backend(fake_cancellation_cls: type[BaseException], mocker: MockerFixtu
 def mock_stream_socket_adapter_factory(mocker: MockerFixture) -> Callable[[], MagicMock]:
     def factory() -> MagicMock:
         mock = mocker.NonCallableMagicMock(spec=AbstractAsyncStreamSocketAdapter)
+        mock.sendall_fromiter = mocker.MagicMock(side_effect=lambda iterable_of_data: mock.sendall(b"".join(iterable_of_data)))
         mock.is_closing.return_value = False
         return mock
 

--- a/tests/unit_test/test_async/test_api/test_client/test_tcp.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_tcp.py
@@ -969,6 +969,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
 
         # Assert
         mock_stream_protocol.generate_chunks.assert_called_once_with(mocker.sentinel.packet)
+        mock_stream_socket_adapter.sendall_fromiter.assert_called_once()
         mock_stream_socket_adapter.sendall.assert_awaited_once_with(b"packet\n")
         mock_tcp_socket.getsockopt.assert_called_once_with(SOL_SOCKET, SO_ERROR)
 
@@ -994,6 +995,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
         # Assert
         assert exc_info.value.errno == EBUSY
         mock_stream_protocol.generate_chunks.assert_called_once_with(mocker.sentinel.packet)
+        mock_stream_socket_adapter.sendall_fromiter.assert_called_once()
         mock_stream_socket_adapter.sendall.assert_awaited_once_with(b"packet\n")
         mock_tcp_socket.getsockopt.assert_called_once_with(SOL_SOCKET, SO_ERROR)
 
@@ -1016,6 +1018,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
 
         # Assert
         mock_stream_protocol.generate_chunks.assert_not_called()
+        mock_stream_socket_adapter.sendall_fromiter.assert_not_called()
         mock_stream_socket_adapter.sendall.assert_not_called()
         mock_tcp_socket.getsockopt.assert_not_called()
 
@@ -1037,6 +1040,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
 
         # Assert
         mock_stream_protocol.generate_chunks.assert_not_called()
+        mock_stream_socket_adapter.sendall_fromiter.assert_not_called()
         mock_stream_socket_adapter.sendall.assert_not_awaited()
         mock_tcp_socket.getsockopt.assert_not_called()
 
@@ -1058,6 +1062,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
 
         # Assert
         mock_stream_protocol.generate_chunks.assert_called_once_with(mocker.sentinel.packet)
+        mock_stream_socket_adapter.sendall_fromiter.assert_called_once()
         mock_stream_socket_adapter.sendall.assert_awaited_once_with(b"packet\n")
         mock_tcp_socket.getsockopt.assert_not_called()
 
@@ -1081,6 +1086,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
 
         # Assert
         mock_stream_protocol.generate_chunks.assert_called_once_with(mocker.sentinel.packet)
+        mock_stream_socket_adapter.sendall_fromiter.assert_called_once()
         mock_stream_socket_adapter.sendall.assert_awaited_once_with(b"packet\n")
         mock_tcp_socket.getsockopt.assert_not_called()
 
@@ -1297,6 +1303,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
 
         # Assert
         mock_stream_protocol.generate_chunks.assert_not_called()
+        mock_stream_socket_adapter.sendall_fromiter.assert_not_called()
         mock_stream_socket_adapter.sendall.assert_not_called()
 
     @pytest.mark.usefixtures("setup_consumer_mock")

--- a/tests/unit_test/test_tools/test_utils.py
+++ b/tests/unit_test/test_tools/test_utils.py
@@ -26,7 +26,6 @@ from easynetwork.tools._utils import (
     check_real_socket_state,
     check_socket_family,
     check_socket_no_ssl,
-    concatenate_chunks,
     ensure_datagram_socket_bound,
     error_from_errno,
     get_socket_linger_struct,
@@ -393,18 +392,6 @@ def test____validate_timeout_delay____not_a_number(positive_check: bool) -> None
     # Act & Assert
     with pytest.raises(ValueError, match=r"^Invalid delay: NaN \(not a number\)$"):
         validate_timeout_delay(delay, positive_check=positive_check)
-
-
-def test____concanetate_chunks____join_several_bytestrings() -> None:
-    # Arrange
-    to_join = [b"a", b"b", b"cd", b"", b"efgh"]
-    expected_result = b"abcdefgh"
-
-    # Act
-    result = concatenate_chunks(to_join)
-
-    # Assert
-    assert result == expected_result
 
 
 def test____iter_bytes____iterate_over_bytes_returning_one_byte() -> None:


### PR DESCRIPTION
## What's changed
- Added `AbstractStreamSocketAdapter.sendall_fromiter()` method
- Avoid concatenating data parts sent by serializer's `incremental_serialize()` generator wherever possible
  - Currently useful only for `asyncio.SSLProtocol`