### PR TITLE
Improved TCP dual-stream handling

### DIFF
--- a/src/easynetwork/api_async/backend/abc.py
+++ b/src/easynetwork/api_async/backend/abc.py
@@ -12,6 +12,7 @@ __all__ = [
     "AbstractAsyncBackend",
     "AbstractAsyncBaseSocketAdapter",
     "AbstractAsyncDatagramSocketAdapter",
+    "AbstractAsyncHalfCloseableStreamSocketAdapter",
     "AbstractAsyncListenerSocketAdapter",
     "AbstractAsyncStreamSocketAdapter",
     "AbstractTask",
@@ -232,6 +233,14 @@ class AbstractAsyncStreamSocketAdapter(AbstractAsyncBaseSocketAdapter):
 
     async def sendall_fromiter(self, iterable_of_data: Iterable[bytes], /) -> None:
         await self.sendall(b"".join(iterable_of_data))
+
+
+class AbstractAsyncHalfCloseableStreamSocketAdapter(AbstractAsyncStreamSocketAdapter):
+    __slots__ = ()
+
+    @abstractmethod
+    async def send_eof(self) -> None:
+        raise NotImplementedError
 
 
 class AbstractAsyncDatagramSocketAdapter(AbstractAsyncBaseSocketAdapter):

--- a/src/easynetwork/api_async/client/tcp.py
+++ b/src/easynetwork/api_async/client/tcp.py
@@ -11,7 +11,7 @@ import contextlib as _contextlib
 import errno as _errno
 import socket as _socket
 from collections.abc import Callable, Iterator, Mapping
-from typing import TYPE_CHECKING, Any, Generic, Literal, NoReturn, TypedDict, TypeVar, cast, final, overload
+from typing import TYPE_CHECKING, Any, Generic, NoReturn, TypedDict, TypeVar, cast, final, overload
 
 try:
     import ssl as _ssl
@@ -32,7 +32,12 @@ from ...tools._utils import (
 )
 from ...tools.constants import CLOSED_SOCKET_ERRNOS, MAX_STREAM_BUFSIZE, SSL_HANDSHAKE_TIMEOUT, SSL_SHUTDOWN_TIMEOUT
 from ...tools.socket import SocketAddress, SocketProxy, new_socket_address, set_tcp_keepalive, set_tcp_nodelay
-from ..backend.abc import AbstractAsyncBackend, AbstractAsyncStreamSocketAdapter, ILock
+from ..backend.abc import (
+    AbstractAsyncBackend,
+    AbstractAsyncHalfCloseableStreamSocketAdapter,
+    AbstractAsyncStreamSocketAdapter,
+    ILock,
+)
 from ..backend.factory import AsyncBackendFactory
 from ..backend.tasks import SingleTaskRunner
 from .abc import AbstractAsyncNetworkClient
@@ -63,6 +68,7 @@ class AsyncTCPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
         "__addr",
         "__peer",
         "__eof_reached",
+        "__eof_sent",
         "__max_recv_size",
     )
 
@@ -79,6 +85,7 @@ class AsyncTCPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
         server_hostname: str | None = ...,
         ssl_handshake_timeout: float | None = ...,
         ssl_shutdown_timeout: float | None = ...,
+        ssl_shared_lock: bool | None = ...,
         max_recv_size: int | None = ...,
         backend: str | AbstractAsyncBackend | None = ...,
         backend_kwargs: Mapping[str, Any] | None = ...,
@@ -96,6 +103,7 @@ class AsyncTCPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
         server_hostname: str | None = ...,
         ssl_handshake_timeout: float | None = ...,
         ssl_shutdown_timeout: float | None = ...,
+        ssl_shared_lock: bool | None = ...,
         max_recv_size: int | None = ...,
         backend: str | AbstractAsyncBackend | None = ...,
         backend_kwargs: Mapping[str, Any] | None = ...,
@@ -112,6 +120,7 @@ class AsyncTCPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
         server_hostname: str | None = None,
         ssl_handshake_timeout: float | None = None,
         ssl_shutdown_timeout: float | None = None,
+        ssl_shared_lock: bool | None = None,
         max_recv_size: int | None = None,
         backend: str | AbstractAsyncBackend | None = None,
         backend_kwargs: Mapping[str, Any] | None = None,
@@ -145,6 +154,12 @@ class AsyncTCPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
 
             if ssl_shutdown_timeout is not None:
                 raise ValueError("ssl_shutdown_timeout is only meaningful with ssl")
+
+            if ssl_shared_lock is not None:
+                raise ValueError("ssl_shared_lock is only meaningful with ssl")
+
+        if ssl_shared_lock is None:
+            ssl_shared_lock = True
 
         def _value_or_default(value: float | None, default: float) -> float:
             return value if value is not None else default
@@ -187,12 +202,19 @@ class AsyncTCPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
                 raise TypeError("Invalid arguments")
 
         assert self.__socket_connector is not None
