### PR TITLE
Definitely fixed StandaloneServer.serve_forever() concurrency issues

### DIFF
--- a/src/easynetwork/api_async/server/__init__.py
+++ b/src/easynetwork/api_async/server/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "AsyncStreamRequestHandler",
     "AsyncTCPNetworkServer",
     "AsyncUDPNetworkServer",
+    "SupportsEventSet",
 ]
 
 from .abc import *

--- a/src/easynetwork/api_async/server/abc.py
+++ b/src/easynetwork/api_async/server/abc.py
@@ -5,15 +5,23 @@
 
 from __future__ import annotations
 
-__all__ = ["AbstractAsyncNetworkServer"]
+__all__ = [
+    "AbstractAsyncNetworkServer",
+    "SupportsEventSet",
+]
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Protocol, Self
 
 if TYPE_CHECKING:
     from types import TracebackType
 
-    from ..backend.abc import AbstractAsyncBackend, IEvent
+    from ..backend.abc import AbstractAsyncBackend
+
+
+class SupportsEventSet(Protocol):
+    def set(self) -> None:  # pragma: no cover
+        ...
 
 
 class AbstractAsyncNetworkServer(metaclass=ABCMeta):
@@ -38,7 +46,7 @@ class AbstractAsyncNetworkServer(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    async def serve_forever(self, *, is_up_event: IEvent | None = ...) -> None:
+    async def serve_forever(self, *, is_up_event: SupportsEventSet | None = ...) -> None:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/easynetwork/api_async/server/tcp.py
+++ b/src/easynetwork/api_async/server/tcp.py
@@ -47,7 +47,7 @@ from ..backend.abc import AbstractAsyncHalfCloseableStreamSocketAdapter
 from ..backend.factory import AsyncBackendFactory
 from ..backend.tasks import SingleTaskRunner
 from ._tools.actions import ErrorAction as _ErrorAction, RequestAction as _RequestAction
-from .abc import AbstractAsyncNetworkServer
+from .abc import AbstractAsyncNetworkServer, SupportsEventSet
 from .handler import AsyncBaseRequestHandler, AsyncClientInterface, AsyncStreamRequestHandler
 
 if TYPE_CHECKING:
@@ -228,7 +228,7 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         if self.__listeners_factory_runner is not None:
             self.__listeners_factory_runner.cancel()
 
-    async def serve_forever(self, *, is_up_event: IEvent | None = None) -> None:
+    async def serve_forever(self, *, is_up_event: SupportsEventSet | None = None) -> None:
         async with _contextlib.AsyncExitStack() as server_exit_stack:
             if is_up_event is not None:
                 # Force is_up_event to be set, in order not to stuck the waiting task

--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -31,7 +31,7 @@ from ...tools.socket import SocketAddress, SocketProxy, new_socket_address
 from ..backend.factory import AsyncBackendFactory
 from ..backend.tasks import SingleTaskRunner
 from ._tools.actions import ErrorAction as _ErrorAction, RequestAction as _RequestAction
-from .abc import AbstractAsyncNetworkServer
+from .abc import AbstractAsyncNetworkServer, SupportsEventSet
 from .handler import AsyncBaseRequestHandler, AsyncClientInterface
 
 if TYPE_CHECKING:
@@ -169,7 +169,7 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         if self.__socket_factory_runner is not None:
             self.__socket_factory_runner.cancel()
 
-    async def serve_forever(self, *, is_up_event: IEvent | None = None) -> None:
+    async def serve_forever(self, *, is_up_event: SupportsEventSet | None = None) -> None:
         async with _contextlib.AsyncExitStack() as server_exit_stack:
             if is_up_event is not None:
                 # Force is_up_event to be set, in order not to stuck the waiting task

--- a/src/easynetwork/api_sync/server/__init__.py
+++ b/src/easynetwork/api_sync/server/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "StandaloneNetworkServerThread",
     "StandaloneTCPNetworkServer",
     "StandaloneUDPNetworkServer",
+    "SupportsEventSet",
 ]
 
 from .abc import *

--- a/src/easynetwork/api_sync/server/_base.py
+++ b/src/easynetwork/api_sync/server/_base.py
@@ -14,10 +14,10 @@ from typing import TYPE_CHECKING, Self
 
 from ...exceptions import ServerAlreadyRunning, ServerClosedError
 from ...tools._lock import ForkSafeLock
-from .abc import AbstractStandaloneNetworkServer
+from .abc import AbstractStandaloneNetworkServer, SupportsEventSet
 
 if TYPE_CHECKING:
-    from ...api_async.backend.abc import AbstractRunner, AbstractThreadsPortal, IEvent
+    from ...api_async.backend.abc import AbstractRunner, AbstractThreadsPortal
     from ...api_async.server.abc import AbstractAsyncNetworkServer
 
 
@@ -47,14 +47,14 @@ class BaseStandaloneNetworkServerImpl(AbstractStandaloneNetworkServer):
         return super().__enter__()
 
     def is_serving(self) -> bool:
-        if (portal := self.__threads_portal) is not None:
+        if (portal := self._portal) is not None:
             with _contextlib.suppress(RuntimeError):
                 return portal.run_sync(self.__server.is_serving)
         return False
 
     def server_close(self) -> None:
         with self.__close_lock.get(), _contextlib.ExitStack() as stack, _contextlib.suppress(RuntimeError):
-            if (portal := self.__threads_portal) is not None:
+            if (portal := self._portal) is not None:
                 CancelledError = self.__server.get_backend().get_cancelled_exc_class()
                 with _contextlib.suppress(CancelledError):
                     portal.run_coroutine(self.__server.server_close)
@@ -67,7 +67,7 @@ class BaseStandaloneNetworkServerImpl(AbstractStandaloneNetworkServer):
                 runner.run(self.__server.server_close)
 
     def shutdown(self, timeout: float | None = None) -> None:
-        if (portal := self.__threads_portal) is not None:
+        if (portal := self._portal) is not None:
             CancelledError = self.__server.get_backend().get_cancelled_exc_class()
             with _contextlib.suppress(RuntimeError, CancelledError):
                 # If shutdown() have been cancelled, that means the scheduler itself is shutting down, and this is what we want
@@ -83,54 +83,53 @@ class BaseStandaloneNetworkServerImpl(AbstractStandaloneNetworkServer):
 
     async def __do_shutdown_with_timeout(self, timeout_delay: float) -> None:
         backend = self.__server.get_backend()
-        with _contextlib.suppress(TimeoutError):
-            async with backend.timeout(timeout_delay):
-                await self.__server.shutdown()
+        async with backend.move_on_after(timeout_delay):
+            await self.__server.shutdown()
 
-    def serve_forever(self, *, is_up_event: _threading.Event | None = None) -> None:
-        async def serve_forever() -> None:
+    def serve_forever(self, *, is_up_event: SupportsEventSet | None = None) -> None:
+        async def serve_forever(locks_stack: _contextlib.ExitStack) -> None:
             backend = self.__server.get_backend()
             try:
                 self.__threads_portal = backend.create_threads_portal()
-                is_up_event_async: IEvent | None = None
-                async with backend.create_task_group() as task_group:
-                    if is_up_event is not None:
-                        is_up_event_async = backend.create_event()
 
-                        async def wait_and_set_event(is_up_event_async: IEvent, is_up_event: _threading.Event) -> None:
-                            await is_up_event_async.wait()
-                            is_up_event.set()
+                # Initialization finished; release the locks
+                locks_stack.close()
 
-                        task_group.start_soon(wait_and_set_event, is_up_event_async, is_up_event)
-                        del wait_and_set_event
-                    await self.__server.serve_forever(is_up_event=is_up_event_async)
+                await self.__server.serve_forever(is_up_event=is_up_event)
             finally:
                 self.__threads_portal = None
-                await backend.coro_yield()  # Everyone must know about the server's death :)
+                await backend.cancel_shielded_coro_yield()  # Everyone must know about the server's death :)
 
         backend = self.__server.get_backend()
-        with _contextlib.ExitStack() as stack, _contextlib.suppress(backend.get_cancelled_exc_class()):
+        with _contextlib.ExitStack() as server_exit_stack, _contextlib.suppress(backend.get_cancelled_exc_class()):
             if is_up_event is not None:
                 # Force is_up_event to be set, in order not to stuck the waiting thread
-                stack.callback(is_up_event.set)
+                server_exit_stack.callback(is_up_event.set)
 
-            with self.__close_lock.get():
-                runner = self.__runner
-                if runner is None:
-                    raise ServerClosedError("Closed server")
+            # locks_stack is used to acquire locks until
+            # serve_forever() coroutine creates the thread portal
+            locks_stack = server_exit_stack.enter_context(_contextlib.ExitStack())
+            locks_stack.enter_context(self.__close_lock.get())
+            locks_stack.enter_context(self.__bootstrap_lock.get())
 
-            with self.__bootstrap_lock.get():
-                if not self.__is_shutdown.is_set():
-                    raise ServerAlreadyRunning("Server is already running")
+            runner = self.__runner
+            if runner is None:
+                raise ServerClosedError("Closed server")
 
