### PR TITLE
`Task.join_or_cancel()` is reserved to system tasks

### DIFF
--- a/src/easynetwork/api_async/backend/abc.py
+++ b/src/easynetwork/api_async/backend/abc.py
@@ -131,6 +131,10 @@ class AbstractTask(Generic[_T_co], metaclass=ABCMeta):
     async def join(self) -> _T_co:
         raise NotImplementedError
 
+
+class AbstractSystemTask(AbstractTask[_T_co]):
+    __slots__ = ()
+
     @abstractmethod
     async def join_or_cancel(self) -> _T_co:
         raise NotImplementedError
@@ -368,7 +372,7 @@ class AbstractAsyncBackend(metaclass=ABCMeta):
         /,
         *args: _P.args,
         **kwargs: _P.kwargs,
-    ) -> AbstractTask[_T]:
+    ) -> AbstractSystemTask[_T]:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/easynetwork/api_async/backend/tasks.py
+++ b/src/easynetwork/api_async/backend/tasks.py
@@ -13,7 +13,7 @@ from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar
 
 if TYPE_CHECKING:
-    from .abc import AbstractAsyncBackend, AbstractTask
+    from .abc import AbstractAsyncBackend, AbstractSystemTask
 
 
 _P = ParamSpec("_P")
@@ -44,7 +44,7 @@ class SingleTaskRunner(Generic[_T_co]):
             args,
             kwargs,
         )
-        self.__task: AbstractTask[_T_co] | None = None
+        self.__task: AbstractSystemTask[_T_co] | None = None
 
     def cancel(self) -> bool:
         self.__coro_func = None

--- a/src/easynetwork/api_async/server/tcp.py
+++ b/src/easynetwork/api_async/server/tcp.py
@@ -290,7 +290,7 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             if self.__shutdown_asked:
                 self.__mainloop_task.cancel()
             try:
-                await self.__mainloop_task.join_or_cancel()
+                await self.__mainloop_task.join()
             finally:
                 self.__mainloop_task = None
 

--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -224,7 +224,7 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             if self.__shutdown_asked:
                 self.__mainloop_task.cancel()
             try:
-                await self.__mainloop_task.join_or_cancel()
+                await self.__mainloop_task.join()
             finally:
                 self.__mainloop_task = None
 

--- a/src/easynetwork_asyncio/backend.py
+++ b/src/easynetwork_asyncio/backend.py
@@ -37,7 +37,7 @@ from .datagram.socket import AsyncioTransportDatagramSocketAdapter, RawDatagramS
 from .runner import AsyncioRunner
 from .stream.listener import AcceptedSocket, AcceptedSSLSocket, ListenerSocketAdapter
 from .stream.socket import AsyncioTransportStreamSocketAdapter, RawStreamSocketAdapter
-from .tasks import Task, TaskGroup, TimeoutHandle, move_on_after, move_on_at, timeout, timeout_at
+from .tasks import SystemTask, TaskGroup, TimeoutHandle, move_on_after, move_on_at, timeout, timeout_at
 from .threads import ThreadsPortal
 
 if TYPE_CHECKING:
@@ -168,8 +168,8 @@ class AsyncioBackend(AbstractAsyncBackend):
         /,
         *args: _P.args,
         **kwargs: _P.kwargs,
-    ) -> Task[_T]:
-        return Task(asyncio.create_task(coro_func(*args, **kwargs)))
+    ) -> SystemTask[_T]:
+        return SystemTask(coro_func(*args, **kwargs))
 
     def create_task_group(self) -> TaskGroup:
         return TaskGroup()

--- a/tests/unit_test/test_async/conftest.py
+++ b/tests/unit_test/test_async/conftest.py
@@ -37,14 +37,14 @@ def fake_cancellation_cls() -> type[BaseException]:
 
 @pytest.fixture
 def mock_backend(fake_cancellation_cls: type[BaseException], mocker: MockerFixture) -> MagicMock:
-    from easynetwork_asyncio.tasks import Task, TaskGroup
+    from easynetwork_asyncio.tasks import SystemTask, TaskGroup
 
     from .._utils import AsyncDummyLock
 
     mock_backend = mocker.NonCallableMagicMock(spec=AbstractAsyncBackend)
 
     mock_backend.get_cancelled_exc_class.return_value = fake_cancellation_cls
-    mock_backend.spawn_task = lambda coro_func, *args, **kwargs: Task(asyncio.create_task(coro_func(*args, **kwargs)))
+    mock_backend.spawn_task = lambda coro_func, *args, **kwargs: SystemTask(coro_func(*args, **kwargs))
     mock_backend.create_lock = AsyncDummyLock
     mock_backend.create_event = asyncio.Event
     mock_backend.create_task_group = TaskGroup

--- a/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
+++ b/tests/unit_test/test_async/test_api/test_backend/_fake_backends.py
@@ -10,7 +10,7 @@ from easynetwork.api_async.backend.abc import (
     AbstractAsyncListenerSocketAdapter,
     AbstractAsyncStreamSocketAdapter,
     AbstractRunner,
-    AbstractTask,
+    AbstractSystemTask,
     AbstractTaskGroup,
     AbstractThreadsPortal,
     AbstractTimeoutHandle,
@@ -57,7 +57,7 @@ class BaseFakeBackend(AbstractAsyncBackend):
     def get_cancelled_exc_class(self) -> type[BaseException]:
         raise NotImplementedError
 
-    def spawn_task(self, *args: Any, **kwargs: Any) -> AbstractTask[Any]:
+    def spawn_task(self, *args: Any, **kwargs: Any) -> AbstractSystemTask[Any]:
         raise NotImplementedError
 
     def create_task_group(self) -> AbstractTaskGroup:


### PR DESCRIPTION
## What's changed
- Added `AbstractSystemTask` interface, which is a task with `join_or_cancel()` method in addition
- `AsyncBackend.spawn_task()` now must return an `AbstractSystemTask` instance.