+        assert ssl_shared_lock is not None
 
-        self.__receive_lock: ILock = backend.create_lock()
-        self.__send_lock: ILock = backend.create_lock()
+        self.__receive_lock: ILock
+        self.__send_lock: ILock
+        if ssl and ssl_shared_lock:
+            self.__send_lock = self.__receive_lock = backend.create_lock()
+        else:
+            self.__receive_lock = backend.create_lock()
+            self.__send_lock = backend.create_lock()
         self.__producer: Callable[[_SentPacketT], Iterator[bytes]] = protocol.generate_chunks
         self.__consumer: StreamDataConsumer[_ReceivedPacketT] = StreamDataConsumer(protocol)
         self.__eof_reached: bool = False
+        self.__eof_sent: bool = False
         self.__max_recv_size: int = max_recv_size
 
     def __repr__(self) -> str:
@@ -214,10 +236,11 @@ class AsyncTCPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
             self.__socket_connector = None
         if self.__info is None:
             self.__info = self.__build_info_dict(self.__socket)
+            socket_proxy = self.__info["proxy"]
             with _contextlib.suppress(OSError):
-                set_tcp_nodelay(self.__info["proxy"], True)
+                set_tcp_nodelay(socket_proxy, True)
             with _contextlib.suppress(OSError):
-                set_tcp_keepalive(self.__info["proxy"], True)
+                set_tcp_keepalive(socket_proxy, True)
 
     @staticmethod
     def __build_info_dict(socket: AbstractAsyncStreamSocketAdapter) -> _ClientInfo:
@@ -258,36 +281,59 @@ class AsyncTCPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
 
     async def send_packet(self, packet: _SentPacketT) -> None:
         async with self.__send_lock:
+            socket = await self.__ensure_connected(check_socket_is_closing=True)
+            if self.__eof_sent:
+                raise RuntimeError("send_eof() has been called earlier")
             with self.__convert_socket_error():
-                socket = await self.__ensure_connected()
                 await socket.sendall_fromiter(self.__producer(packet))
                 _check_real_socket_state(self.socket)
 
+    async def send_eof(self) -> None:
+        try:
+            socket = await self.__ensure_connected(check_socket_is_closing=False)
+        except ConnectionError:
+            return
+        if not isinstance(socket, AbstractAsyncHalfCloseableStreamSocketAdapter):
+            raise NotImplementedError
+
+        async with self.__send_lock:
+            if self.__eof_sent:
+                return
+            self.__eof_sent = True
+            if not socket.is_closing():
+                await socket.send_eof()
+
     async def recv_packet(self) -> _ReceivedPacketT:
         async with self.__receive_lock:
-            with self.__convert_socket_error():
-                consumer = self.__consumer
+            consumer = self.__consumer
+            try:
+                return next(consumer)  # If there is enough data from last call to create a packet, return immediately
+            except StopIteration:
+                pass
+
+            socket = await self.__ensure_connected(check_socket_is_closing=True)
+            if self.__eof_reached:
+                self.__abort(None)
+
+            bufsize: int = self.__max_recv_size
+            backend = self.__backend
+
+            while True:
+                with self.__convert_socket_error():
+                    chunk: bytes = await socket.recv(bufsize)
                 try:
-                    return next(consumer)  # If there is enough data from last call to create a packet, return immediately
+                    if not chunk:
+                        self.__eof_reached = True
+                        self.__abort(None)
+                    consumer.feed(chunk)
+                finally:
+                    del chunk
+                try:
+                    return next(consumer)
                 except StopIteration:
                     pass
-                socket = await self.__ensure_connected()
-                bufsize: int = self.__max_recv_size
-                backend = self.__backend
-                while True:
-                    chunk: bytes = await socket.recv(bufsize)
-                    try:
-                        if not chunk:
-                            self.__eof_error(False)
-                        consumer.feed(chunk)
-                    finally:
-                        del chunk
-                    try:
-                        return next(consumer)
-                    except StopIteration:
-                        pass
-                    # Attempt failed, wait for one iteration
-                    await backend.coro_yield()
+                # Attempt failed, wait for one iteration
+                await backend.coro_yield()
 
     def get_local_address(self) -> SocketAddress:
         if self.__info is None:
@@ -308,29 +354,28 @@ class AsyncTCPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
     def get_backend(self) -> AbstractAsyncBackend:
         return self.__backend
 
-    async def __ensure_connected(self) -> AbstractAsyncStreamSocketAdapter:
+    async def __ensure_connected(self, *, check_socket_is_closing: bool) -> AbstractAsyncStreamSocketAdapter:
         await self.wait_connected()
         assert self.__socket is not None
