### PR TITLE
`codecov-action` now uses the repo's CODECOV_TOKEN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
         if: hashFiles('coverage.xml') != ''  # Rudimentary `file.exists()`
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: >-  # Mark which lines are covered by which envs
             test-unit,
             Py-${{ matrix.python_version }}
@@ -98,6 +99,7 @@ jobs:
         if: hashFiles('coverage.xml') != ''  # Rudimentary `file.exists()`
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: >-  # Mark which lines are covered by which envs
             test-functional,
             OS-${{ runner.os }},


### PR DESCRIPTION
Sometimes `codecov-actions` silently fails with a `404` error code :)

```
['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
```
