### PR TITLE
Fixed use of `getaddrinfo()` in both sync and async contexts

### DIFF
--- a/src/easynetwork/api_async/backend/abc.py
+++ b/src/easynetwork/api_async/backend/abc.py
@@ -443,7 +443,7 @@ class AbstractAsyncBackend(metaclass=ABCMeta):
     async def create_udp_endpoint(
         self,
         *,
-        local_address: tuple[str | None, int] | None = ...,
+        local_address: tuple[str, int] | None = ...,
         remote_address: tuple[str, int] | None = ...,
         reuse_port: bool = ...,
     ) -> AbstractAsyncDatagramSocketAdapter:

--- a/src/easynetwork/api_async/client/udp.py
+++ b/src/easynetwork/api_async/client/udp.py
@@ -100,7 +100,7 @@ class AsyncUDPNetworkEndpoint(Generic[_SentPacketT, _ReceivedPacketT]):
                 self.__socket_builder = SingleTaskRunner(backend, backend.wrap_udp_socket, socket, **kwargs)
             case _:
                 if kwargs.get("local_address") is None:
-                    kwargs["local_address"] = (None, 0)
+                    kwargs["local_address"] = ("localhost", 0)
                 self.__socket_builder = SingleTaskRunner(backend, backend.create_udp_endpoint, **kwargs)
 
         self.__receive_lock: ILock = backend.create_lock()

--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -91,6 +91,9 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
 
         assert isinstance(protocol, DatagramProtocol)
 