-        if self.__socket.is_closing() or self.__eof_reached:
-            raise _error_from_errno(_errno.ECONNABORTED)
-        return self.__socket
+        socket = self.__socket
+        if check_socket_is_closing and socket.is_closing():
+            self.__abort(None)
+        return socket
 
     @_contextlib.contextmanager
     def __convert_socket_error(self) -> Iterator[None]:
         try:
             yield
-        except (ConnectionAbortedError, ClientClosedError):
-            raise
         except ConnectionError as exc:
-            self.__eof_error(exc)
+            self.__abort(exc)
         except OSError as exc:
             if exc.errno in CLOSED_SOCKET_ERRNOS:
-                self.__eof_error(exc)
+                self.__abort(exc)
             raise
 
-    def __eof_error(self, cause: BaseException | None | Literal[False]) -> NoReturn:
-        self.__eof_reached = True
-        if cause is False:
+    @staticmethod
+    def __abort(cause: BaseException | None) -> NoReturn:
+        if cause is None:
             raise _error_from_errno(_errno.ECONNABORTED)
         raise _error_from_errno(_errno.ECONNABORTED) from cause
 

--- a/src/easynetwork_asyncio/socket.py
+++ b/src/easynetwork_asyncio/socket.py
@@ -12,6 +12,7 @@ import asyncio
 import asyncio.trsock
 import contextlib
 import errno as _errno
+import socket as _socket
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Literal, Self, TypeAlias
 from weakref import WeakSet
@@ -19,7 +20,6 @@ from weakref import WeakSet
 from easynetwork.tools._utils import check_socket_no_ssl as _check_socket_no_ssl, error_from_errno as _error_from_errno
 
 if TYPE_CHECKING:
-    import socket as _socket
     from types import TracebackType
 
     from _typeshed import ReadableBuffer
@@ -35,7 +35,8 @@ class AsyncSocket:
         "__loop",
         "__tasks",
         "__waiters",
-        "__closing",
+        "__close_waiter",
+        "__shutdown_write",
         "__weakref__",
     )
 
@@ -50,10 +51,10 @@ class AsyncSocket:
         self.__loop: asyncio.AbstractEventLoop = loop
         self.__tasks: WeakSet[asyncio.Task[Any]] = WeakSet()
         self.__waiters: dict[_SocketTaskId, asyncio.Future[None]] = {}
-        self.__closing: bool = False
+        self.__close_waiter: asyncio.Future[None] = loop.create_future()
+        self.__shutdown_write: bool = False
 
     def __del__(self) -> None:  # pragma: no cover
-        self.__closing = True
         try:
             socket: _socket.socket | None = self.__socket
         except AttributeError:
@@ -73,28 +74,32 @@ class AsyncSocket:
         await self.aclose()
 
     def is_closing(self) -> bool:
-        return self.__socket is None or self.__closing
+        return self.__socket is None
 
     async def aclose(self) -> None:
-        socket, self.__socket = self.__socket, None
-        self.__closing = True
+        socket = self.__socket
 
         if socket is None:
-            await asyncio.sleep(0)
+            await asyncio.shield(self.__close_waiter)
             return
-        try:
+        async with contextlib.AsyncExitStack() as stack:
+            stack.push_async_callback(asyncio.sleep, 0)
+            stack.callback(self.__close_waiter.set_result, None)
+            stack.callback(socket.close)
+
+            self.__socket = None
+
+            del stack
+
             for task in list(self.__tasks):
                 task.cancel()
                 del task
             futures_to_wait_for_completion: set[asyncio.Future[None]] = set(self.__waiters.values())
             if futures_to_wait_for_completion:
                 await asyncio.wait(futures_to_wait_for_completion, return_when=asyncio.ALL_COMPLETED)
-        finally:
-            socket.close()
-            await asyncio.sleep(0)
 
     async def accept(self) -> tuple[_socket.socket, _socket._RetAddress]:
-        with self.__conflict_detection("accept") as socket:
+        with self.__conflict_detection("accept", abort_errno=_errno.EINTR) as socket:
             return await self.__loop.sock_accept(socket)
 
     async def sendall(self, data: ReadableBuffer, /) -> None:
@@ -113,21 +118,31 @@ class AsyncSocket:
         with self.__conflict_detection("recv", abort_errno=_errno.ECONNABORTED) as socket:
             return await self.__loop.sock_recvfrom(socket, bufsize)
 
+    async def shutdown(self, how: int, /) -> None:
+        with contextlib.ExitStack() as stack:
+            socket: _socket.socket = self.__check_not_closed()
+            did_shutdown_SHUT_WR: bool = False
+            if how in {_socket.SHUT_RDWR, _socket.SHUT_WR}:
+                stack.enter_context(self.__conflict_detection("send", abort_errno=None))
+                did_shutdown_SHUT_WR = True
+
+            socket.shutdown(how)
+            if did_shutdown_SHUT_WR:
+                self.__shutdown_write = True
+
+        # Yield out of the conflict detections scopes
+        await asyncio.sleep(0)
+
     @contextlib.contextmanager
