### PR TITLE
`BaseProtocolParseError` now holds the exception object

### DIFF
--- a/src/easynetwork/exceptions.py
+++ b/src/easynetwork/exceptions.py
@@ -17,7 +17,7 @@ __all__ = [
     "StreamProtocolParseError",
 ]
 
-from typing import TYPE_CHECKING, Any, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .tools.socket import SocketAddress
@@ -54,13 +54,9 @@ class PacketConversionError(Exception):
 
 
 class BaseProtocolParseError(Exception):
-    ParseErrorType: TypeAlias = Literal["deserialization", "conversion"]
-
-    def __init__(self, error_type: ParseErrorType, message: str, error_info: Any = None) -> None:
-        super().__init__(f"Error while parsing data: {message}")
-        self.error_type: BaseProtocolParseError.ParseErrorType = error_type
-        self.error_info: Any = error_info
-        self.message: str = message
+    def __init__(self, error: DeserializeError | PacketConversionError) -> None:
+        super().__init__(f"Error while parsing data: {error}")
+        self.error: DeserializeError | PacketConversionError = error
 
 
 class DatagramProtocolParseError(BaseProtocolParseError):
@@ -68,16 +64,7 @@ class DatagramProtocolParseError(BaseProtocolParseError):
 
 
 class StreamProtocolParseError(BaseProtocolParseError):
-    def __init__(
-        self,
-        remaining_data: bytes,
-        error_type: StreamProtocolParseError.ParseErrorType,
-        message: str,
-        error_info: Any = None,
-    ) -> None:
-        super().__init__(
-            error_type=error_type,
-            message=message,
-            error_info=error_info,
-        )
+    def __init__(self, remaining_data: bytes, error: IncrementalDeserializeError | PacketConversionError) -> None:
+        super().__init__(error)
+        self.error: IncrementalDeserializeError | PacketConversionError
         self.remaining_data: bytes = remaining_data

--- a/src/easynetwork/protocol.py
+++ b/src/easynetwork/protocol.py
@@ -68,12 +68,12 @@ class DatagramProtocol(Generic[_SentPacketT, _ReceivedPacketT]):
         try:
             packet: _ReceivedPacketT = self.__serializer.deserialize(datagram)
         except DeserializeError as exc:
-            raise DatagramProtocolParseError("deserialization", str(exc), error_info=exc.error_info) from exc
+            raise DatagramProtocolParseError(exc) from exc
         if (converter := self.__converter) is not None:
             try:
                 packet = converter.create_from_dto_packet(packet)
             except PacketConversionError as exc:
-                raise DatagramProtocolParseError("conversion", str(exc), error_info=exc.error_info) from exc
+                raise DatagramProtocolParseError(exc) from exc
         return packet
 
 
@@ -117,7 +117,7 @@ class StreamProtocol(Generic[_SentPacketT, _ReceivedPacketT]):
             packet, remaining_data = yield from self.__serializer.incremental_deserialize()
         except IncrementalDeserializeError as exc:
             remaining_data, exc.remaining_data = exc.remaining_data, b""
-            raise StreamProtocolParseError(remaining_data, "deserialization", str(exc), error_info=exc.error_info) from exc
+            raise StreamProtocolParseError(remaining_data, exc) from exc
         except DeserializeError as exc:
             raise RuntimeError("DeserializeError raised instead of IncrementalDeserializeError") from exc
 
@@ -125,6 +125,6 @@ class StreamProtocol(Generic[_SentPacketT, _ReceivedPacketT]):
             try:
                 packet = converter.create_from_dto_packet(packet)
             except PacketConversionError as exc:
-                raise StreamProtocolParseError(remaining_data, "conversion", str(exc), error_info=exc.error_info) from exc
+                raise StreamProtocolParseError(remaining_data, exc) from exc
 
         return packet, remaining_data

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -386,11 +386,18 @@ def transform_future_exception(exc: BaseException) -> BaseException:
 
 
 def recursively_clear_exception_traceback_frames(exc: BaseException) -> None:
+    _recursively_clear_exception_traceback_frames_with_memo(exc, set())
+
+
+def _recursively_clear_exception_traceback_frames_with_memo(exc: BaseException, memo: set[int]) -> None:
+    if id(exc) in memo:
+        return
+    memo.add(id(exc))
     traceback.clear_frames(exc.__traceback__)
     if exc.__context__ is not None:
-        recursively_clear_exception_traceback_frames(exc.__context__)
+        _recursively_clear_exception_traceback_frames_with_memo(exc.__context__, memo)
     if exc.__cause__ is not exc.__context__ and exc.__cause__ is not None:
-        recursively_clear_exception_traceback_frames(exc.__cause__)
+        _recursively_clear_exception_traceback_frames_with_memo(exc.__cause__, memo)
 
 
 def remove_traceback_frames_in_place(exc: BaseException, n: int) -> None:

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -14,7 +14,12 @@ from weakref import WeakValueDictionary
 from easynetwork.api_async.backend.abc import AbstractAsyncBackend
 from easynetwork.api_async.server.handler import AsyncBaseRequestHandler, AsyncClientInterface, AsyncStreamRequestHandler
 from easynetwork.api_async.server.tcp import AsyncTCPNetworkServer
-from easynetwork.exceptions import BaseProtocolParseError, ClientClosedError, StreamProtocolParseError
+from easynetwork.exceptions import (
+    BaseProtocolParseError,
+    ClientClosedError,
+    IncrementalDeserializeError,
+    StreamProtocolParseError,
+)
 from easynetwork.protocol import StreamProtocol
 from easynetwork.tools._utils import set_socket_linger
 from easynetwork.tools.socket import SocketAddress
@@ -677,7 +682,7 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
         assert await reader.readline() == b"wrong encoding man.\n"
         assert request_handler.request_received[client_address] == []
         assert isinstance(request_handler.bad_request_received[client_address][0], StreamProtocolParseError)
