### PR TITLE
Servers: New request handler API

### DIFF
--- a/src/easynetwork/api_async/server/__init__.py
+++ b/src/easynetwork/api_async/server/__init__.py
@@ -7,8 +7,11 @@ from __future__ import annotations
 
 __all__ = [
     "AbstractAsyncNetworkServer",
+    "AsyncBaseClientInterface",
     "AsyncBaseRequestHandler",
-    "AsyncClientInterface",
+    "AsyncDatagramClient",
+    "AsyncDatagramRequestHandler",
+    "AsyncStreamClient",
     "AsyncStreamRequestHandler",
     "AsyncTCPNetworkServer",
     "AsyncUDPNetworkServer",

--- a/src/easynetwork/api_async/server/tcp.py
+++ b/src/easynetwork/api_async/server/tcp.py
@@ -48,7 +48,7 @@ from ..backend.factory import AsyncBackendFactory
 from ..backend.tasks import SingleTaskRunner
 from ._tools.actions import ErrorAction as _ErrorAction, RequestAction as _RequestAction
 from .abc import AbstractAsyncNetworkServer, SupportsEventSet
-from .handler import AsyncBaseRequestHandler, AsyncClientInterface, AsyncStreamRequestHandler
+from .handler import AsyncStreamClient, AsyncStreamRequestHandler
 
 if TYPE_CHECKING:
     from ssl import SSLContext as _SSLContext
@@ -91,7 +91,7 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         host: str | None | Sequence[str],
         port: int,
         protocol: StreamProtocol[_ResponseT, _RequestT],
-        request_handler: AsyncBaseRequestHandler[_RequestT, _ResponseT],
+        request_handler: AsyncStreamRequestHandler[_RequestT, _ResponseT],
         *,
         ssl: _SSLContext | None = None,
         ssl_handshake_timeout: float | None = None,
@@ -109,8 +109,8 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
 
         if not isinstance(protocol, StreamProtocol):
             raise TypeError(f"Expected a StreamProtocol object, got {protocol!r}")
-        if not isinstance(request_handler, AsyncBaseRequestHandler):
-            raise TypeError(f"Expected an AsyncBaseRequestHandler object, got {request_handler!r}")
+        if not isinstance(request_handler, AsyncStreamRequestHandler):
+            raise TypeError(f"Expected an AsyncStreamRequestHandler object, got {request_handler!r}")
 
         backend = AsyncBackendFactory.ensure(backend, backend_kwargs)
 
@@ -163,7 +163,7 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         self.__backend: AbstractAsyncBackend = backend
         self.__listeners: tuple[AbstractAsyncListenerSocketAdapter, ...] | None = None
         self.__protocol: StreamProtocol[_ResponseT, _RequestT] = protocol
-        self.__request_handler: AsyncBaseRequestHandler[_RequestT, _ResponseT] = request_handler
+        self.__request_handler: AsyncStreamRequestHandler[_RequestT, _ResponseT] = request_handler
         self.__is_shutdown: IEvent = self.__backend.create_event()
         self.__is_shutdown.set()
         self.__shutdown_asked: bool = False
@@ -265,8 +265,7 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             self.__request_handler.set_async_backend(self.__backend)
             await self.__request_handler.service_init()
             server_exit_stack.push_async_callback(self.__request_handler.service_quit)
-            if isinstance(self.__request_handler, AsyncStreamRequestHandler):
-                self.__request_handler.set_stop_listening_callback(self.__make_stop_listening_callback())
+            self.__request_handler.set_stop_listening_callback(self.__make_stop_listening_callback())
             ############################
 
             # Setup task group
@@ -385,20 +384,19 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             client_exit_stack.enter_context(self.__suppress_and_log_remaining_exception(client_address=client.address))
 
             request_handler_generator: AsyncGenerator[None, _RequestT] | None = None
-            if isinstance(self.__request_handler, AsyncStreamRequestHandler):
-                _on_connection_hook = self.__request_handler.on_connection(client)
-                if inspect.isasyncgen(_on_connection_hook):
-                    try:
-                        await _on_connection_hook.asend(None)
-                    except StopAsyncIteration:
-                        pass
-                    else:
-                        request_handler_generator = _on_connection_hook
+            _on_connection_hook = self.__request_handler.on_connection(client)
+            if inspect.isasyncgen(_on_connection_hook):
+                try:
+                    await _on_connection_hook.asend(None)
+                except StopAsyncIteration:
+                    pass
                 else:
-                    assert inspect.isawaitable(_on_connection_hook)  # nosec assert_used
-                    await _on_connection_hook
-                del _on_connection_hook
-                client_exit_stack.push_async_callback(self.__request_handler.on_disconnection, client)
+                    request_handler_generator = _on_connection_hook
+            else:
+                assert inspect.isawaitable(_on_connection_hook)  # nosec assert_used
+                await _on_connection_hook
+            del _on_connection_hook
+            client_exit_stack.push_async_callback(self.__request_handler.on_disconnection, client)
 
             del client_exit_stack
 
@@ -457,7 +455,7 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
                 if request_handler_generator is not None:
                     await request_handler_generator.aclose()
 
-    async def __new_request_handler(self, client: AsyncClientInterface[_ResponseT]) -> AsyncGenerator[None, _RequestT] | None:
+    async def __new_request_handler(self, client: _ConnectedClientAPI[_ResponseT]) -> AsyncGenerator[None, _RequestT] | None:
         request_handler_generator = self.__request_handler.handle(client)
         try:
             await anext(request_handler_generator)
@@ -593,7 +591,7 @@ class _RequestReceiver(Generic[_RequestT]):
 
 
 @final
-class _ConnectedClientAPI(AsyncClientInterface[_ResponseT]):
+class _ConnectedClientAPI(AsyncStreamClient[_ResponseT]):
     __slots__ = (
         "__socket",
         "__closed",

--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -32,7 +32,7 @@ from ..backend.factory import AsyncBackendFactory
 from ..backend.tasks import SingleTaskRunner
 from ._tools.actions import ErrorAction as _ErrorAction, RequestAction as _RequestAction
 from .abc import AbstractAsyncNetworkServer, SupportsEventSet
-from .handler import AsyncBaseRequestHandler, AsyncClientInterface
+from .handler import AsyncDatagramClient, AsyncDatagramRequestHandler
 
 if TYPE_CHECKING:
     from ..backend.abc import (
@@ -74,10 +74,10 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
 
     def __init__(
         self,
-        host: str | None,
+        host: str,
         port: int,
         protocol: DatagramProtocol[_ResponseT, _RequestT],
-        request_handler: AsyncBaseRequestHandler[_RequestT, _ResponseT],
+        request_handler: AsyncDatagramRequestHandler[_RequestT, _ResponseT],
         *,
         reuse_port: bool = False,
         backend: str | AbstractAsyncBackend | None = None,
@@ -89,13 +89,10 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
 
         if not isinstance(protocol, DatagramProtocol):
             raise TypeError(f"Expected a DatagramProtocol object, got {protocol!r}")
-        if not isinstance(request_handler, AsyncBaseRequestHandler):
-            raise TypeError(f"Expected an AsyncBaseRequestHandler object, got {request_handler!r}")
+        if not isinstance(request_handler, AsyncDatagramRequestHandler):
+            raise TypeError(f"Expected an AsyncDatagramRequestHandler object, got {request_handler!r}")
 
         backend = AsyncBackendFactory.ensure(backend, backend_kwargs)
-
-        if host is None:
-            host = "localhost"
 
         self.__socket_factory: Callable[[], Coroutine[Any, Any, AbstractAsyncDatagramSocketAdapter]] | None
         self.__socket_factory = _make_callback(
@@ -113,7 +110,7 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         self.__backend: AbstractAsyncBackend = backend
         self.__socket: AbstractAsyncDatagramSocketAdapter | None = None
         self.__protocol: DatagramProtocol[_ResponseT, _RequestT] = protocol
-        self.__request_handler: AsyncBaseRequestHandler[_RequestT, _ResponseT] = request_handler
+        self.__request_handler: AsyncDatagramRequestHandler[_RequestT, _ResponseT] = request_handler
         self.__is_shutdown: IEvent = self.__backend.create_event()
         self.__is_shutdown.set()
         self.__shutdown_asked: bool = False
@@ -374,7 +371,7 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
                     if request_handler_generator is not None:
                         await request_handler_generator.aclose()
 
-    async def __new_request_handler(self, client: AsyncClientInterface[_ResponseT]) -> AsyncGenerator[None, _RequestT] | None:
+    async def __new_request_handler(self, client: _ClientAPI[_ResponseT]) -> AsyncGenerator[None, _RequestT] | None:
         request_handler_generator = self.__request_handler.handle(client)
         try:
             await anext(request_handler_generator)
@@ -461,7 +458,6 @@ class _ClientAPIManager(Generic[_ResponseT]):
         "__clients",
         "__client_lock",
         "__client_queue",
-        "__backend",
         "__protocol",
         "__send_lock",
         "__logger",
@@ -479,7 +475,6 @@ class _ClientAPIManager(Generic[_ResponseT]):
 
         self.__clients: WeakValueDictionary[tuple[AbstractAsyncDatagramSocketAdapter, SocketAddress], _ClientAPI[_ResponseT]]
         self.__clients = WeakValueDictionary()
-        self.__backend: AbstractAsyncBackend = backend
         self.__protocol: DatagramProtocol[_ResponseT, Any] = protocol
         self.__send_lock: ILock = send_lock
         self.__logger: _logging.Logger = logger
@@ -497,7 +492,7 @@ class _ClientAPIManager(Generic[_ResponseT]):
         try:
             return self.__clients[key]
         except KeyError:
-            client = _ClientAPI(self.__backend, address, socket, self.__protocol, self.__send_lock, self.__logger)
+            client = _ClientAPI(address, socket, self.__protocol, self.__send_lock, self.__logger)
             self.__clients[key] = client
             return client
 
@@ -547,9 +542,8 @@ class _TemporaryValue(Generic[_KT, _VT]):
 
 
 @final
-class _ClientAPI(AsyncClientInterface[_ResponseT]):
+class _ClientAPI(AsyncDatagramClient[_ResponseT]):
     __slots__ = (
-        "__backend",
         "__socket_ref",
         "__socket_proxy",
         "__protocol",
@@ -560,7 +554,6 @@ class _ClientAPI(AsyncClientInterface[_ResponseT]):
 
     def __init__(
         self,
-        backend: AbstractAsyncBackend,
         address: SocketAddress,
         socket: AbstractAsyncDatagramSocketAdapter,
         protocol: DatagramProtocol[_ResponseT, Any],
@@ -569,8 +562,7 @@ class _ClientAPI(AsyncClientInterface[_ResponseT]):
     ) -> None:
         super().__init__(address)
 
-        self.__backend: AbstractAsyncBackend = backend
-        self.__socket_ref: Callable[[], AbstractAsyncDatagramSocketAdapter | None] = weakref.ref(socket)
+        self.__socket_ref: weakref.ref[AbstractAsyncDatagramSocketAdapter] = weakref.ref(socket)
         self.__socket_proxy: SocketProxy = SocketProxy(socket.socket())
         self.__h: int | None = None
         self.__protocol: DatagramProtocol[_ResponseT, Any] = protocol
@@ -579,19 +571,16 @@ class _ClientAPI(AsyncClientInterface[_ResponseT]):
 
     def __hash__(self) -> int:
         if (h := self.__h) is None:
-            self.__h = h = hash((_ClientAPI, self.address, 0xFF))
+            self.__h = h = hash((_ClientAPI, self.__socket_ref, self.address, 0xFF))
         return h
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, _ClientAPI):
             return NotImplemented
-        return self.address == other.address
+        return self.__socket_ref == other.__socket_ref and self.address == other.address
 
     def is_closing(self) -> bool:
         return (socket := self.__socket_ref()) is None or socket.is_closing()
-
-    async def aclose(self) -> None:
-        await self.__backend.coro_yield()
 
     async def send_packet(self, packet: _ResponseT, /) -> None:
         async with self.__send_lock:

--- a/src/easynetwork/api_sync/server/tcp.py
+++ b/src/easynetwork/api_sync/server/tcp.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from ssl import SSLContext as _SSLContext
 
     from ...api_async.backend.abc import AbstractAsyncBackend
-    from ...api_async.server.handler import AsyncBaseRequestHandler
+    from ...api_async.server.handler import AsyncStreamRequestHandler
     from ...protocol import StreamProtocol
 
 _RequestT = TypeVar("_RequestT")
@@ -37,7 +37,7 @@ class StandaloneTCPNetworkServer(_base.BaseStandaloneNetworkServerImpl, Generic[
         host: str | None | Sequence[str],
         port: int,
         protocol: StreamProtocol[_ResponseT, _RequestT],
-        request_handler: AsyncBaseRequestHandler[_RequestT, _ResponseT],
+        request_handler: AsyncStreamRequestHandler[_RequestT, _ResponseT],
         backend: str | AbstractAsyncBackend = "asyncio",
         *,
         ssl: _SSLContext | None = None,

--- a/src/easynetwork/api_sync/server/udp.py
+++ b/src/easynetwork/api_sync/server/udp.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     import logging as _logging
 
     from ...api_async.backend.abc import AbstractAsyncBackend
-    from ...api_async.server.handler import AsyncBaseRequestHandler
+    from ...api_async.server.handler import AsyncDatagramRequestHandler
     from ...protocol import DatagramProtocol
 
 _RequestT = TypeVar("_RequestT")
@@ -33,10 +33,10 @@ class StandaloneUDPNetworkServer(_base.BaseStandaloneNetworkServerImpl, Generic[
 
     def __init__(
         self,
-        host: str | None,
+        host: str,
         port: int,
         protocol: DatagramProtocol[_ResponseT, _RequestT],
-        request_handler: AsyncBaseRequestHandler[_RequestT, _ResponseT],
+        request_handler: AsyncDatagramRequestHandler[_RequestT, _ResponseT],
         backend: str | AbstractAsyncBackend = "asyncio",
         *,
         reuse_port: bool = False,

--- a/tests/unit_test/test_async/test_api/conftest.py
+++ b/tests/unit_test/test_async/test_api/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from easynetwork.api_async.server.handler import AsyncClientInterface
+from easynetwork.api_async.server.handler import AsyncDatagramClient, AsyncStreamClient
 
 import pytest
 
@@ -13,5 +13,10 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def mock_async_client(mocker: MockerFixture) -> MagicMock:
-    return mocker.NonCallableMagicMock(spec=AsyncClientInterface)
+def mock_async_datagram_client(mocker: MockerFixture) -> MagicMock:
+    return mocker.NonCallableMagicMock(spec=AsyncDatagramClient)
+
+
+@pytest.fixture
+def mock_async_stream_client(mocker: MockerFixture) -> MagicMock:
+    return mocker.NonCallableMagicMock(spec=AsyncStreamClient)

--- a/tests/unit_test/test_async/test_api/test_server/conftest.py
+++ b/tests/unit_test/test_async/test_api/test_server/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from easynetwork.api_async.server.handler import AsyncBaseRequestHandler, AsyncStreamRequestHandler
+from easynetwork.api_async.server.handler import AsyncDatagramRequestHandler, AsyncStreamRequestHandler
 
 import pytest
 
@@ -13,8 +13,8 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def mock_request_handler(mocker: MockerFixture) -> MagicMock:
-    return mocker.NonCallableMagicMock(spec=AsyncBaseRequestHandler)
+def mock_datagram_request_handler(mocker: MockerFixture) -> MagicMock:
+    return mocker.NonCallableMagicMock(spec=AsyncDatagramRequestHandler)
 
 
 @pytest.fixture

--- a/tests/unit_test/test_async/test_api/test_server/test_tcp.py
+++ b/tests/unit_test/test_async/test_api/test_server/test_tcp.py
@@ -9,30 +9,27 @@ import pytest
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
-    from pytest_mock import MockerFixture
-
 
 @pytest.mark.asyncio
 class TestAsyncTCPNetworkServer:
     async def test____dunder_init____protocol____invalid_value(
         self,
         mock_datagram_protocol: MagicMock,
-        mock_request_handler: MagicMock,
+        mock_stream_request_handler: MagicMock,
     ) -> None:
         # Arrange
 
         # Act & Assert
         with pytest.raises(TypeError, match=r"^Expected a StreamProtocol object, got .*$"):
-            _ = AsyncTCPNetworkServer(None, 0, mock_datagram_protocol, mock_request_handler)
+            _ = AsyncTCPNetworkServer(None, 0, mock_datagram_protocol, mock_stream_request_handler)
 
     async def test____dunder_init____request_handler____invalid_value(
         self,
         mock_stream_protocol: MagicMock,
-        mocker: MockerFixture,
+        mock_datagram_request_handler: MagicMock,
     ) -> None:
         # Arrange
-        mock_invalid_request_handler = mocker.NonCallableMagicMock(spec=object)
 
         # Act & Assert
-        with pytest.raises(TypeError, match=r"^Expected an AsyncBaseRequestHandler object, got .*$"):
-            _ = AsyncTCPNetworkServer(None, 0, mock_stream_protocol, mock_invalid_request_handler)
+        with pytest.raises(TypeError, match=r"^Expected an AsyncStreamRequestHandler object, got .*$"):
+            _ = AsyncTCPNetworkServer(None, 0, mock_stream_protocol, mock_datagram_request_handler)

--- a/tests/unit_test/test_async/test_api/test_server/test_udp.py
+++ b/tests/unit_test/test_async/test_api/test_server/test_udp.py
@@ -9,30 +9,27 @@ import pytest
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
-    from pytest_mock import MockerFixture
-
 
 @pytest.mark.asyncio
 class TestAsyncUDPNetworkServer:
     async def test____dunder_init____protocol____invalid_value(
         self,
         mock_stream_protocol: MagicMock,
-        mock_request_handler: MagicMock,
+        mock_datagram_request_handler: MagicMock,
     ) -> None:
         # Arrange
 
         # Act & Assert
         with pytest.raises(TypeError, match=r"^Expected a DatagramProtocol object, got .*$"):
-            _ = AsyncUDPNetworkServer(None, 0, mock_stream_protocol, mock_request_handler)
+            _ = AsyncUDPNetworkServer("localhost", 0, mock_stream_protocol, mock_datagram_request_handler)
 
     async def test____dunder_init____request_handler____invalid_value(
         self,
         mock_datagram_protocol: MagicMock,
-        mocker: MockerFixture,
+        mock_stream_request_handler: MagicMock,
     ) -> None:
         # Arrange
-        mock_invalid_request_handler = mocker.NonCallableMagicMock(spec=object)
 
         # Act & Assert
-        with pytest.raises(TypeError, match=r"^Expected an AsyncBaseRequestHandler object, got .*$"):
-            _ = AsyncUDPNetworkServer(None, 0, mock_datagram_protocol, mock_invalid_request_handler)
+        with pytest.raises(TypeError, match=r"^Expected an AsyncDatagramRequestHandler object, got .*$"):
+            _ = AsyncUDPNetworkServer("localhost", 0, mock_datagram_protocol, mock_stream_request_handler)


### PR DESCRIPTION
## What's changed
### Request handlers
- `AsyncClientInterface` is splitted to 3 interfaces:
  - `AsyncBaseClientInterface` with mandatory methods for all clients:
    - `send_packet()`
    - `is_closing()`
  - `AsyncStreamClient` which adds the following methods:
    - `aclose()`
  - `AsyncDatagramClient` which adds the following methods:
    - `__hash__()`
    - `__eq__()`
- Request handlers are splitted to 3 interfaces:
  - `AsyncBaseRequestHandler` which now only keeps service management methods:
    - `set_async_backend()`
    - `service_init()`
    - `service_quit()`
    - `service_actions()`
  - `AsyncStreamRequestHandler` which adds the following methods:
    - `handle()`
    - `bad_request()`
    - `on_connection()`
    - `on_disconnection()`
    - `set_stop_listening_callback()`
  - `AsyncDatagramRequestHandler` which adds the following methods:
    - `handle()`
    - `bad_request()`

### Servers implementations
- `AsyncTCPNetworkServer` now only accepts `AsyncStreamRequestHandler` instances
- `AsyncUDPNetworkServer` now only accepts `AsyncDatagramRequestHandler` instances