-    def __conflict_detection(self, task_id: _SocketTaskId, *, abort_errno: int | None = None) -> Iterator[_socket.socket]:
-        if (socket := self.__socket if not self.__closing else None) is None:
-            raise _error_from_errno(_errno.ENOTSOCK)
+    def __conflict_detection(self, task_id: _SocketTaskId, *, abort_errno: int | None) -> Iterator[_socket.socket]:
+        socket = self.__check_not_closed()
 
         if task_id in self.__waiters:
             raise _error_from_errno(_errno.EBUSY)
 
-        if abort_errno is None:
-            abort_errno = _errno.EINTR
-
-        task = asyncio.current_task()
+        task = asyncio.current_task(self.__loop)
         if task is None:  # pragma: no cover
-            raise RuntimeError("This function should be called within a task.")
-        assert task.get_loop() is self.__loop, "coroutine will not be executed with the bound event loop"
+            raise RuntimeError("This function will not be executed with the bound event loop.")
 
         with contextlib.ExitStack() as stack:
             self.__tasks.add(task)
@@ -139,14 +154,29 @@ class AsyncSocket:
             stack.callback(self.__waiters.pop, task_id)
             del waiter
 
+            if abort_errno is None:
+                # Short circuit.
+                del task
+                yield socket
+                return
+
+            task_cancelling = task.cancelling()
+
             try:
                 yield socket
             except asyncio.CancelledError:
-                if self.__socket is not None or task.uncancel() > 0:
+                if self.__socket is not None:
+                    raise
+                if (not task.cancelling() > task_cancelling) or task.uncancel() > task_cancelling:
                     raise
                 raise _error_from_errno(abort_errno) from None
             finally:
                 del task
+
+    def __check_not_closed(self) -> _socket.socket:
+        if (socket := self.__socket) is None:
+            raise _error_from_errno(_errno.ENOTSOCK)
+        return socket
 
     @property
     def loop(self) -> asyncio.AbstractEventLoop:
@@ -155,3 +185,7 @@ class AsyncSocket:
     @property
     def socket(self) -> asyncio.trsock.TransportSocket:
         return self.__trsock
+
+    @property
+    def did_shutdown_SHUT_WR(self) -> bool:
+        return self.__shutdown_write

--- a/src/easynetwork_asyncio/stream/socket.py
+++ b/src/easynetwork_asyncio/stream/socket.py
@@ -12,9 +12,9 @@ import asyncio
 import errno
 import socket as _socket
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, final
+from typing import TYPE_CHECKING, Any, Self, cast, final
 
-from easynetwork.api_async.backend.abc import AbstractAsyncStreamSocketAdapter
+from easynetwork.api_async.backend.abc import AbstractAsyncHalfCloseableStreamSocketAdapter, AbstractAsyncStreamSocketAdapter
 from easynetwork.tools._utils import error_from_errno as _error_from_errno
 
 from ..socket import AsyncSocket
@@ -23,13 +23,21 @@ if TYPE_CHECKING:
     import asyncio.trsock
 
 
-@final
 class AsyncioTransportStreamSocketAdapter(AbstractAsyncStreamSocketAdapter):
     __slots__ = (
         "__reader",
         "__writer",
         "__socket",
     )
