### PR TITLE
Request handlers: `handle()` generator can be closed after a `bad_request()` call

### DIFF
--- a/src/easynetwork/api_async/server/handler.py
+++ b/src/easynetwork/api_async/server/handler.py
@@ -78,7 +78,7 @@ class AsyncBaseRequestHandler(Generic[_RequestT, _ResponseT], metaclass=ABCMeta)
         raise NotImplementedError
 
     @abstractmethod
-    async def bad_request(self, client: AsyncClientInterface[_ResponseT], exc: BaseProtocolParseError, /) -> None:
+    async def bad_request(self, client: AsyncClientInterface[_ResponseT], exc: BaseProtocolParseError, /) -> bool | None:
         raise NotImplementedError
 
 

--- a/src/easynetwork/api_async/server/tcp.py
+++ b/src/easynetwork/api_async/server/tcp.py
@@ -424,7 +424,12 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
                                         _recursively_clear_exception_traceback_frames(exception)
                                     except RecursionError:
                                         logger.warning("Recursion depth reached when clearing exception's traceback frames")
-                                    await self.__request_handler.bad_request(client, exception)
+                                    should_close_handle = not (await self.__request_handler.bad_request(client, exception))
+                                    if should_close_handle:
+                                        try:
+                                            await request_handler_generator.aclose()
+                                        finally:
+                                            request_handler_generator = None
                                 finally:
                                     del exception
                             case _ErrorAction(exception):

--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -344,7 +344,13 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
                                             _recursively_clear_exception_traceback_frames(exception)
                                         except RecursionError:
                                             logger.warning("Recursion depth reached when clearing exception's traceback frames")
-                                        await self.__request_handler.bad_request(client, exception)
+                                        should_close_handle = not (await self.__request_handler.bad_request(client, exception))
+                                        if should_close_handle:
+                                            try:
+                                                await request_handler_generator.aclose()
+                                            finally:
+                                                request_handler_generator = None
+                                            return
                                     finally:
                                         del exception
                                 case _ErrorAction(exception):


### PR DESCRIPTION
## What's changed
`AsyncBaseRequestHandler.bad_request()` can now return a boolean or `None`:
- If a false value is returned (`False` or `None`), `handle()` generator will be closed.
- If a true value is returned, the generator is left as is.

### Why ?
To avoid adding annoying error handling code, the parse errors are handled outside of `handle()`.

The side effect of this was that the `handle()` generator will ONLY be touched when the client sends something (and it is something good). For TCP servers, this is not a real problem because there is connection management. But for UDP servers, this would be a security hole.

Therefore, by default, any resource must be freed on error. This is unless the user explicitly wants to keep the generator alive for a given context.