-                def safe_shutdown_set() -> None:
-                    with self.__bootstrap_lock.get():
-                        self.__is_shutdown.set()
+            if not self.__is_shutdown.is_set():
+                raise ServerAlreadyRunning("Server is already running")
 
-                self.__is_shutdown.clear()
-                stack.callback(safe_shutdown_set)
+            self.__is_shutdown.clear()
+            server_exit_stack.callback(self.__is_shutdown.set)
 
-            runner.run(serve_forever)
+            # Ensure all coroutines/callbacks scheduled in threads are finished (100ms is quite sufficient)
+            server_exit_stack.callback(runner.run, backend.sleep, 0.1)  # type: ignore[arg-type]
+
+            try:
+                runner.run(serve_forever, locks_stack)
+            finally:
+                # Acquire the bootstrap lock at teardown, before calling is_shutdown.set().
+                locks_stack.enter_context(self.__bootstrap_lock.get())
 
     @property
     def _server(self) -> AbstractAsyncNetworkServer:
@@ -138,4 +137,5 @@ class BaseStandaloneNetworkServerImpl(AbstractStandaloneNetworkServer):
 
     @property
     def _portal(self) -> AbstractThreadsPortal | None:
-        return self.__threads_portal
+        with self.__bootstrap_lock.get():
+            return self.__threads_portal

--- a/src/easynetwork/api_sync/server/abc.py
+++ b/src/easynetwork/api_sync/server/abc.py
@@ -7,13 +7,15 @@ from __future__ import annotations
 
 __all__ = [
     "AbstractStandaloneNetworkServer",
+    "SupportsEventSet",
 ]
 
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Any, Self
 
+from ...api_async.server.abc import SupportsEventSet
+
 if TYPE_CHECKING:
-    import threading as _threading
     from types import TracebackType
 
 
@@ -39,7 +41,7 @@ class AbstractStandaloneNetworkServer(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def serve_forever(self, *, is_up_event: _threading.Event | None = ...) -> None:
+    def serve_forever(self, *, is_up_event: SupportsEventSet | None = ...) -> None:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/easynetwork_asyncio/backend.py
+++ b/src/easynetwork_asyncio/backend.py
@@ -140,7 +140,7 @@ class AsyncioBackend(AbstractAsyncBackend):
                 TimeoutHandle._reschedule_delayed_task_cancel(current_task, task_cancel_msg)
         finally:
             task_cancel_msg = None
-            del current_task, future
+            del current_task, future, abort_func
 
     @staticmethod
     def _get_cancelled_error_message(exc: asyncio.CancelledError) -> str | None:
@@ -438,20 +438,27 @@ class AsyncioBackend(AbstractAsyncBackend):
     async def wait_future(self, future: concurrent.futures.Future[_T_co]) -> _T_co:
         if not future.done():
             future_wrapper = asyncio.wrap_future(future)
-            # If future.cancel() failed, that means future.set_running_or_notify_cancel() has been called
-            # and set future in RUNNING state.
-            # This future cannot be cancelled anymore, therefore it must be awaited.
-            await self._cancel_shielded_wait_asyncio_future(future_wrapper, future.cancel)
-            if not future_wrapper.cancelled():
-                # Unwrap "future_wrapper" instead to prevent reports about unhandled exceptions.
-                assert future_wrapper.done()  # nosec assert_used
-                return future_wrapper.result()
+            try:
+                # If future.cancel() failed, that means future.set_running_or_notify_cancel() has been called
+                # and set future in RUNNING state.
+                # This future cannot be cancelled anymore, therefore it must be awaited.
+                await self._cancel_shielded_wait_asyncio_future(future_wrapper, future.cancel)
+                if not future_wrapper.cancelled():
+                    del future
+                    # Unwrap "future_wrapper" instead to prevent reports about unhandled exceptions.
+                    assert future_wrapper.done()  # nosec assert_used
+                    return future_wrapper.result()
+            finally:
+                del future_wrapper
             assert future.done()  # nosec assert_used
 
-        if future.cancelled():
-            # Task cancellation prevails over future cancellation
-            await asyncio.sleep(0)
-        return future.result()
+        try:
+            if future.cancelled():
+                # Task cancellation prevails over future cancellation
+                await asyncio.sleep(0)
+            return future.result()
+        finally:
+            del future
 
     def using_asyncio_transport(self) -> bool:
         return self.__use_asyncio_transport


### PR DESCRIPTION
## What's changed
- `serve_forever()` methods now accept any `Event`-like object with a `set()` method.
- `AsyncioRunner.run()` does not cancel idle tasks anymore.