+        if host is None:
+            host = "localhost"
+
         self.__socket_factory: Callable[[], Coroutine[Any, Any, AbstractAsyncDatagramSocketAdapter]] | None
         self.__socket_factory = _make_callback(
             backend.create_udp_endpoint,

--- a/src/easynetwork/api_sync/client/udp.py
+++ b/src/easynetwork/api_sync/client/udp.py
@@ -62,7 +62,7 @@ class UDPNetworkEndpoint(Generic[_SentPacketT, _ReceivedPacketT]):
         /,
         protocol: DatagramProtocol[_SentPacketT, _ReceivedPacketT],
         *,
-        local_address: tuple[str | None, int] | None = ...,
+        local_address: tuple[str, int] | None = ...,
         remote_address: tuple[str, int] | None = ...,
         reuse_port: bool = ...,
         retry_interval: float = ...,
@@ -106,14 +106,13 @@ class UDPNetworkEndpoint(Generic[_SentPacketT, _ReceivedPacketT]):
             self.__retry_interval = None
 
         socket: _socket.socket
-        peername: SocketAddress | None = None
         external_socket: bool
         match kwargs:
             case {"socket": _socket.socket() as socket, **remainder} if not remainder:
                 external_socket = True
             case _ if "socket" not in kwargs:
                 external_socket = False
-                socket, peername = _create_udp_socket(**kwargs)
+                socket = _create_udp_socket(**kwargs)
             case _:  # pragma: no cover
                 raise TypeError("Invalid arguments")
 
@@ -125,10 +124,10 @@ class UDPNetworkEndpoint(Generic[_SentPacketT, _ReceivedPacketT]):
             _check_socket_family(socket.family)
             if external_socket:
                 _ensure_datagram_socket_bound(socket)
-                try:
-                    peername = new_socket_address(socket.getpeername(), socket.family)
-                except OSError:
-                    peername = None
+            try:
+                peername = new_socket_address(socket.getpeername(), socket.family)
+            except OSError:
+                peername = None
 
             # Do not use global default timeout here
             socket.settimeout(0)
@@ -375,55 +374,78 @@ class UDPNetworkClient(AbstractNetworkClient[_SentPacketT, _ReceivedPacketT], Ge
 
 def _create_udp_socket(
     *,
-    local_address: tuple[str | None, int] | None = None,
+    local_address: tuple[str, int] | None = None,
     remote_address: tuple[str, int] | None = None,
     reuse_port: bool = False,
-) -> tuple[_socket.socket, SocketAddress | None]:
+) -> _socket.socket:
     local_host: str | None
     local_port: int
     if local_address is None:
-        local_host = None
+        local_host = "localhost"
         local_port = 0
+        local_address = (local_host, local_port)
     else:
         local_host, local_port = local_address
-        if local_host == "":
-            local_host = None
-        assert local_port is not None, "Expected 'port' to be an int"
+
+    flags: int = 0
+    if not remote_address:
+        flags |= _socket.AI_PASSIVE
 
     errors: list[OSError] = []
 
     for family, _, proto, _, sockaddr in _socket.getaddrinfo(
-        local_host,
-        local_port,
+        *(remote_address or local_address),
         family=_socket.AF_UNSPEC,
         type=_socket.SOCK_DGRAM,
-        flags=_socket.AI_PASSIVE,
+        flags=flags,
     ):
-        socket = _socket.socket(family, _socket.SOCK_DGRAM, proto)
+        try:
+            socket = _socket.socket(family, _socket.SOCK_DGRAM, proto)
+        except OSError as exc:
+            errors.append(exc)
+            continue
+        except BaseException:
+            errors.clear()
+            raise
         try:
             if reuse_port:
                 _set_reuseport(socket)
 
-            socket.bind(sockaddr)
+            if remote_address is None:
+                local_sockaddr = sockaddr
+                remote_sockaddr = None
+            else:
+                local_sockaddr = local_address
+                remote_sockaddr = sockaddr
 
-            peername: SocketAddress | None = None
-            if remote_address is not None:
-                remote_host, remote_port = remote_address
-                socket.connect((remote_host, remote_port))
-                peername = new_socket_address(socket.getpeername(), socket.family)
-            return socket, peername
+            del sockaddr
+
+            try:
+                socket.bind(local_sockaddr)
+            except OSError as exc:
+                msg = f"error while attempting to bind to address {local_sockaddr!r}: {exc.strerror.lower()}"
+                raise OSError(exc.errno, msg).with_traceback(exc.__traceback__) from None
+            if remote_sockaddr:
+                socket.connect(remote_sockaddr)
+
+            errors.clear()
+            return socket
         except OSError as exc:
             socket.close()
             errors.append(exc)
             continue
         except BaseException:
+            errors.clear()
             socket.close()
             raise
 
     if errors:
         try:
-            raise ExceptionGroup("Error when trying to create the UDP socket", errors)
+            raise ExceptionGroup("Could not create the UDP socket", errors)
         finally:
-            errors = []
-
-    raise OSError(f"getaddrinfo({local_host!r}) returned empty list")
+            errors.clear()
+    elif remote_address is not None:
+        remote_host = remote_address[0]
+        raise OSError(f"getaddrinfo({remote_host!r}) returned empty list")
+    else:
+        raise OSError(f"getaddrinfo({local_host!r}) returned empty list")

--- a/src/easynetwork/tools/_utils.py
+++ b/src/easynetwork/tools/_utils.py
@@ -268,7 +268,7 @@ def ensure_datagram_socket_bound(sock: _socket.socket) -> None:
         is_bound = False
 
     if not is_bound:
-        sock.bind(("", 0))
+        sock.bind(("localhost", 0))
 
 
 def set_reuseport(sock: SupportsSocketOptions) -> None:

--- a/src/easynetwork_asyncio/_utils.py
+++ b/src/easynetwork_asyncio/_utils.py
@@ -17,7 +17,7 @@ from typing import Any
 from easynetwork.tools._utils import set_reuseport as _set_reuseport
 
 
-async def _ensure_resolved(
+async def ensure_resolved(
     host: str | None,
     port: int,
     family: int,
@@ -39,17 +39,126 @@ async def _ensure_resolved(
     return info
 
 
-async def _create_socket_from_getaddrinfo_result(
-    socktype: int,
-    local_addrinfo: Sequence[tuple[int, int, int, str, tuple[Any, ...]]] | None,
-    remote_addrinfo: Sequence[tuple[int, int, int, str, tuple[Any, ...]]] | None,
+async def create_connection(
+    host: str,
+    port: int,
     loop: asyncio.AbstractEventLoop,
-    reuse_port: bool,
+    local_address: tuple[str, int] | None = None,
 ) -> _socket.socket:
-    assert local_addrinfo or remote_addrinfo, "Either 'local_addrinfo' or 'remote_addrinfo' must be defined (and not empty)"
-    assert all(
-        type_ == socktype for info in (local_addrinfo or (), remote_addrinfo or ()) for _, type_, _, _, _ in info
-    ), f"socket type mismatch with those in getaddrinfo() result ({socktype=!r})"
+    remote_addrinfo: Sequence[tuple[int, int, int, str, tuple[Any, ...]]] = await ensure_resolved(
+        host,
+        port,
+        family=_socket.AF_UNSPEC,
+        type=_socket.SOCK_STREAM,
+        loop=loop,
+    )
+    local_addrinfo: Sequence[tuple[int, int, int, str, tuple[Any, ...]]] | None = None
+    if local_address is not None:
+        local_host, local_port = local_address
+        local_addrinfo = await ensure_resolved(
+            local_host,
+            local_port,
+            family=_socket.AF_UNSPEC,
+            type=_socket.SOCK_STREAM,
+            loop=loop,
+        )
+
+    errors: list[OSError] = []
+    for family, _, proto, _, remote_sockaddr in remote_addrinfo:
+        try:
+            socket = _socket.socket(family, _socket.SOCK_STREAM, proto)
+        except OSError as exc:
+            errors.append(exc)
+            continue
+        except BaseException:
+            errors.clear()
+            raise
+        try:
+            socket.setblocking(False)
+
+            if local_addrinfo is not None:
+                bind_errors: list[OSError] = []
+                try:
+                    for lfamily, _, _, _, local_sockaddr in local_addrinfo:
+                        # skip local addresses of different family
+                        if lfamily != family:
+                            continue
+                        try:
+                            socket.bind(local_sockaddr)
+                            break
+                        except OSError as exc:
+                            msg = f"error while attempting to bind on address {local_sockaddr!r}: {exc.strerror.lower()}"
+                            bind_errors.append(OSError(exc.errno, msg).with_traceback(exc.__traceback__))
+                    else:  # all bind attempts failed
+                        if bind_errors:
+                            socket.close()
+                            errors.extend(bind_errors)
+                            continue
+                        raise OSError(f"no matching local address with {family=} found")
+                finally:
+                    bind_errors.clear()
+                    del bind_errors
+
+            await loop.sock_connect(socket, remote_sockaddr)
+            errors.clear()
+            return socket
+        except OSError as exc:
+            socket.close()
+            errors.append(exc)
+            continue
+        except BaseException:
+            errors.clear()
+            socket.close()
+            raise
+
+    assert errors
+    try:
+        raise ExceptionGroup("create_connection() failed", errors)
+    finally:
+        errors.clear()
+
+
+async def create_datagram_socket(
+    loop: asyncio.AbstractEventLoop,
+    family: int = 0,
+    local_address: tuple[str, int] | None = None,
+    remote_address: tuple[str, int] | None = None,
+    reuse_port: bool = False,
+) -> _socket.socket:
+    if local_address is None and remote_address is None:
+        if family == 0:
+            raise ValueError("unexpected address family")
+        socket = _socket.socket(family, _socket.SOCK_DGRAM, _socket.IPPROTO_UDP)
+        try:
+            socket.setblocking(False)
+            if reuse_port:
+                _set_reuseport(socket)
+        except BaseException:
+            socket.close()
+            raise
+        return socket
+
+    local_addrinfo: Sequence[tuple[int, int, int, str, tuple[Any, ...]]] | None = None
+    if local_address is not None:
+        local_host, local_port = local_address
+        local_addrinfo = await ensure_resolved(
+            local_host,
+            local_port,
+            family=family,
+            type=_socket.SOCK_DGRAM,
+            loop=loop,
+            flags=_socket.AI_PASSIVE if remote_address is None else 0,
+        )
+    remote_addrinfo: Sequence[tuple[int, int, int, str, tuple[Any, ...]]] | None = None
+    if remote_address is not None:
+        remote_host, remote_port = remote_address
+        remote_addrinfo = await ensure_resolved(
+            remote_host,
+            remote_port,
+            family=family,
+            type=_socket.SOCK_DGRAM,
+            loop=loop,
+        )
 
     ## Taken from asyncio.base_events module
     ## c.f. https://github.com/python/cpython/blob/v3.11.2/Lib/asyncio/base_events.py#L1325
@@ -58,8 +167,8 @@ async def _create_socket_from_getaddrinfo_result(
     addr_infos: dict[tuple[int, int], list[tuple[Any, ...] | None]] = {}  # Using order preserving dict
     for idx, infos in ((0, local_addrinfo), (1, remote_addrinfo)):
         if infos is not None:
-            for af, _, proto, _, address in infos:
-                key = (af, proto)
+            for family, _, proto, _, address in infos:
+                key = (family, proto)
                 if key not in addr_infos:
                     addr_infos[key] = [None, None]
                 addr_infos[key][idx] = address
@@ -73,116 +182,51 @@ async def _create_socket_from_getaddrinfo_result(
 
     errors: list[OSError] = []
 
-    for (af, proto), (local_address, remote_address) in addr_pairs_info:
-        socket: _socket.socket | None = None
+    del local_address, remote_address
+
+    for (family, proto), (local_sockaddr, remote_sockaddr) in addr_pairs_info:
         try:
-            socket = _socket.socket(af, socktype, proto)
+            socket = _socket.socket(family, _socket.SOCK_DGRAM, proto)
+        except OSError as exc:
+            errors.append(exc)
+            continue
+        except BaseException:
+            errors.clear()
+            raise
+        try:
             socket.setblocking(False)
 
             if reuse_port:
                 _set_reuseport(socket)
 
-            if local_address is not None:
+            if local_sockaddr is not None:
                 try:
-                    socket.bind(local_address)
+                    socket.bind(local_sockaddr)
                 except OSError as exc:
-                    msg = f"error while attempting to bind on address {local_address!r}: {exc.strerror.lower()}"
+                    msg = f"error while attempting to bind to address {local_sockaddr!r}: {exc.strerror.lower()}"
                     raise OSError(exc.errno, msg).with_traceback(exc.__traceback__) from None
 
-            if remote_address is not None:
-                await loop.sock_connect(socket, remote_address)
+            if remote_sockaddr is not None:
+                await loop.sock_connect(socket, remote_sockaddr)
 
             errors.clear()
             return socket
         except OSError as exc:
             errors.append(exc)
-            if socket is not None:
-                socket.close()
+            socket.close()
             continue
         except BaseException:
-            if socket is not None:
-                socket.close()
+            errors.clear()
+            socket.close()
             raise
 
     if errors:
         try:
             raise ExceptionGroup("Errors while attempting to create socket", errors)
         finally:
-            errors = []
+            errors.clear()
 
     raise OSError("No matching local/remote pair according to family and proto found")
-
-
-async def create_connection(
-    host: str,
-    port: int,
-    loop: asyncio.AbstractEventLoop,
-    local_address: tuple[str, int] | None = None,
-) -> _socket.socket:
-    remote_addrinfo: Sequence[tuple[int, int, int, str, tuple[Any, ...]]] = await _ensure_resolved(
-        host,
-        port,
-        family=_socket.AF_UNSPEC,
-        type=_socket.SOCK_STREAM,
-        loop=loop,
-    )
-    local_addrinfo: Sequence[tuple[int, int, int, str, tuple[Any, ...]]] | None = None
-    if local_address is not None:
-        local_host, local_port = local_address
-        local_addrinfo = await _ensure_resolved(
-            local_host,
-            local_port,
-            family=_socket.AF_UNSPEC,
-            type=_socket.SOCK_STREAM,
-            loop=loop,
-        )
-
-    return await _create_socket_from_getaddrinfo_result(
-        _socket.SOCK_STREAM,
-        local_addrinfo=local_addrinfo,
-        remote_addrinfo=remote_addrinfo,
-        loop=loop,
-        reuse_port=False,
-    )
-
-
-async def create_datagram_socket(
-    loop: asyncio.AbstractEventLoop,
-    local_address: tuple[str | None, int] | None = None,
-    remote_address: tuple[str, int] | None = None,
-    reuse_port: bool = False,
-) -> _socket.socket:
-    if local_address is None:
-        local_address = (None, 0)
-    local_host, local_port = local_address
-    if local_host == "":
-        local_host = None
-    local_addrinfo: Sequence[tuple[int, int, int, str, tuple[Any, ...]]] = await _ensure_resolved(
-        local_host,
-        local_port,
-        family=_socket.AF_UNSPEC,
-        type=_socket.SOCK_DGRAM,
-        loop=loop,
-        flags=_socket.AI_PASSIVE,
-    )
-    remote_addrinfo: Sequence[tuple[int, int, int, str, tuple[Any, ...]]] | None = None
-    if remote_address is not None:
-        remote_host, remote_port = remote_address
-        remote_addrinfo = await _ensure_resolved(
-            remote_host,
-            remote_port,
-            family=_socket.AF_UNSPEC,
-            type=_socket.SOCK_DGRAM,
-            loop=loop,
-        )
-
-    return await _create_socket_from_getaddrinfo_result(
-        _socket.SOCK_DGRAM,
-        local_addrinfo=local_addrinfo,
-        remote_addrinfo=remote_addrinfo,
-        loop=loop,
-        reuse_port=reuse_port,
-    )
 
 
 def open_listener_sockets_from_getaddrinfo_result(
@@ -194,8 +238,12 @@ def open_listener_sockets_from_getaddrinfo_result(
 ) -> list[_socket.socket]:
     sockets: list[_socket.socket] = []
     reuse_address = reuse_address and hasattr(_socket, "SO_REUSEADDR")
-    with contextlib.ExitStack() as socket_exit_stack:
+    with contextlib.ExitStack() as _whole_context_stack:
         errors: list[OSError] = []
+        _whole_context_stack.callback(errors.clear)
+
+        socket_exit_stack = _whole_context_stack.enter_context(contextlib.ExitStack())
+
         for af, _, proto, _, sa in infos:
             try:
                 sock = socket_exit_stack.enter_context(contextlib.closing(_socket.socket(af, _socket.SOCK_STREAM, proto)))
@@ -221,17 +269,15 @@ def open_listener_sockets_from_getaddrinfo_result(
             except OSError as exc:
                 errors.append(
                     OSError(
-                        exc.errno, f"error while attempting to bind on address {sa!r}: {exc.strerror.lower()}"
+                        exc.errno, f"error while attempting to bind to address {sa!r}: {exc.strerror.lower()}"
                     ).with_traceback(exc.__traceback__)
                 )
                 continue
             sock.listen(backlog)
 
         if errors:
-            try:
-                raise ExceptionGroup("Error when trying to create TCP listeners", errors)
-            finally:
-                errors = []
+            # No need to call errors.clear(), this is done by exit stack
+            raise ExceptionGroup("Error when trying to create TCP listeners", errors)
 
         # There were no errors, therefore do not close the sockets
         socket_exit_stack.pop_all()

--- a/src/easynetwork_asyncio/backend.py
+++ b/src/easynetwork_asyncio/backend.py
@@ -388,24 +388,15 @@ class AsyncioBackend(AbstractAsyncBackend):
         family: int = 0
         if local_address is None and remote_address is None:
             family = _socket.AF_INET
-        if not self.__use_asyncio_transport:
-            loop = asyncio.get_running_loop()
-            socket = await create_datagram_socket(
-                loop=loop,
-                family=family,
-                local_address=local_address,
-                remote_address=remote_address,
-                reuse_port=reuse_port,
-            )
-            return RawDatagramSocketAdapter(socket, loop)
 
-        endpoint = await create_datagram_endpoint(
+        socket = await create_datagram_socket(
+            loop=asyncio.get_running_loop(),
             family=family,
-            local_addr=local_address,
-            remote_addr=remote_address,
+            local_address=local_address,
+            remote_address=remote_address,
             reuse_port=reuse_port,
         )
-        return AsyncioTransportDatagramSocketAdapter(endpoint)
+        return await self.wrap_udp_socket(socket)
 
     async def wrap_udp_socket(self, socket: _socket.socket) -> AsyncioTransportDatagramSocketAdapter | RawDatagramSocketAdapter:
         assert socket is not None, "Expected 'socket' to be a socket.socket instance"

--- a/src/easynetwork_asyncio/socket.py
+++ b/src/easynetwork_asyncio/socket.py
@@ -83,7 +83,6 @@ class AsyncSocket:
             await asyncio.shield(self.__close_waiter)
             return
         async with contextlib.AsyncExitStack() as stack:
-            stack.push_async_callback(asyncio.sleep, 0)
             stack.callback(self.__close_waiter.set_result, None)
             stack.callback(socket.close)
 
@@ -97,6 +96,8 @@ class AsyncSocket:
             futures_to_wait_for_completion: set[asyncio.Future[None]] = set(self.__waiters.values())
             if futures_to_wait_for_completion:
                 await asyncio.wait(futures_to_wait_for_completion, return_when=asyncio.ALL_COMPLETED)
+
+        await asyncio.sleep(0)
 
     async def accept(self) -> tuple[_socket.socket, _socket._RetAddress]:
         with self.__conflict_detection("accept", abort_errno=_errno.EINTR) as socket:

--- a/src/easynetwork_asyncio/stream/listener.py
+++ b/src/easynetwork_asyncio/stream/listener.py
@@ -19,7 +19,6 @@ from easynetwork.api_async.backend.abc import (
     AbstractAsyncListenerSocketAdapter,
     AbstractAsyncStreamSocketAdapter,
 )
-from easynetwork.tools.constants import MAX_STREAM_BUFSIZE
 
 from ..socket import AsyncSocket
 from .socket import AsyncioTransportStreamSocketAdapter, RawStreamSocketAdapter
@@ -111,7 +110,7 @@ class AcceptedSocket(_BaseAcceptedSocket):
         if not self.__use_asyncio_transport:
             return RawStreamSocketAdapter(socket, loop)
 
-        reader = asyncio.streams.StreamReader(MAX_STREAM_BUFSIZE, loop)
+        reader = asyncio.streams.StreamReader(loop=loop)
         protocol = asyncio.streams.StreamReaderProtocol(reader, loop=loop)
         transport, _ = await loop.connect_accepted_socket(lambda: protocol, socket)
         writer = asyncio.streams.StreamWriter(transport, protocol, reader, loop)
@@ -141,7 +140,7 @@ class AcceptedSSLSocket(_BaseAcceptedSocket):
 
     async def _make_socket_adapter(self, socket: _socket.socket) -> AbstractAsyncStreamSocketAdapter:
         loop = self.loop
-        reader = asyncio.streams.StreamReader(MAX_STREAM_BUFSIZE, loop)
+        reader = asyncio.streams.StreamReader(loop=loop)
         protocol = asyncio.streams.StreamReaderProtocol(reader, loop=loop)
         transport, _ = await loop.connect_accepted_socket(
             lambda: protocol,

--- a/src/easynetwork_asyncio/stream/socket.py
+++ b/src/easynetwork_asyncio/stream/socket.py
@@ -76,8 +76,6 @@ class AsyncioTransportStreamSocketAdapter(AbstractAsyncStreamSocketAdapter):
     async def recv(self, bufsize: int, /) -> bytes:
         if bufsize < 0:
             raise ValueError("'bufsize' must be a positive or null integer")
-        if bufsize == 0:
-            return b""
         return await self.__reader.read(bufsize)
 
     async def sendall(self, data: bytes, /) -> None:

--- a/tests/functional_test/test_communication/test_async/test_client/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_client/test_udp.py
@@ -93,21 +93,6 @@ class TestAsyncUDPNetworkClient:
             assert client.is_connected()
             yield client
 
-    @pytest.mark.parametrize("ipaddr_any", ["", None], ids=repr)
-    async def test____dunder_init____local_address____bind_to_all_interfaces(
-        self,
-        remote_address: tuple[str, int],
-        ipaddr_any: str,
-        datagram_protocol: DatagramProtocol[str, str],
-    ) -> None:
-        async with AsyncUDPNetworkClient(
-            remote_address,
-            datagram_protocol,
-            local_address=(ipaddr_any, 0),
-        ) as client:
-            assert client.is_connected()
-            assert client.get_local_address().port > 0
-
     async def test____dunder_init____remote_address____not_set(
         self,
         udp_socket_factory: Callable[[], Socket],
@@ -499,16 +484,6 @@ class TestAsyncUDPNetworkEndpoint:
 
         socket = Socket(socket_family, SOCK_DGRAM)
         async with AsyncUDPNetworkEndpoint(socket=socket, protocol=datagram_protocol) as client:
-            assert client.is_bound()
-            assert client.get_local_address().port > 0
-
-    @pytest.mark.parametrize("ipaddr_any", ["", None], ids=repr)
-    async def test____dunder_init____local_address____bind_to_all_interfaces(
-        self,
-        ipaddr_any: str,
-        datagram_protocol: DatagramProtocol[str, str],
-    ) -> None:
-        async with AsyncUDPNetworkEndpoint(datagram_protocol, local_address=(ipaddr_any, 0)) as client:
             assert client.is_bound()
             assert client.get_local_address().port > 0
 

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -396,7 +396,7 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
     @pytest.mark.parametrize("host", [None, ""], ids=repr)
     @pytest.mark.parametrize("log_client_connection", [True, False], ids=lambda p: f"log_client_connection=={p}")
     @pytest.mark.parametrize("use_ssl", ["NO_SSL"], indirect=True)
-    async def test____dunder_init____bind_on_all_available_interfaces(
+    async def test____dunder_init____bind_to_all_available_interfaces(
         self,
         host: str | None,
         log_client_connection: bool,

--- a/tests/unit_test/base.py
+++ b/tests/unit_test/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from socket import AF_INET6
-from typing import TYPE_CHECKING, Any
+from socket import AF_INET, AF_INET6
+from typing import TYPE_CHECKING
 
 from easynetwork.tools.socket import AddressFamily
 
@@ -15,34 +15,67 @@ UNSUPPORTED_FAMILIES: tuple[str, ...] = tuple(sorted(get_all_socket_families().d
 
 
 class BaseTestSocket:
-    @staticmethod
+    @classmethod
+    def get_local_addr_from_family(cls, socket_family: int) -> str:
+        if socket_family == AF_INET6:
+            address = "::1"
+        else:
+            assert socket_family == AF_INET
+            address = "127.0.0.1"
+        return address
+
+    @classmethod
+    def get_any_addr_from_family(cls, socket_family: int) -> str:
+        if socket_family == AF_INET6:
+            address = "::"
+        else:
+            assert socket_family == AF_INET
+            address = "0.0.0.0"
+        return address
+
+    @classmethod
+    def get_resolved_addr_format(
+        cls,
+        address: tuple[str, int],
+        socket_family: int,
+    ) -> tuple[str, int] | tuple[str, int, int, int]:
+        if socket_family == AF_INET6:
+            return address + (0, 0)
+        return address
+
+    @classmethod
+    def get_resolved_local_addr(cls, socket_family: int) -> tuple[str, int] | tuple[str, int, int, int]:
+        return cls.get_resolved_addr_format((cls.get_local_addr_from_family(socket_family), 0), socket_family)
+
+    @classmethod
+    def get_resolved_any_addr(cls, socket_family: int) -> tuple[str, int] | tuple[str, int, int, int]:
+        return cls.get_resolved_addr_format((cls.get_any_addr_from_family(socket_family), 0), socket_family)
+
+    @classmethod
     def set_local_address_to_socket_mock(
+        cls,
         mock_socket: MagicMock,
         socket_family: int,
         address: tuple[str, int] | None,
     ) -> None:
-        additional_address_components: tuple[Any, ...] = (0, 0) if socket_family == AF_INET6 else ()
-
         if address is None:
-            if socket_family == AF_INET6:
-                address = ("::", 0)
-            else:
-                address = ("0.0.0.0", 0)
+            full_address = cls.get_resolved_local_addr(socket_family)
+        else:
+            full_address = cls.get_resolved_addr_format(address, socket_family)
 
-        mock_socket.getsockname.return_value = address + additional_address_components
+        mock_socket.getsockname.return_value = full_address
 
-    @staticmethod
+    @classmethod
     def set_remote_address_to_socket_mock(
+        cls,
         mock_socket: MagicMock,
         socket_family: int,
         address: tuple[str, int],
     ) -> None:
-        additional_address_components: tuple[Any, ...] = (0, 0) if socket_family == AF_INET6 else ()
+        mock_socket.getpeername.return_value = cls.get_resolved_addr_format(address, socket_family)
 
-        mock_socket.getpeername.return_value = address + additional_address_components
-
-    @staticmethod
-    def configure_socket_mock_to_raise_ENOTCONN(mock_socket: MagicMock) -> OSError:
+    @classmethod
+    def configure_socket_mock_to_raise_ENOTCONN(cls, mock_socket: MagicMock) -> OSError:
         import errno
         import os
 

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -27,6 +27,20 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
 
 @pytest.fixture
+def SO_REUSEPORT(monkeypatch: pytest.MonkeyPatch) -> int:
+    import socket
+
+    if not hasattr(socket, "SO_REUSEPORT"):
+        monkeypatch.setattr("socket.SO_REUSEPORT", 15, raising=False)
+    return getattr(socket, "SO_REUSEPORT")
+
+
+@pytest.fixture
+def remove_SO_REUSEPORT_support(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr("socket.SO_REUSEPORT", raising=False)
+
+
+@pytest.fixture
 def mock_socket_factory(mocker: MockerFixture) -> Callable[[], MagicMock]:
     def factory() -> MagicMock:
         mock_socket = mocker.NonCallableMagicMock(spec=Socket)

--- a/tests/unit_test/test_async/test_api/test_client/test_udp.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_udp.py
@@ -193,7 +193,6 @@ class TestAsyncUDPNetworkEndpoint(BaseTestClient):
         remote_address: tuple[str, int] | None,
         mock_datagram_protocol: MagicMock,
         mock_backend: MagicMock,
-        mocker: MockerFixture,
     ) -> None:
         # Arrange
 
@@ -208,7 +207,7 @@ class TestAsyncUDPNetworkEndpoint(BaseTestClient):
         # Assert
         mock_backend.create_udp_endpoint.assert_awaited_once_with(
             remote_address=remote_address,
-            local_address=(None, 0),
+            local_address=("localhost", 0),
         )
 
     async def test____dunder_init____backend____from_string(
@@ -290,7 +289,7 @@ class TestAsyncUDPNetworkEndpoint(BaseTestClient):
         )
 
         # Assert
-        mock_udp_socket.bind.assert_called_once_with(("", 0))
+        mock_udp_socket.bind.assert_called_once_with(("localhost", 0))
 
     async def test____context____close_endpoint_at_end(
         self,

--- a/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
@@ -1166,24 +1166,18 @@ class TestAsyncIOBackend:
         )
 
         # Assert
+        mock_create_datagram_socket.assert_awaited_once_with(
+            loop=event_loop,
+            family=expected_family,
+            local_address=local_address,
+            remote_address=remote_address,
+            reuse_port=mocker.sentinel.reuse_port,
+        )
         if use_asyncio_transport:
-            mock_create_datagram_endpoint.assert_awaited_once_with(
-                family=expected_family,
-                local_addr=local_address,
-                remote_addr=remote_address,
-                reuse_port=mocker.sentinel.reuse_port,
-            )
-            mock_create_datagram_socket.assert_not_awaited()
+            mock_create_datagram_endpoint.assert_awaited_once_with(socket=mock_udp_socket)
             mock_AsyncioTransportDatagramSocketAdapter.assert_called_once_with(mock_endpoint)
             mock_RawDatagramSocketAdapter.assert_not_called()
         else:
-            mock_create_datagram_socket.assert_awaited_once_with(
-                loop=event_loop,
-                family=expected_family,
-                local_address=local_address,
-                remote_address=remote_address,
-                reuse_port=mocker.sentinel.reuse_port,
-            )
             mock_create_datagram_endpoint.assert_not_awaited()
             mock_RawDatagramSocketAdapter.assert_called_once_with(mock_udp_socket, event_loop)
             mock_AsyncioTransportDatagramSocketAdapter.assert_not_called()

--- a/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
@@ -4,10 +4,10 @@ import asyncio
 import contextlib
 import contextvars
 from collections.abc import Callable, Sequence
+from socket import AF_INET
 from typing import TYPE_CHECKING, Any, cast
 
 from easynetwork.api_async.backend.abc import AbstractAsyncStreamSocketAdapter
-from easynetwork.tools.constants import MAX_STREAM_BUFSIZE
 from easynetwork_asyncio import AsyncioBackend
 
 import pytest
@@ -166,7 +166,6 @@ class TestAsyncIOBackend:
             **expected_ssl_kwargs,
             happy_eyeballs_delay=42,
             local_addr=local_address,
-            limit=MAX_STREAM_BUFSIZE,
         )
         mock_StreamSocketAdapter.assert_called_once_with(mock_asyncio_reader, mock_asyncio_writer)
         assert socket is mocker.sentinel.socket
@@ -224,7 +223,6 @@ class TestAsyncIOBackend:
             *remote_address,
             **expected_ssl_kwargs,
             local_addr=local_address,
-            limit=MAX_STREAM_BUFSIZE,
         )
 
     @pytest.mark.parametrize("use_asyncio_transport", [True], indirect=True)
@@ -281,7 +279,6 @@ class TestAsyncIOBackend:
             **expected_ssl_kwargs,
             local_addr=local_address,
             happy_eyeballs_delay=0.25,
-            limit=MAX_STREAM_BUFSIZE,
         )
 
     @pytest.mark.parametrize("use_asyncio_transport", [False], indirect=True)
@@ -507,10 +504,7 @@ class TestAsyncIOBackend:
 
         # Assert
         if use_asyncio_transport:
-            mock_open_connection.assert_awaited_once_with(
-                sock=mock_tcp_socket,
-                limit=MAX_STREAM_BUFSIZE,
-            )
+            mock_open_connection.assert_awaited_once_with(sock=mock_tcp_socket)
             mock_AsyncioTransportStreamSocketAdapter.assert_called_once_with(mock_asyncio_reader, mock_asyncio_writer)
             mock_RawStreamSocketAdapter.assert_not_called()
         else:
@@ -565,7 +559,6 @@ class TestAsyncIOBackend:
                 server_hostname="server_hostname",
                 ssl_handshake_timeout=123456.789,
                 ssl_shutdown_timeout=9876543.21,
-                limit=MAX_STREAM_BUFSIZE,
             )
             mock_AsyncioTransportStreamSocketAdapter.assert_called_once_with(mock_asyncio_reader, mock_asyncio_writer)
             assert socket is mocker.sentinel.socket
@@ -792,7 +785,7 @@ class TestAsyncIOBackend:
         indirect=["use_asyncio_transport"],
     )
     @pytest.mark.parametrize("remote_host", [None, ""], ids=repr)
-    async def test____create_tcp_listeners____bind_on_any_interfaces(
+    async def test____create_tcp_listeners____bind_to_any_interfaces(
         self,
         remote_host: str,
         event_loop: asyncio.AbstractEventLoop,
@@ -905,7 +898,7 @@ class TestAsyncIOBackend:
         ],
         indirect=["use_asyncio_transport"],
     )
-    async def test____create_tcp_listeners____bind_on_several_hosts(
+    async def test____create_tcp_listeners____bind_to_several_hosts(
         self,
         event_loop: asyncio.AbstractEventLoop,
         backend: AsyncioBackend,
@@ -1161,32 +1154,41 @@ class TestAsyncIOBackend:
             new_callable=mocker.AsyncMock,
             return_value=mock_udp_socket,
         )
+        expected_family = 0
+        if local_address is None and remote_address is None:
+            expected_family = AF_INET
 
         # Act
         socket = await backend.create_udp_endpoint(
             local_address=local_address,
             remote_address=remote_address,
-            reuse_port=True,
+            reuse_port=mocker.sentinel.reuse_port,
         )
 
         # Assert
-        mock_create_datagram_socket.assert_awaited_once_with(
-            loop=event_loop,
-            local_address=local_address,
-            remote_address=remote_address,
-            reuse_port=True,
-        )
         if use_asyncio_transport:
-            mock_create_datagram_endpoint.assert_awaited_once_with(socket=mock_udp_socket)
+            mock_create_datagram_endpoint.assert_awaited_once_with(
+                family=expected_family,
+                local_addr=local_address,
+                remote_addr=remote_address,
+                reuse_port=mocker.sentinel.reuse_port,
+            )
+            mock_create_datagram_socket.assert_not_awaited()
             mock_AsyncioTransportDatagramSocketAdapter.assert_called_once_with(mock_endpoint)
             mock_RawDatagramSocketAdapter.assert_not_called()
         else:
+            mock_create_datagram_socket.assert_awaited_once_with(
+                loop=event_loop,
+                family=expected_family,
+                local_address=local_address,
+                remote_address=remote_address,
+                reuse_port=mocker.sentinel.reuse_port,
+            )
             mock_create_datagram_endpoint.assert_not_awaited()
             mock_RawDatagramSocketAdapter.assert_called_once_with(mock_udp_socket, event_loop)
             mock_AsyncioTransportDatagramSocketAdapter.assert_not_called()
 
         assert socket is mocker.sentinel.socket
-        mock_udp_socket.setblocking.assert_called_with(False)
 
     async def test____wrap_udp_socket____use_loop_create_datagram_endpoint(
         self,

--- a/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
@@ -9,7 +9,6 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from easynetwork.api_async.backend.abc import AbstractAcceptedSocket
-from easynetwork.tools.constants import MAX_STREAM_BUFSIZE
 from easynetwork_asyncio.stream.listener import AcceptedSocket, AcceptedSSLSocket, ListenerSocketAdapter
 from easynetwork_asyncio.stream.socket import (
     AsyncioTransportHalfCloseableStreamSocketAdapter,
@@ -160,18 +159,19 @@ class BaseTestAsyncioTransportBasedStreamSocket(BaseTestTransportStreamSocket):
         mock_asyncio_reader.read.assert_awaited_once_with(1024)
         assert data == b"data"
 
-    async def test____recv____null_bufsize_directly_return(
+    async def test____recv____null_bufsize(
         self,
         socket: AsyncioTransportStreamSocketAdapter,
         mock_asyncio_reader: MagicMock,
     ) -> None:
         # Arrange
+        mock_asyncio_reader.read.return_value = b""
 
         # Act
         data: bytes = await socket.recv(0)
 
         # Assert
-        mock_asyncio_reader.read.assert_not_awaited()
+        mock_asyncio_reader.read.assert_awaited_once_with(0)
         assert data == b""
 
     async def test____recv____negative_bufsize_error(
@@ -578,7 +578,7 @@ class TestAcceptedSocket(BaseTestTransportStreamSocket, BaseTestSocket):
         assert socket is mock_stream_socket_adapter
         if use_asyncio_transport:
             mock_raw_stream_socket_adapter_cls.assert_not_called()
-            mock_asyncio_reader_cls.assert_called_once_with(MAX_STREAM_BUFSIZE, event_loop)
+            mock_asyncio_reader_cls.assert_called_once_with(loop=event_loop)
             mock_asyncio_reader_protocol_cls.assert_called_once_with(mock_asyncio_reader, loop=event_loop)
             mock_event_loop_connect_accepted_socket.assert_awaited_once_with(
                 mocker.ANY,  # protocol_factory
@@ -716,7 +716,7 @@ class TestAcceptedSSLSocket(BaseTestTransportStreamSocket):
         # Assert
         assert socket is mock_stream_socket_adapter
 
-        mock_asyncio_reader_cls.assert_called_once_with(MAX_STREAM_BUFSIZE, event_loop)
+        mock_asyncio_reader_cls.assert_called_once_with(loop=event_loop)
         mock_asyncio_reader_protocol_cls.assert_called_once_with(mock_asyncio_reader, loop=event_loop)
         mock_event_loop_connect_accepted_socket.assert_awaited_once_with(
             mocker.ANY,  # protocol_factory

--- a/tests/unit_test/test_tools/test_utils.py
+++ b/tests/unit_test/test_tools/test_utils.py
@@ -417,7 +417,7 @@ def test____ensure_datagram_socket_bound____socket_not_bound____null_port(
     ensure_datagram_socket_bound(mock_udp_socket)
 
     # Assert
-    mock_udp_socket.bind.assert_called_once_with(("", 0))
+    mock_udp_socket.bind.assert_called_once_with(("localhost", 0))
 
 
 def test____ensure_datagram_socket_bound____socket_not_bound____EINVAL_error_when_calling_getsockname(
@@ -432,7 +432,7 @@ def test____ensure_datagram_socket_bound____socket_not_bound____EINVAL_error_whe
     ensure_datagram_socket_bound(mock_udp_socket)
 
     # Assert
-    mock_udp_socket.bind.assert_called_once_with(("", 0))
+    mock_udp_socket.bind.assert_called_once_with(("localhost", 0))
 
 
 def test____ensure_datagram_socket_bound____already_bound(
@@ -478,12 +478,10 @@ def test____ensure_datagram_socket_bound____invalid_socket_type(
 
 def test____set_reuseport____setsockopt(
     mock_tcp_socket: MagicMock,
-    monkeypatch: pytest.MonkeyPatch,
+    SO_REUSEPORT: int,
 ) -> None:
     # Arrange
-    SO_REUSEPORT: int = 123456
     mock_tcp_socket.setsockopt.return_value = None
-    monkeypatch.setattr("socket.SO_REUSEPORT", SO_REUSEPORT, raising=False)
 
     # Act
     set_reuseport(mock_tcp_socket)
@@ -492,13 +490,12 @@ def test____set_reuseport____setsockopt(
     mock_tcp_socket.setsockopt.assert_called_once_with(SOL_SOCKET, SO_REUSEPORT, True)
 
 
+@pytest.mark.usefixtures("remove_SO_REUSEPORT_support")
 def test____set_reuseport____not_supported____not_defined(
     mock_tcp_socket: MagicMock,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Arrange
     mock_tcp_socket.setsockopt.side_effect = OSError
-    monkeypatch.delattr("socket.SO_REUSEPORT", raising=False)
 
     # Act
     with pytest.raises(ValueError, match=r"^reuse_port not supported by socket module$"):
@@ -510,12 +507,10 @@ def test____set_reuseport____not_supported____not_defined(
 
 def test____set_reuseport____not_supported____defined_but_not_implemented(
     mock_tcp_socket: MagicMock,
-    monkeypatch: pytest.MonkeyPatch,
+    SO_REUSEPORT: int,
 ) -> None:
     # Arrange
-    SO_REUSEPORT: int = 123456
     mock_tcp_socket.setsockopt.side_effect = OSError
-    monkeypatch.setattr("socket.SO_REUSEPORT", SO_REUSEPORT, raising=False)
 
     # Act
     with pytest.raises(


### PR DESCRIPTION
## What's changed
- UDP sockets are now bound to `localhost` by default, instead of all interfaces
- Bogus usage of `getaddrinfo()` is fixed

### Miscellaneous
- `asyncio.StreamReader` instances now uses the default limit