-        assert request_handler.bad_request_received[client_address][0].error_type == "deserialization"
+        assert isinstance(request_handler.bad_request_received[client_address][0].error, IncrementalDeserializeError)
 
     @pytest.mark.parametrize("request_handler", [ErrorInRequestHandler], indirect=True)
     async def test____serve_forever____bad_request____unexpected_error(

--- a/tests/functional_test/test_communication/test_async/test_server/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_udp.py
@@ -11,7 +11,7 @@ from typing import Any
 from easynetwork.api_async.backend.abc import AbstractAsyncBackend
 from easynetwork.api_async.server.handler import AsyncBaseRequestHandler, AsyncClientInterface
 from easynetwork.api_async.server.udp import AsyncUDPNetworkServer
-from easynetwork.exceptions import BaseProtocolParseError, ClientClosedError, DatagramProtocolParseError
+from easynetwork.exceptions import BaseProtocolParseError, ClientClosedError, DatagramProtocolParseError, DeserializeError
 from easynetwork.protocol import DatagramProtocol
 from easynetwork_asyncio.datagram.endpoint import DatagramEndpoint, create_datagram_endpoint
 
@@ -410,7 +410,7 @@ class TestAsyncUDPNetworkServer(BaseTestAsyncServer):
         assert (await endpoint.recvfrom())[0] == b"wrong encoding man."
         assert request_handler.request_received[client_address] == []
         assert isinstance(request_handler.bad_request_received[client_address][0], DatagramProtocolParseError)
-        assert request_handler.bad_request_received[client_address][0].error_type == "deserialization"
+        assert isinstance(request_handler.bad_request_received[client_address][0].error, DeserializeError)
 
     @pytest.mark.parametrize("request_handler", [ErrorInBadRequestHandler], indirect=True)
     async def test____serve_forever____bad_request____unexpected_error(

--- a/tests/unit_test/test_async/test_api/test_client/test_tcp.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_tcp.py
@@ -6,7 +6,7 @@ from socket import AF_INET6, IPPROTO_TCP, SO_KEEPALIVE, SOL_SOCKET, TCP_NODELAY
 from typing import TYPE_CHECKING, Any
 
 from easynetwork.api_async.client.tcp import AsyncTCPNetworkClient
-from easynetwork.exceptions import ClientClosedError
+from easynetwork.exceptions import ClientClosedError, IncrementalDeserializeError
 from easynetwork.tools.socket import CLOSED_SOCKET_ERRNOS, MAX_STREAM_BUFSIZE, IPv4SocketAddress, IPv6SocketAddress, SocketProxy
 
 import pytest
@@ -1185,7 +1185,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
         from easynetwork.exceptions import StreamProtocolParseError
 
         mock_stream_socket_adapter.recv.side_effect = [b"packet\n"]
-        expected_error = StreamProtocolParseError(b"", "deserialization", "Sorry")
+        expected_error = StreamProtocolParseError(b"", IncrementalDeserializeError("Sorry", b""))
         mock_stream_data_consumer.__next__.side_effect = [StopIteration, expected_error]
 
         # Act

--- a/tests/unit_test/test_async/test_api/test_client/test_udp.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_udp.py
@@ -4,7 +4,7 @@ from socket import AF_INET6
 from typing import TYPE_CHECKING, Any, cast
 
 from easynetwork.api_async.client.udp import AsyncUDPNetworkClient, AsyncUDPNetworkEndpoint
-from easynetwork.exceptions import ClientClosedError
+from easynetwork.exceptions import ClientClosedError, DeserializeError
 from easynetwork.tools.socket import MAX_DATAGRAM_BUFSIZE, IPv4SocketAddress, IPv6SocketAddress, SocketProxy
 
 import pytest
@@ -742,7 +742,7 @@ class TestAsyncUDPNetworkEndpoint(BaseTestClient):
         from easynetwork.exceptions import DatagramProtocolParseError
 
         mock_datagram_socket_adapter.recvfrom.side_effect = [(b"packet", sender_address)]
-        expected_error = DatagramProtocolParseError("deserialization", "Sorry")
+        expected_error = DatagramProtocolParseError(DeserializeError("Sorry"))
         mock_datagram_protocol.build_packet_from_datagram.side_effect = expected_error
 
         # Act
@@ -835,7 +835,7 @@ class TestAsyncUDPNetworkEndpoint(BaseTestClient):
         from easynetwork.exceptions import DatagramProtocolParseError
 
         mock_datagram_socket_adapter.recvfrom.side_effect = [(b"packet", sender_address)]
-        expected_error = DatagramProtocolParseError("deserialization", "Sorry")
+        expected_error = DatagramProtocolParseError(DeserializeError("Sorry"))
         mock_datagram_protocol.build_packet_from_datagram.side_effect = expected_error
 
         # Act

--- a/tests/unit_test/test_protocol.py
+++ b/tests/unit_test/test_protocol.py
@@ -139,9 +139,7 @@ class TestDatagramProtocol:
 
         # Assert
         mock_convert_func.assert_not_called()
-        assert exception.error_type == "deserialization"
-        assert exception.message == "Deserialization error"
-        assert exception.error_info is mocker.sentinel.error_info
+        assert exception.error is mock_serializer.deserialize.side_effect
         assert exception.__cause__ is mock_serializer.deserialize.side_effect
         assert not hasattr(exception, "sender_address")
 
@@ -166,9 +164,7 @@ class TestDatagramProtocol:
 
         # Assert
         mock_convert_func.assert_called_once()
-        assert exception.error_type == "conversion"
-        assert exception.message == "Conversion error"
-        assert exception.error_info is mocker.sentinel.error_info
+        assert exception.error is mock_convert_func.side_effect
         assert exception.__cause__ is mock_convert_func.side_effect
         assert not hasattr(exception, "sender_address")
 
@@ -326,11 +322,9 @@ class TestStreamProtocol:
 
         # Assert
         mock_convert_func.assert_not_called()
-        assert exception.error_type == "deserialization"
+        assert isinstance(exception.error, IncrementalDeserializeError)
         assert exception.remaining_data is mocker.sentinel.chunk
-        assert exception.message == "Deserialization error"
-        assert exception.error_info is mocker.sentinel.error_info
-        assert isinstance(exception.__cause__, DeserializeError)
+        assert isinstance(exception.__cause__, IncrementalDeserializeError)
 
     def test____build_packet_from_chunks____wrong_deserialize_error(
         self,
@@ -380,8 +374,6 @@ class TestStreamProtocol:
 
         # Assert
         mock_convert_func.assert_called_once()
-        assert exception.error_type == "conversion"
+        assert isinstance(exception.error, PacketConversionError)
         assert exception.remaining_data is mocker.sentinel.chunk
-        assert exception.message == "Conversion error"
-        assert exception.error_info is mocker.sentinel.error_info
         assert exception.__cause__ is mock_convert_func.side_effect

--- a/tests/unit_test/test_sync/test_client/test_tcp.py
+++ b/tests/unit_test/test_sync/test_client/test_tcp.py
@@ -9,7 +9,7 @@ from ssl import SSLEOFError, SSLError, SSLErrorNumber, SSLWantReadError, SSLWant
 from typing import TYPE_CHECKING, Any
 
 from easynetwork.api_sync.client.tcp import TCPNetworkClient
-from easynetwork.exceptions import ClientClosedError
+from easynetwork.exceptions import ClientClosedError, IncrementalDeserializeError
 from easynetwork.tools.socket import (
     CLOSED_SOCKET_ERRNOS,
     MAX_STREAM_BUFSIZE,
@@ -1524,7 +1524,7 @@ class TestTCPNetworkClient(BaseTestClient):
         from easynetwork.exceptions import StreamProtocolParseError
 
         mock_used_socket.recv.side_effect = [b"packet\n"]
-        expected_error = StreamProtocolParseError(b"", "deserialization", "Sorry")
+        expected_error = StreamProtocolParseError(b"", IncrementalDeserializeError("Sorry", b""))
         mock_stream_data_consumer.__next__.side_effect = [StopIteration, expected_error]
 
         # Act
@@ -1741,7 +1741,7 @@ class TestTCPNetworkClient(BaseTestClient):
         # Arrange
         from easynetwork.exceptions import StreamProtocolParseError
 
-        mock_stream_data_consumer.__next__.side_effect = StreamProtocolParseError(b"", "deserialization", "Sorry")
+        mock_stream_data_consumer.__next__.side_effect = StreamProtocolParseError(b"", IncrementalDeserializeError("Sorry", b""))
 
         # Act
         with pytest.raises(StreamProtocolParseError) as exc_info:

--- a/tests/unit_test/test_sync/test_client/test_udp.py
+++ b/tests/unit_test/test_sync/test_client/test_udp.py
@@ -8,7 +8,7 @@ from socket import AF_INET, AF_INET6, AF_UNSPEC, AI_PASSIVE, IPPROTO_UDP, SOCK_D
 from typing import TYPE_CHECKING, Any
 
 from easynetwork.api_sync.client.udp import UDPNetworkClient, UDPNetworkEndpoint
-from easynetwork.exceptions import ClientClosedError
+from easynetwork.exceptions import ClientClosedError, DeserializeError
 from easynetwork.tools.socket import CLOSED_SOCKET_ERRNOS, MAX_DATAGRAM_BUFSIZE, IPv4SocketAddress, IPv6SocketAddress
 
 import pytest
@@ -921,7 +921,7 @@ class TestUDPNetworkEndpoint(BaseTestClient):
         from easynetwork.exceptions import DatagramProtocolParseError
 
         mock_udp_socket.recvfrom.side_effect = [(b"packet", sender_address)]
-        expected_error = DatagramProtocolParseError("deserialization", "Sorry")
+        expected_error = DatagramProtocolParseError(DeserializeError("Sorry"))
         mock_datagram_protocol.build_packet_from_datagram.side_effect = expected_error
 
         # Act
@@ -1108,7 +1108,7 @@ class TestUDPNetworkEndpoint(BaseTestClient):
         from easynetwork.exceptions import DatagramProtocolParseError
 
         mock_udp_socket.recvfrom.side_effect = [(b"packet", sender_address)]
-        expected_error = DatagramProtocolParseError("deserialization", "Sorry")
+        expected_error = DatagramProtocolParseError(DeserializeError("Sorry"))
         mock_datagram_protocol.build_packet_from_datagram.side_effect = expected_error
 
         # Act

--- a/tests/unit_test/test_tools/test_stream.py
+++ b/tests/unit_test/test_tools/test_stream.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
+from easynetwork.exceptions import IncrementalDeserializeError
 from easynetwork.tools.stream import StreamDataConsumer, StreamDataProducer
 
 import pytest
@@ -365,7 +366,7 @@ class TestStreamDataConsumer:
         def side_effect() -> Generator[None, bytes, tuple[Any, bytes]]:
             data = yield
             assert data == b"Hello"
-            raise StreamProtocolParseError(b"World", "deserialization", "Error occurred")
+            raise StreamProtocolParseError(b"World", IncrementalDeserializeError("Error occurred", b""))
 
         mock_build_packet_from_chunks_func: MagicMock = mock_stream_protocol.build_packet_from_chunks
         mock_build_packet_from_chunks_func.side_effect = side_effect

--- a/tests/unit_test/test_tools/test_utils.py
+++ b/tests/unit_test/test_tools/test_utils.py
@@ -794,7 +794,7 @@ def test____recursively_clear_exception_traceback_frames____exception_with_conte
         mocker.call(exception.__traceback__),
         mocker.call(exception.__context__.__traceback__),
         mocker.call(exception.__context__.__context__.__traceback__),
-        mocker.call(exception.__cause__.__traceback__),
+        # mocker.call(exception.__cause__.__traceback__),  # Already cleared because of the context nesting
     ]
 
 


### PR DESCRIPTION
## What's changed
- Now, instead of having `deserialization` and `conversion` error types, the exception holds the `DeserializeError` or `PacketConversionError` instance as attribute.