### PR TITLE
General improvement on servers

### DIFF
--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -14,7 +14,7 @@ import math
 import operator
 import weakref
 from collections import Counter, deque
-from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterator, Mapping
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, assert_never, final
 from weakref import WeakValueDictionary
 
@@ -22,6 +22,7 @@ from ...exceptions import ClientClosedError, DatagramProtocolParseError, ServerA
 from ...protocol import DatagramProtocol
 from ...tools._utils import (
     check_real_socket_state as _check_real_socket_state,
+    make_callback as _make_callback,
     recursively_clear_exception_traceback_frames as _recursively_clear_exception_traceback_frames,
     remove_traceback_frames_in_place as _remove_traceback_frames_in_place,
 )
@@ -56,6 +57,7 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         "__backend",
         "__socket",
         "__socket_factory",
+        "__socket_factory_runner",
         "__protocol",
         "__request_handler",
         "__is_shutdown",
@@ -88,14 +90,14 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
 
         assert isinstance(protocol, DatagramProtocol)
 
-        self.__socket_factory: SingleTaskRunner[AbstractAsyncDatagramSocketAdapter] | None
-        self.__socket_factory = SingleTaskRunner(
-            backend,
+        self.__socket_factory: Callable[[], Coroutine[Any, Any, AbstractAsyncDatagramSocketAdapter]] | None
+        self.__socket_factory = _make_callback(
             backend.create_udp_endpoint,
             local_address=(host, port),
             remote_address=None,
             reuse_port=reuse_port,
         )
+        self.__socket_factory_runner: SingleTaskRunner[AbstractAsyncDatagramSocketAdapter] | None = None
 
         if service_actions_interval is None:
             service_actions_interval = 1.0
@@ -121,25 +123,32 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         self.__client_task_running: set[_ClientAPI[_ResponseT]] = set()
 
     def is_serving(self) -> bool:
-        return self.__socket is not None
+        return (socket := self.__socket) is not None and not socket.is_closing()
 
     async def server_close(self) -> None:
-        if self.__socket_factory is not None:
-            self.__socket_factory.cancel()
-            self.__socket_factory = None
-        self.__stop_mainloop()
+        self.__kill_socket_factory_runner()
+        self.__socket_factory = None
         await self.__close_socket()
 
     async def __close_socket(self) -> None:
-        async with self.__sendto_lock:
+        async with _contextlib.AsyncExitStack() as exit_stack:
             socket, self.__socket = self.__socket, None
-            if socket is None:
-                return
-            with _contextlib.suppress(OSError):
-                await socket.aclose()
+            if socket is not None:
+
+                async def close_socket(socket: AbstractAsyncDatagramSocketAdapter) -> None:
+                    with _contextlib.suppress(OSError):
+                        await socket.aclose()
+
+                exit_stack.push_async_callback(close_socket, socket)
+
+            if self.__mainloop_task is not None:
+                self.__mainloop_task.cancel()
+                exit_stack.push_async_callback(self.__mainloop_task.wait)
 
     async def shutdown(self) -> None:
-        self.__stop_mainloop()
+        self.__kill_socket_factory_runner()
+        if self.__mainloop_task is not None:
+            self.__mainloop_task.cancel()
         if self.__shutdown_asked:
             await self.__is_shutdown.wait()
             return
@@ -149,35 +158,38 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         finally:
             self.__shutdown_asked = False
 
-    def __stop_mainloop(self) -> None:
-        if self.__mainloop_task is not None:
-            self.__mainloop_task.cancel()
-            self.__mainloop_task = None
+    def __kill_socket_factory_runner(self) -> None:
+        if self.__socket_factory_runner is not None:
+            self.__socket_factory_runner.cancel()
 
     async def serve_forever(self, *, is_up_event: IEvent | None = None) -> None:
-        if not self.__is_shutdown.is_set():
-            raise ServerAlreadyRunning("Server is already running")
-
         async with _contextlib.AsyncExitStack() as server_exit_stack:
-            # Wake up server
-            self.__is_shutdown = is_shutdown = self.__backend.create_event()
-            server_exit_stack.callback(is_shutdown.set)
             if is_up_event is not None:
                 # Force is_up_event to be set, in order not to stuck the waiting task
                 server_exit_stack.callback(is_up_event.set)
+
+            # Wake up server
+            if not self.__is_shutdown.is_set():
+                raise ServerAlreadyRunning("Server is already running")
+            self.__is_shutdown = is_shutdown = self.__backend.create_event()
+            server_exit_stack.callback(is_shutdown.set)
             ################
 
             # Bind and activate
             assert self.__socket is None
+            assert self.__socket_factory_runner is None
             if self.__socket_factory is None:
                 raise ServerClosedError("Closed server")
-            self.__socket = await self.__socket_factory.run()
-            self.__socket_factory = None
+            try:
+                self.__socket_factory_runner = SingleTaskRunner(self.__backend, self.__socket_factory)
+                self.__socket = await self.__socket_factory_runner.run()
+            finally:
+                self.__socket_factory_runner = None
             ###################
 
             # Final teardown
             server_exit_stack.callback(self.__logger.info, "Server stopped")
-            server_exit_stack.push_async_callback(lambda: self.__backend.ignore_cancellation(self.server_close()))
+            server_exit_stack.push_async_callback(lambda: self.__backend.ignore_cancellation(self.__close_socket()))
             ################
 
             # Initialize request handler
@@ -204,22 +216,22 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             ##############
 
             # Main loop
-            self.__mainloop_task = task_group.start_soon(self.__receive_datagrams_task, self.__socket, task_group)
+            self.__mainloop_task = task_group.start_soon(self.__receive_datagrams, self.__socket, task_group)
             if self.__shutdown_asked:
                 self.__mainloop_task.cancel()
             try:
-                await self.__mainloop_task.join()
+                await self.__mainloop_task.join_or_cancel()
             finally:
                 self.__mainloop_task = None
 
-    async def __receive_datagrams_task(
+    async def __receive_datagrams(
         self,
         socket: AbstractAsyncDatagramSocketAdapter,
         task_group: AbstractTaskGroup,
     ) -> None:
         backend = self.__backend
         socket_family: int = socket.socket().family
-        datagram_received_task_method = self.__datagram_received_task
+        datagram_received_task_method = self.__datagram_received_coroutine
         logger: _logging.Logger = self.__logger
         bufsize: int = MAX_DATAGRAM_BUFSIZE
         client_manager: _ClientAPIManager[_ResponseT] = self.__client_manager
@@ -261,7 +273,7 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             except Exception:
                 self.__logger.exception("Error occurred in request_handler.service_actions()")
 
-    async def __datagram_received_task(
+    async def __datagram_received_coroutine(
         self,
         client: _ClientAPI[_ResponseT],
         task_group: AbstractTaskGroup,
@@ -398,9 +410,9 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         finally:
             if datagram_queue:
                 try:
-                    task_group.start_soon_with_context(default_context, self.__datagram_received_task, client, task_group)
+                    task_group.start_soon_with_context(default_context, self.__datagram_received_coroutine, client, task_group)
                 except NotImplementedError:
-                    default_context.run(task_group.start_soon, self.__datagram_received_task, client, task_group)  # type: ignore[arg-type]
+                    default_context.run(task_group.start_soon, self.__datagram_received_coroutine, client, task_group)  # type: ignore[arg-type]
 
     @_contextlib.contextmanager
     def __client_task_running_context(self, client: _ClientAPI[_ResponseT]) -> Iterator[None]:
@@ -518,7 +530,7 @@ class _TemporaryValue(Generic[_KT, _VT]):
             assert self.__counter[key] >= 0, f"{self.__counter[key]=}"
             if self.__counter[key] == 0 and self.__must_delete_value(value):
                 del self.__counter[key], self.__values[key]
-            del key
+            del key, value
 
 
 @final

--- a/src/easynetwork/api_sync/server/_base.py
+++ b/src/easynetwork/api_sync/server/_base.py
@@ -10,19 +10,23 @@ __all__ = ["BaseStandaloneNetworkServerImpl"]
 import contextlib as _contextlib
 import threading as _threading
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
-from ...exceptions import ServerAlreadyRunning
+from ...exceptions import ServerAlreadyRunning, ServerClosedError
+from ...tools.lock import ForkSafeLock
 from .abc import AbstractStandaloneNetworkServer
 
 if TYPE_CHECKING:
-    from ...api_async.backend.abc import AbstractThreadsPortal, IEvent
+    from ...api_async.backend.abc import AbstractRunner, AbstractThreadsPortal, IEvent
     from ...api_async.server.abc import AbstractAsyncNetworkServer
 
 
 class BaseStandaloneNetworkServerImpl(AbstractStandaloneNetworkServer):
     __slots__ = (
         "__server",
+        "__runner",
+        "__close_lock",
+        "__bootstrap_lock",
         "__threads_portal",
         "__is_shutdown",
     )
@@ -33,6 +37,14 @@ class BaseStandaloneNetworkServerImpl(AbstractStandaloneNetworkServer):
         self.__threads_portal: AbstractThreadsPortal | None = None
         self.__is_shutdown = _threading.Event()
         self.__is_shutdown.set()
+        self.__runner: AbstractRunner | None = self.__server.get_backend().new_runner()
+        self.__close_lock = ForkSafeLock()
+        self.__bootstrap_lock = ForkSafeLock()
+
+    def __enter__(self) -> Self:
+        assert self.__runner is not None, "Server is entered twice"
+        self.__runner.__enter__()
+        return super().__enter__()
 
     def is_serving(self) -> bool:
         if (portal := self.__threads_portal) is not None:
@@ -41,13 +53,18 @@ class BaseStandaloneNetworkServerImpl(AbstractStandaloneNetworkServer):
         return False
 
     def server_close(self) -> None:
-        backend = self.__server.get_backend()
-        if (portal := self.__threads_portal) is not None:
-            with _contextlib.suppress(RuntimeError):
-                portal.run_coroutine(lambda: backend.ignore_cancellation(self.__server.server_close()))
-        else:
-            self.__is_shutdown.wait()  # Ensure we are not in the interval between the server shutdown and the scheduler shutdown
-            backend.bootstrap(self.__server.server_close)
+        with self.__close_lock.get(), _contextlib.ExitStack() as stack, _contextlib.suppress(RuntimeError):
+            if (portal := self.__threads_portal) is not None:
+                CancelledError = self.__server.get_backend().get_cancelled_exc_class()
+                with _contextlib.suppress(CancelledError):
+                    portal.run_coroutine(self.__server.server_close)
+            else:
+                runner, self.__runner = self.__runner, None
+                if runner is None:
+                    return
+                stack.push(runner)
+                self.__is_shutdown.wait()  # Ensure we are not in the interval between the server shutdown and the scheduler shutdown
+                runner.run(self.__server.server_close)
 
     def shutdown(self, timeout: float | None = None) -> None:
         if (portal := self.__threads_portal) is not None:
@@ -71,34 +88,50 @@ class BaseStandaloneNetworkServerImpl(AbstractStandaloneNetworkServer):
                 await self.__server.shutdown()
 
     def serve_forever(self, *, is_up_event: _threading.Event | None = None) -> None:
-        async def wait_and_set_event(is_up_event_async: IEvent, is_up_event: _threading.Event) -> None:
-            await is_up_event_async.wait()
-            is_up_event.set()
-
         async def serve_forever() -> None:
-            if self.__threads_portal is not None:
-                raise ServerAlreadyRunning("Server is already running")
+            assert self.__threads_portal is None, "Server is already running"
             backend = self.__server.get_backend()
             try:
                 self.__threads_portal = backend.create_threads_portal()
                 is_up_event_async: IEvent | None = None
-                async with self.__server, backend.create_task_group() as task_group:
+                async with backend.create_task_group() as task_group:
                     if is_up_event is not None:
                         is_up_event_async = backend.create_event()
+
+                        async def wait_and_set_event(is_up_event_async: IEvent, is_up_event: _threading.Event) -> None:
+                            await is_up_event_async.wait()
+                            is_up_event.set()
+
                         task_group.start_soon(wait_and_set_event, is_up_event_async, is_up_event)
+                        del wait_and_set_event
                     await self.__server.serve_forever(is_up_event=is_up_event_async)
             finally:
                 self.__threads_portal = None
+                await backend.coro_yield()  # Everyone must know about the server's death :)
 
         backend = self.__server.get_backend()
-        with _contextlib.suppress(backend.get_cancelled_exc_class()), _contextlib.ExitStack() as stack:
-            stack.callback(self.__is_shutdown.set)
-            self.__is_shutdown.clear()
-
+        with _contextlib.ExitStack() as stack, _contextlib.suppress(backend.get_cancelled_exc_class()):
             if is_up_event is not None:
                 # Force is_up_event to be set, in order not to stuck the waiting thread
                 stack.callback(is_up_event.set)
-            backend.bootstrap(serve_forever)
+
+            with self.__close_lock.get():
+                runner = self.__runner
+                if runner is None:
+                    raise ServerClosedError("Closed server")
+
+            with self.__bootstrap_lock.get():
+                if not self.__is_shutdown.is_set():
+                    raise ServerAlreadyRunning("Server is already running")
+
+                def safe_shutdown_set() -> None:
+                    with self.__bootstrap_lock.get():
+                        self.__is_shutdown.set()
+
+                self.__is_shutdown.clear()
+                stack.callback(safe_shutdown_set)
+
+            runner.run(serve_forever)
 
     @property
     def _server(self) -> AbstractAsyncNetworkServer:

--- a/src/easynetwork/api_sync/server/tcp.py
+++ b/src/easynetwork/api_sync/server/tcp.py
@@ -48,6 +48,7 @@ class StandaloneTCPNetworkServer(_base.BaseStandaloneNetworkServerImpl, Generic[
         max_recv_size: int | None = None,
         service_actions_interval: float | None = None,
         backend_kwargs: Mapping[str, Any] | None = None,
+        log_client_connection: bool | None = None,
         logger: _logging.Logger | None = None,
         **kwargs: Any,
     ) -> None:
@@ -67,6 +68,7 @@ class StandaloneTCPNetworkServer(_base.BaseStandaloneNetworkServerImpl, Generic[
                 service_actions_interval=service_actions_interval,
                 backend=backend,
                 backend_kwargs=backend_kwargs,
+                log_client_connection=log_client_connection,
                 logger=logger,
                 **kwargs,
             )
@@ -90,6 +92,10 @@ class StandaloneTCPNetworkServer(_base.BaseStandaloneNetworkServerImpl, Generic[
                 sockets = portal.run_sync(lambda: self._server.sockets)
                 return tuple(SocketProxy(sock, runner=portal.run_sync) for sock in sockets)
         return ()
+
+    @property
+    def logger(self) -> _logging.Logger:
+        return self._server.logger
 
     if TYPE_CHECKING:
 

--- a/src/easynetwork/api_sync/server/thread.py
+++ b/src/easynetwork/api_sync/server/thread.py
@@ -42,13 +42,15 @@ class StandaloneNetworkServerThread(_threading.Thread):
             self.__is_up_event.set()
 
     def join(self, timeout: float | None = None) -> None:
-        _start = time.perf_counter()
-        try:
-            server = self.__server
-            if server is not None:
+        server = self.__server
+        if server is not None:
+            _start = time.perf_counter()
+            try:
                 server.shutdown(timeout=timeout)
-        finally:
-            _end = time.perf_counter()
-            if timeout is not None:
-                timeout -= _end - _start
+            finally:
+                _end = time.perf_counter()
+                if timeout is not None:
+                    timeout -= _end - _start
+                super().join(timeout=timeout)
+        else:
             super().join(timeout=timeout)

--- a/src/easynetwork/api_sync/server/udp.py
+++ b/src/easynetwork/api_sync/server/udp.py
@@ -75,6 +75,10 @@ class StandaloneUDPNetworkServer(_base.BaseStandaloneNetworkServerImpl, Generic[
                 return SocketProxy(socket, runner=portal.run_sync) if socket is not None else None
         return None
 
+    @property
+    def logger(self) -> _logging.Logger:
+        return self._server.logger
+
     if TYPE_CHECKING:
 
         @property

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -10,6 +10,7 @@ __all__ = [
     "is_ssl_eof_error",
     "is_ssl_socket",
     "lock_with_timeout",
+    "make_callback",
     "open_listener_sockets_from_getaddrinfo_result",
     "remove_traceback_frames_in_place",
     "replace_kwargs",
@@ -26,6 +27,7 @@ __all__ = [
 import concurrent.futures
 import contextlib
 import errno as _errno
+import functools
 import os
 import selectors as _selectors
 import socket as _socket
@@ -66,6 +68,10 @@ def replace_kwargs(kwargs: dict[str, Any], keys: dict[str, str]) -> None:
             kwargs[new_key] = kwargs.pop(old_key)
         except KeyError:
             pass
+
+
+def make_callback(func: Callable[_P, _R], /, *args: _P.args, **kwargs: _P.kwargs) -> Callable[[], _R]:
+    return functools.partial(func, *args, **kwargs)
 
 
 def error_from_errno(errno: int) -> OSError:

--- a/src/easynetwork/tools/socket.py
+++ b/src/easynetwork/tools/socket.py
@@ -32,7 +32,6 @@ from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, ParamSpec, Pr
 if TYPE_CHECKING:
     import threading as _threading
 
-    from _typeshed import ReadableBuffer
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
@@ -153,7 +152,7 @@ class SupportsSocketOptions(Protocol):
         ...
 
     @overload
-    def setsockopt(self, __level: int, __optname: int, __value: int | ReadableBuffer, /) -> None:
+    def setsockopt(self, __level: int, __optname: int, __value: int | bytes, /) -> None:
         ...
 
     @overload
@@ -259,7 +258,7 @@ class SocketProxy:
         return self.__execute(self.__socket.getsockopt, *args)
 
     @overload
-    def setsockopt(self, __level: int, __optname: int, __value: int | ReadableBuffer, /) -> None:
+    def setsockopt(self, __level: int, __optname: int, __value: int | bytes, /) -> None:
         ...
 
     @overload

--- a/src/easynetwork_asyncio/backend.py
+++ b/src/easynetwork_asyncio/backend.py
@@ -36,6 +36,7 @@ from easynetwork.tools.socket import MAX_STREAM_BUFSIZE
 from ._utils import _ensure_resolved, create_connection, create_datagram_socket
 from .datagram.endpoint import create_datagram_endpoint
 from .datagram.socket import AsyncioTransportDatagramSocketAdapter, RawDatagramSocketAdapter
+from .runner import AsyncioRunner
 from .stream.listener import AcceptedSocket, AcceptedSSLSocket, ListenerSocketAdapter
 from .stream.socket import AsyncioTransportStreamSocketAdapter, RawStreamSocketAdapter
 from .tasks import Task, TaskGroup, timeout, timeout_at
@@ -61,9 +62,8 @@ class AsyncioBackend(AbstractAsyncBackend):
         self.__use_asyncio_transport: bool = bool(transport)
         self.__asyncio_runner_factory: Callable[[], asyncio.Runner] = runner_factory or asyncio.Runner
 
-    def bootstrap(self, coro_func: Callable[..., Coroutine[Any, Any, _T]], *args: Any) -> _T:
-        with self.__asyncio_runner_factory() as runner:
-            return runner.run(coro_func(*args))
+    def new_runner(self) -> AsyncioRunner:
+        return AsyncioRunner(self.__asyncio_runner_factory())
 
     @staticmethod
     def _current_asyncio_task() -> asyncio.Task[Any]:

--- a/src/easynetwork_asyncio/runner.py
+++ b/src/easynetwork_asyncio/runner.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2021-2023, Francis Clairicia-Rose-Claire-Josephine
+#
+#
+"""asyncio engine for easynetwork.api_async
+"""
+
+from __future__ import annotations
+
+__all__ = ["AsyncioRunner"]
+
+import asyncio
+import contextlib
+from collections.abc import Callable, Coroutine
+from typing import Any, Self, TypeVar
+
+from easynetwork.api_async.backend.abc import AbstractRunner
+
+_T = TypeVar("_T")
+
+
+class AsyncioRunner(AbstractRunner):
+    __slots__ = ("__runner",)
+
+    def __init__(self, runner: asyncio.Runner) -> None:
+        super().__init__()
+
+        self.__runner: asyncio.Runner = runner
+
+    def __enter__(self) -> Self:
+        self.__runner.__enter__()
+        return super().__enter__()
+
+    def close(self) -> None:
+        return self.__runner.close()
+
+    def run(self, coro_func: Callable[..., Coroutine[Any, Any, _T]], *args: Any) -> _T:
+        with contextlib.closing(coro_func(*args)) as coro:  # Avoid ResourceWarning by always closing the coroutine
+            loop = self.__runner.get_loop()
+            try:
+                return self.__runner.run(coro)
+            finally:
+                _cancel_all_tasks(loop)
+                loop.run_until_complete(loop.shutdown_asyncgens())
+
+
+def _cancel_all_tasks(loop: asyncio.AbstractEventLoop) -> None:  # pragma: no cover
+    # Exact copy of what runner.close() would do
+    # Ref: https://github.com/python/cpython/blob/3.11/Lib/asyncio/runners.py#L193
+
+    to_cancel = asyncio.all_tasks(loop)
+    if not to_cancel:
+        return
+
+    for task in to_cancel:
+        task.cancel()
+
+    loop.run_until_complete(asyncio.gather(*to_cancel, return_exceptions=True))
+
+    for task in to_cancel:
+        if task.cancelled():
+            continue
+        if task.exception() is not None:
+            loop.call_exception_handler(
+                {
+                    "message": "unhandled exception during asyncio.run() shutdown",
+                    "exception": task.exception(),
+                    "task": task,
+                }
+            )

--- a/tests/functional_test/test_async/test_backend/test_asyncio_backend.py
+++ b/tests/functional_test/test_async/test_backend/test_asyncio_backend.py
@@ -476,7 +476,7 @@ class TestAsyncioBackend:
                 assert asyncio.get_running_loop() is not event_loop
                 return threads_portal.run_coroutine(coroutine, 42)
 
-            return asyncio.run(main())
+            return backend.bootstrap(main)
 
         assert await backend.run_in_thread(thread) == 42
 
@@ -592,7 +592,7 @@ class TestAsyncioBackend:
                 assert asyncio.get_running_loop() is not event_loop
                 return threads_portal.run_sync(not_threadsafe_func, 42)
 
-            return asyncio.run(main())
+            return backend.bootstrap(main)
 
         assert await backend.run_in_thread(thread) == 42
 

--- a/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
+++ b/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
@@ -9,6 +9,7 @@ from easynetwork.api_async.backend.abc import (
     AbstractAsyncDatagramSocketAdapter,
     AbstractAsyncListenerSocketAdapter,
     AbstractAsyncStreamSocketAdapter,
+    AbstractRunner,
     AbstractTask,
     AbstractTaskGroup,
     AbstractThreadsPortal,
@@ -20,7 +21,7 @@ from easynetwork.api_async.backend.abc import (
 
 
 class BaseFakeBackend(AbstractAsyncBackend):
-    def bootstrap(self, coro_func: Callable[..., Coroutine[Any, Any, Any]], *args: Any) -> Any:
+    def new_runner(self) -> AbstractRunner:
         raise NotImplementedError
 
     async def sleep(self, delay: float) -> None:

--- a/tests/unit_test/test_tools/test_utils.py
+++ b/tests/unit_test/test_tools/test_utils.py
@@ -33,6 +33,7 @@ from easynetwork.tools._utils import (
     is_ssl_socket,
     iter_bytes,
     lock_with_timeout,
+    make_callback,
     open_listener_sockets_from_getaddrinfo_result,
     recursively_clear_exception_traceback_frames,
     remove_traceback_frames_in_place,
@@ -120,6 +121,19 @@ def test____replace_kwargs____error_empty_key_dict() -> None:
 
     # Assert
     assert kwargs == {"arg1": 4, "arg12000": "Yes"}
+
+
+def test____make_callback____build_no_arg_callable(mocker: MockerFixture) -> None:
+    # Arrange
+    stub = mocker.stub()
+    stub.return_value = mocker.sentinel.ret_val
+
+    # Act
+    cb = make_callback(stub, mocker.sentinel.arg1, mocker.sentinel.arg2, kw1=mocker.sentinel.kw1, kw2=mocker.sentinel.kw2)
+
+    # Assert
+    assert cb() is mocker.sentinel.ret_val
+    stub.assert_called_once_with(mocker.sentinel.arg1, mocker.sentinel.arg2, kw1=mocker.sentinel.kw1, kw2=mocker.sentinel.kw2)
 
 
 def test____error_from_errno____returns_OSError(mocker: MockerFixture) -> None:


### PR DESCRIPTION
## What's changed
### Async API - All servers
- `serve_forever()` can be launched several times before a `server_close()`

### Async API - TCP server
- Added `log_client_connection` boolean option
  - (In fact the connection log will always be available in `DEBUG` level)

### Sync API - Standalone servers
- `serve_forever()` can be launched several times before a `server_close()`
- Fixed concurrency issues
- Fixed scheduler context management
- Added `logger` property

### AsyncBackend
- Added `AbstractRunner` interface and `backend.new_runner()` abstract method
- `backend.bootstrap()` now uses `backend.new_runner()` by default