+
+    def __new__(
+        cls,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> Self:
+        if cls is AsyncioTransportStreamSocketAdapter and writer.can_write_eof():
+            return cast(Self, super().__new__(AsyncioTransportHalfCloseableStreamSocketAdapter))
+        return super().__new__(cls)
 
     def __init__(
         self,
@@ -80,16 +88,33 @@ class AsyncioTransportStreamSocketAdapter(AbstractAsyncStreamSocketAdapter):
         self.__writer.writelines(iterable_of_data)
         await self.__writer.drain()
 
+    async def _send_eof_impl(self) -> None:
+        assert self.__writer.can_write_eof()
+        self.__writer.write_eof()
+        await asyncio.sleep(0)
+
     def socket(self) -> asyncio.trsock.TransportSocket:
         return self.__socket
 
 
 @final
-class RawStreamSocketAdapter(AbstractAsyncStreamSocketAdapter):
-    __slots__ = (
-        "__socket",
-        "__remote_addr",
-    )
+class AsyncioTransportHalfCloseableStreamSocketAdapter(
+    AsyncioTransportStreamSocketAdapter,
+    AbstractAsyncHalfCloseableStreamSocketAdapter,
+):
+    __slots__ = ()
+
+    def __new__(cls, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> Self:
+        if not writer.can_write_eof():
+            raise ValueError(f"{writer!r} cannot write eof")
+        return super().__new__(cls, reader, writer)
+
+    send_eof = AsyncioTransportStreamSocketAdapter._send_eof_impl
+
+
+@final
+class RawStreamSocketAdapter(AbstractAsyncHalfCloseableStreamSocketAdapter):
+    __slots__ = ("__socket",)
 
     def __init__(
         self,
@@ -102,9 +127,6 @@ class RawStreamSocketAdapter(AbstractAsyncStreamSocketAdapter):
 
         assert socket.type == _socket.SOCK_STREAM, "A 'SOCK_STREAM' socket is expected"
 
-        remote_address = socket.getpeername()
-        self.__remote_addr: tuple[Any, ...] = tuple(remote_address)
-
     async def aclose(self) -> None:
         return await self.__socket.aclose()
 
@@ -115,13 +137,22 @@ class RawStreamSocketAdapter(AbstractAsyncStreamSocketAdapter):
         return self.__socket.socket.getsockname()
 
     def get_remote_address(self) -> tuple[Any, ...]:
-        return self.__remote_addr
+        return self.__socket.socket.getpeername()
 
     async def recv(self, bufsize: int, /) -> bytes:
         return await self.__socket.recv(bufsize)
 
     async def sendall(self, data: bytes, /) -> None:
         await self.__socket.sendall(data)
+
+    async def send_eof(self) -> None:
+        socket = self.__socket
+        if socket.did_shutdown_SHUT_WR:
+            # On macOS, calling shutdown a second time raises ENOTCONN, but
+            # send_eof needs to be idempotent.
+            await asyncio.sleep(0)
+            return
+        await socket.shutdown(_socket.SHUT_WR)
 
     def socket(self) -> asyncio.trsock.TransportSocket:
         return self.__socket.socket

--- a/tests/unit_test/_utils.py
+++ b/tests/unit_test/_utils.py
@@ -8,11 +8,14 @@ from typing import Any
 class _LockMixin:
     _locked_count: int = 0
 
+    class WouldBlock(Exception):
+        pass
+
     def _acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
         if self._locked_count > 0:
             if not blocking or timeout >= 0:
                 return False
-            raise RuntimeError(f"{self.__class__.__name__}.acquire() would block")
+            raise _LockMixin.WouldBlock(f"{self.__class__.__name__}.acquire() would block")
 
         self._locked_count += 1
         return True

--- a/tests/unit_test/_utils.py
+++ b/tests/unit_test/_utils.py
@@ -5,13 +5,30 @@ from types import TracebackType
 from typing import Any
 
 
-class DummyLock:
+class _LockMixin:
+    _locked_count: int = 0
+
+    def _acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
+        if self._locked_count > 0:
+            if not blocking or timeout >= 0:
+                return False
+            raise RuntimeError(f"{self.__class__.__name__}.acquire() would block")
+
+        self._locked_count += 1
+        return True
+
+    def locked(self) -> bool:
+        return self._locked_count > 0
+
+    def _release(self) -> None:
+        assert self._locked_count > 0
+        self._locked_count -= 1
+
+
+class DummyLock(_LockMixin):
     """
     Helper class used to mock threading.Lock and threading.RLock classes
     """
-
-    def __init__(self) -> None:
-        pass
 
     def __enter__(self) -> bool:
         return self.acquire()
@@ -20,18 +37,18 @@ class DummyLock:
         self.release()
 
     def acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
-        return True
+        return self._acquire(blocking=blocking, timeout=timeout)
 
     def release(self) -> None:
-        pass
+        return self._release()
 
 
-class AsyncDummyLock:
+class AsyncDummyLock(_LockMixin):
     """
     Helper class used to mock asyncio.Lock classes
     """
 
-    def __init__(self) -> None:
+    class AcquireFailed(Exception):
         pass
 
     async def __aenter__(self) -> None:
@@ -43,10 +60,13 @@ class AsyncDummyLock:
         self.release()
 
     async def acquire(self) -> bool:
+        locked = self._acquire(blocking=False)
+        if not locked:
+            raise AsyncDummyLock.AcquireFailed("not locked")
         return True
 
     def release(self) -> None:
-        pass
+        return self._release()
 
 
 class partial_eq(functools.partial[Any]):

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -33,6 +33,7 @@ def mock_socket_factory(mocker: MockerFixture) -> Callable[[], MagicMock]:
         mock_socket.family = AF_INET
         mock_socket.type = -1
         mock_socket.proto = 0
+        mock_socket.fileno.return_value = 123
         return mock_socket
 
     return factory
@@ -82,6 +83,7 @@ def mock_ssl_socket_factory(mocker: MockerFixture) -> Callable[[], MagicMock]:
         mock_socket.family = AF_INET
         mock_socket.type = SOCK_STREAM
         mock_socket.proto = IPPROTO_TCP
+        mock_socket.fileno.return_value = 123
         mock_socket.do_handshake.return_value = None
         return mock_socket
 

--- a/tests/unit_test/test_async/test_api/test_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_api/test_backend/test_backend.py
@@ -287,14 +287,14 @@ class TestAsyncBackendFactory:
         # Arrange
 
         # Act & Assert
-        with pytest.raises(TypeError, match=r"^Invalid backend class: %r$" % invalid_cls):
+        with pytest.raises(TypeError, match=rf"^Invalid backend class: {invalid_cls!r}$"):
             AsyncBackendFactory.set_default_backend(invalid_cls)
 
     def test____set_default_backend____from_class____error_abstract_class_given(self) -> None:
         # Arrange
 
         # Act & Assert
-        with pytest.raises(TypeError, match=r"^Invalid backend class: %r$" % AbstractAsyncBackend):
+        with pytest.raises(TypeError, match=rf"^Invalid backend class: {AbstractAsyncBackend!r}$"):
             AsyncBackendFactory.set_default_backend(AbstractAsyncBackend)
 
     @pytest.mark.parametrize("backend_name", list(BACKENDS))

--- a/tests/unit_test/test_async/test_asyncio_backend/conftest.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/conftest.py
@@ -21,6 +21,7 @@ def mock_async_socket_factory(mocker: MockerFixture, event_loop: asyncio.Abstrac
         mock = mocker.NonCallableMagicMock(spec=AsyncSocket)
         mock.is_closing.return_value = False
         mock.loop = event_loop
+        mock.did_shutdown_SHUT_WR = False
         return mock
 
     return factory
@@ -55,6 +56,7 @@ def mock_asyncio_stream_writer_factory(mocker: MockerFixture) -> Callable[[], Ma
     def factory() -> MagicMock:
         mock = mocker.NonCallableMagicMock(spec=asyncio.StreamWriter)
         mock.is_closing.return_value = False
+        mock.can_write_eof.return_value = True
         return mock
 
     return factory

--- a/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import asyncio.trsock
+import contextlib
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from easynetwork.api_async.backend.abc import AbstractAcceptedSocket
 from easynetwork.tools.constants import MAX_STREAM_BUFSIZE
 from easynetwork_asyncio.stream.listener import AcceptedSocket, AcceptedSSLSocket, ListenerSocketAdapter
-from easynetwork_asyncio.stream.socket import AsyncioTransportStreamSocketAdapter, RawStreamSocketAdapter
+from easynetwork_asyncio.stream.socket import (
+    AsyncioTransportHalfCloseableStreamSocketAdapter,
+    AsyncioTransportStreamSocketAdapter,
+    RawStreamSocketAdapter,
+)
 
 import pytest
 
@@ -60,12 +65,7 @@ class BaseTestTransportStreamSocket:
 
 
 @pytest.mark.asyncio
-class TestTransportBasedStreamSocket(BaseTestTransportStreamSocket):
-    @pytest.fixture
-    @staticmethod
-    def socket(mock_asyncio_reader: MagicMock, mock_asyncio_writer: MagicMock) -> AsyncioTransportStreamSocketAdapter:
-        return AsyncioTransportStreamSocketAdapter(mock_asyncio_reader, mock_asyncio_writer)
-
+class BaseTestAsyncioTransportBasedStreamSocket(BaseTestTransportStreamSocket):
     async def test____aclose____close_transport_and_wait(
         self,
         socket: AsyncioTransportStreamSocketAdapter,
@@ -277,6 +277,74 @@ class TestTransportBasedStreamSocket(BaseTestTransportStreamSocket):
 
         # Assert
         assert transport_socket is mock_tcp_socket
+
+
+@pytest.mark.asyncio
+class TestAsyncioTransportStreamSocketAdapter(BaseTestAsyncioTransportBasedStreamSocket):
+    @pytest.fixture
+    @staticmethod
+    def socket(mock_asyncio_reader: MagicMock, mock_asyncio_writer: MagicMock) -> AsyncioTransportStreamSocketAdapter:
+        mock_asyncio_writer.can_write_eof.return_value = False
+        return AsyncioTransportStreamSocketAdapter(mock_asyncio_reader, mock_asyncio_writer)
+
+    @pytest.mark.parametrize("can_write_eof", [False, True], ids=lambda p: f"can_write_eof=={p}")
+    async def test____dunder_new____instanciate_subclass(
+        self,
+        can_write_eof: bool,
+        mock_asyncio_reader: MagicMock,
+        mock_asyncio_writer: MagicMock,
+    ) -> None:
+        # Arrange
+        mock_asyncio_writer.can_write_eof.return_value = can_write_eof
+
+        # Act
+        socket = AsyncioTransportStreamSocketAdapter(mock_asyncio_reader, mock_asyncio_writer)
+
+        # Assert
+        if can_write_eof:
+            assert type(socket) is AsyncioTransportHalfCloseableStreamSocketAdapter
+        else:
+            assert type(socket) is AsyncioTransportStreamSocketAdapter
+
+
+@pytest.mark.asyncio
+class TestAsyncioTransportHalfCloseableStreamSocketAdapter(BaseTestAsyncioTransportBasedStreamSocket):
+    @pytest.fixture
+    @staticmethod
+    def socket(
+        mock_asyncio_reader: MagicMock,
+        mock_asyncio_writer: MagicMock,
+    ) -> AsyncioTransportHalfCloseableStreamSocketAdapter:
+        mock_asyncio_writer.can_write_eof.return_value = True
+        return AsyncioTransportHalfCloseableStreamSocketAdapter(mock_asyncio_reader, mock_asyncio_writer)
+
+    @pytest.mark.parametrize("can_write_eof", [False, True], ids=lambda p: f"can_write_eof=={p}")
+    async def test____dunder_new____check_write_eof_possibility(
+        self,
+        can_write_eof: bool,
+        mock_asyncio_reader: MagicMock,
+        mock_asyncio_writer: MagicMock,
+    ) -> None:
+        # Arrange
+        mock_asyncio_writer.can_write_eof.return_value = can_write_eof
+
+        # Act & Assert
+        with pytest.raises(ValueError) if not can_write_eof else contextlib.nullcontext():
+            _ = AsyncioTransportHalfCloseableStreamSocketAdapter(mock_asyncio_reader, mock_asyncio_writer)
+
+    async def test____send_eof____write_eof(
+        self,
+        socket: AsyncioTransportHalfCloseableStreamSocketAdapter,
+        mock_asyncio_writer: MagicMock,
+    ) -> None:
+        # Arrange
+        mock_asyncio_writer.write_eof.return_value = None
+
+        # Act
+        await socket.send_eof()
+
+        # Assert
+        mock_asyncio_writer.write_eof.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -729,7 +797,6 @@ class TestRawStreamSocketAdapter(BaseTestSocket):
         mock_tcp_socket: MagicMock,
     ) -> None:
         # Arrange
-        mock_tcp_socket.getpeername.assert_called_once_with()
 
         # Act
         remote_address = socket.get_remote_address()
@@ -823,3 +890,35 @@ class TestRawStreamSocketAdapter(BaseTestSocket):
 
         # Assert
         mock_async_socket.sendall.assert_awaited_once_with(b"datatosend")
+
+    async def test_____send_eof____shutdown_socket(
+        self,
+        socket: RawStreamSocketAdapter,
+        mock_async_socket: MagicMock,
+    ) -> None:
+        # Arrange
+        from socket import SHUT_WR
+
+        mock_async_socket.shutdown.return_value = None
+        mock_async_socket.did_shutdown_SHUT_WR = False
+
+        # Act
+        await socket.send_eof()
+
+        # Assert
+        mock_async_socket.shutdown.assert_awaited_once_with(SHUT_WR)
+
+    async def test_____send_eof____already_shutdown(
+        self,
+        socket: RawStreamSocketAdapter,
+        mock_async_socket: MagicMock,
+    ) -> None:
+        # Arrange
+        mock_async_socket.shutdown.return_value = None
+        mock_async_socket.did_shutdown_SHUT_WR = True
+
+        # Act
+        await socket.send_eof()
+
+        # Assert
+        mock_async_socket.shutdown.assert_not_awaited()

--- a/tests/unit_test/test_sync/test_client/base.py
+++ b/tests/unit_test/test_sync/test_client/base.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Any
+
+from easynetwork.tools._utils import validate_timeout_delay
 
 from ...base import BaseTestSocket
 
 if TYPE_CHECKING:
+    from threading import Lock
     from unittest.mock import MagicMock
 
     from pytest_mock import MockerFixture
@@ -18,8 +21,30 @@ class BaseTestClient(BaseTestSocket):
         key = mocker.sentinel.key
         mock_selector_select.side_effect = [[key] for _ in range(nb_calls)] + [[]]
 
+    @staticmethod
+    def selector_action_during_select(
+        mock_selector_select: MagicMock,
+        mocker: MockerFixture,
+        callback: Callable[[], Any],
+    ) -> None:
+        key = mocker.sentinel.key
+
+        def selector_side_effect(timeout: float | None = None) -> list[Any]:
+            callback()
+            return [key]
+
+        mock_selector_select.side_effect = selector_side_effect
+
 
 @contextlib.contextmanager
-def dummy_lock_with_timeout(lock: Any, timeout: float | None, *args: Any, **kwargs: Any) -> Iterator[float | None]:
-    with lock:
+def dummy_lock_with_timeout(lock: Lock, timeout: float | None, *args: Any, **kwargs: Any) -> Iterator[float | None]:
+    with contextlib.ExitStack() as stack:
+        if timeout is None:
+            stack.enter_context(lock)
+        else:
+            timeout = validate_timeout_delay(timeout, positive_check=False)
+            if lock.acquire(blocking=True, timeout=timeout):
+                stack.push(lock)
+            else:
+                raise TimeoutError()
         yield timeout

--- a/tests/unit_test/test_sync/test_client/test_tcp.py
+++ b/tests/unit_test/test_sync/test_client/test_tcp.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
+from ..._utils import DummyLock
 from ...base import UNSUPPORTED_FAMILIES
 from .base import BaseTestClient, dummy_lock_with_timeout
 
@@ -2046,8 +2047,8 @@ class TestTCPNetworkClient(BaseTestClient):
             ssl_shared_lock = True  # Should be true by default
 
         def during_select() -> None:
-            with pytest.raises(TimeoutError) if ssl_shared_lock else contextlib.nullcontext():
-                client.send_packet(mocker.sentinel.packet, timeout=0)
+            with pytest.raises(DummyLock.WouldBlock) if ssl_shared_lock else contextlib.nullcontext():
+                client.send_packet(mocker.sentinel.packet)
 
         mock_used_socket.recv.side_effect = [SSLWantReadError, b""]
         self.selector_action_during_select(mock_selector_select, mocker, during_select)

--- a/tests/unit_test/test_sync/test_client/test_udp.py
+++ b/tests/unit_test/test_sync/test_client/test_udp.py
@@ -1124,37 +1124,6 @@ class TestUDPNetworkEndpoint(BaseTestClient):
         assert (exception.sender_address.host, exception.sender_address.port) == sender_address
 
     @pytest.mark.usefixtures("setup_protocol_mock")
-    def test____iter_received_packets_from____release_internal_lock_before_yield(
-        self,
-        client: UDPNetworkEndpoint[Any, Any],
-        sender_address: tuple[str, int],
-        recv_timeout: float | None,
-        mock_udp_socket: MagicMock,
-        mocker: MockerFixture,
-    ) -> None:
-        # Arrange
-        from threading import Lock
-
-        mock_acquire = mocker.patch.object(Lock, "acquire", return_value=True)
-        mock_release = mocker.patch.object(Lock, "release", return_value=None)
-        mock_udp_socket.recvfrom.side_effect = [(b"packet_1", sender_address), (b"packet_2", sender_address)]
-
-        # Act & Assert
-        iterator = client.iter_received_packets_from(timeout=recv_timeout)
-        mock_acquire.assert_not_called()
-        mock_release.assert_not_called()
-        packet_1 = next(iterator)
-        mock_acquire.assert_called_once_with()
-        mock_release.assert_called_once_with()
-        mock_acquire.reset_mock()
-        mock_release.reset_mock()
-        packet_2 = next(iterator)
-        mock_acquire.assert_called_once_with()
-        mock_release.assert_called_once_with()
-        assert packet_1[0] is mocker.sentinel.packet_1
-        assert packet_2[0] is mocker.sentinel.packet_2
-
-    @pytest.mark.usefixtures("setup_protocol_mock")
     def test____iter_received_packets_from____closed_client_during_iteration(
         self,
         client: UDPNetworkEndpoint[Any, Any],

--- a/tests/unit_test/test_tools/test_utils.py
+++ b/tests/unit_test/test_tools/test_utils.py
@@ -155,6 +155,19 @@ def test____check_real_socket_state____socket_with_error(mock_tcp_socket: MagicM
     mock_error_from_errno.assert_called_once_with(errno)
 
 
+def test____check_real_socket_state____closed_socket(mock_tcp_socket: MagicMock, mocker: MockerFixture) -> None:
+    # Arrange
+    mock_tcp_socket.fileno.return_value = -1
+    mock_error_from_errno = mocker.patch(f"{error_from_errno.__module__}.{error_from_errno.__qualname__}")
+
+    # Act
+    check_real_socket_state(mock_tcp_socket)
+
+    # Assert
+    mock_tcp_socket.getsockopt.assert_not_called()
+    mock_error_from_errno.assert_not_called()
+
+
 def test____check_socket_family____valid_family(socket_family: int) -> None:
     # Arrange
 
@@ -654,9 +667,10 @@ def test____remove_traceback_frames_in_place____remove_n_first_traceback(n: int)
     # Act
     exception = pytest.raises(Exception, func).value
     assert len(list(traceback.walk_tb(exception.__traceback__))) == 3
-    remove_traceback_frames_in_place(exception, n)
+    _returned_exception = remove_traceback_frames_in_place(exception, n)
 
     # Assert
+    assert _returned_exception is exception
     if 0 <= n <= 3:
         assert len(list(traceback.walk_tb(exception.__traceback__))) == 3 - n
     elif n < 0:


### PR DESCRIPTION
## What's changed
### For `TCPNetworkClient` and `AsyncTCPNetworkClient`
- Added `send_eof()` method
  - Added `AbstractAsyncHalfCloseableStreamSocketAdapter` interface for async backend
- Added `ssl_shared_lock` parameter
- `send_packet()` can be called even if `recv_packet()` received an EOF marker

### For `AsyncTCPNetworkServer`
- `socket.shutdown(SHUT_WR)` is called before closing the socket, if it is supported