### PR TITLE
Minor bug fix in servers

### DIFF
--- a/src/easynetwork/api_async/server/abc.py
+++ b/src/easynetwork/api_async/server/abc.py
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Protocol, Self
+from typing import TYPE_CHECKING, Any, NoReturn, Protocol, Self
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -74,7 +74,7 @@ class AbstractAsyncNetworkServer(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    async def serve_forever(self, *, is_up_event: SupportsEventSet | None = ...) -> None:
+    async def serve_forever(self, *, is_up_event: SupportsEventSet | None = ...) -> NoReturn:
         """
         Starts the server's main loop.
 

--- a/src/easynetwork/api_async/server/tcp.py
+++ b/src/easynetwork/api_async/server/tcp.py
@@ -282,11 +282,6 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
 
     async def serve_forever(self, *, is_up_event: SupportsEventSet | None = None) -> None:
         async with _contextlib.AsyncExitStack() as server_exit_stack:
-            is_up_callback = server_exit_stack.enter_context(_contextlib.ExitStack())
-            if is_up_event is not None:
-                # Force is_up_event to be set, in order not to stuck the waiting task
-                is_up_callback.callback(is_up_event.set)
-
             # Wake up server
             if not self.__is_shutdown.is_set():
                 raise ServerAlreadyRunning("Server is already running")
@@ -338,8 +333,8 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             #################
 
             # Server is up
-            is_up_callback.close()
-            del is_up_callback
+            if is_up_event is not None and not self.__shutdown_asked:
+                is_up_event.set()
             ##############
 
             # Main loop

--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -371,12 +371,12 @@ class AsyncUDPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
                 self.__logger.warning(
                     "There have been attempts to do operation on closed client %s",
                     client_address,
-                    exc_info=True,
+                    exc_info=excgrp,
                 )
         except Exception as exc:
             _remove_traceback_frames_in_place(exc, 1)  # Removes the 'yield' frame just above
             self.__logger.error("-" * 40)
-            self.__logger.exception("Exception occurred during processing of request from %s", client_address)
+            self.__logger.error("Exception occurred during processing of request from %s", client_address, exc_info=exc)
             self.__logger.error("-" * 40)
 
     @_contextlib.contextmanager

--- a/src/easynetwork/api_sync/server/_base.py
+++ b/src/easynetwork/api_sync/server/_base.py
@@ -78,18 +78,14 @@ class BaseStandaloneNetworkServerImpl(AbstractNetworkServer):
 
     def shutdown(self, timeout: float | None = None) -> None:
         if (portal := self._portal) is not None:
-            try:
+            with _contextlib.suppress(RuntimeError, concurrent.futures.CancelledError):
                 # If shutdown() have been cancelled, that means the scheduler itself is shutting down, and this is what we want
                 if timeout is None:
                     portal.run_coroutine(self.__server.shutdown)
                 else:
                     _start = time.perf_counter()
-                    try:
-                        portal.run_coroutine(self.__do_shutdown_with_timeout, timeout)
-                    finally:
-                        timeout -= time.perf_counter() - _start
-            except (RuntimeError, concurrent.futures.CancelledError):
-                pass
+                    portal.run_coroutine(self.__do_shutdown_with_timeout, timeout)
+                    timeout -= time.perf_counter() - _start
         self.__is_shutdown.wait(timeout)
 
     shutdown.__doc__ = AbstractNetworkServer.shutdown.__doc__
@@ -119,10 +115,6 @@ class BaseStandaloneNetworkServerImpl(AbstractNetworkServer):
 
         backend = self.__server.get_backend()
         with _contextlib.ExitStack() as server_exit_stack, _contextlib.suppress(backend.get_cancelled_exc_class()):
-            if is_up_event is not None:
-                # Force is_up_event to be set, in order not to stuck the waiting thread
-                server_exit_stack.callback(is_up_event.set)
-
             # locks_stack is used to acquire locks until
             # serve_forever() coroutine creates the thread portal
             locks_stack = server_exit_stack.enter_context(_contextlib.ExitStack())
@@ -138,16 +130,16 @@ class BaseStandaloneNetworkServerImpl(AbstractNetworkServer):
             self.__is_shutdown.clear()
             server_exit_stack.callback(self.__is_shutdown.set)
 
+            def reset_threads_portal() -> None:
+                self.__threads_portal = None
+
+            def acquire_bootstrap_lock() -> None:
+                locks_stack.enter_context(self.__bootstrap_lock.get())
+
+            server_exit_stack.callback(reset_threads_portal)
+            server_exit_stack.callback(acquire_bootstrap_lock)
+
             async def serve_forever() -> None:
-                def reset_threads_portal() -> None:
-                    self.__threads_portal = None
-
-                def acquire_bootstrap_lock() -> None:
-                    locks_stack.enter_context(self.__bootstrap_lock.get())
-
-                server_exit_stack.callback(reset_threads_portal)
-                server_exit_stack.callback(acquire_bootstrap_lock)
-
                 async with backend.create_threads_portal() as self.__threads_portal:
                     # Initialization finished; release the locks
                     locks_stack.close()

--- a/src/easynetwork/api_sync/server/thread.py
+++ b/src/easynetwork/api_sync/server/thread.py
@@ -45,7 +45,7 @@ class NetworkServerThread(_threading.Thread):
 
     def run(self) -> None:
         try:
-            return self.__server.serve_forever(is_up_event=self.__is_up_event)
+            self.__server.serve_forever(is_up_event=self.__is_up_event)
         finally:
             self.__is_up_event.set()
 

--- a/src/easynetwork/api_sync/server/thread.py
+++ b/src/easynetwork/api_sync/server/thread.py
@@ -36,7 +36,7 @@ class NetworkServerThread(_threading.Thread):
         daemon: bool | None = None,
     ) -> None:
         super().__init__(group=group, target=None, name=name, daemon=daemon)
-        self.__server: AbstractNetworkServer | None = server
+        self.__server: AbstractNetworkServer = server
         self.__is_up_event: _threading.Event = _threading.Event()
 
     def start(self) -> None:
@@ -44,23 +44,15 @@ class NetworkServerThread(_threading.Thread):
         self.__is_up_event.wait()
 
     def run(self) -> None:
-        assert self.__server is not None, f"{self.__server=}"  # nosec assert_used
         try:
             return self.__server.serve_forever(is_up_event=self.__is_up_event)
         finally:
-            self.__server = None
             self.__is_up_event.set()
 
     def join(self, timeout: float | None = None) -> None:
-        server = self.__server
-        if server is not None:
-            _start = time.perf_counter()
-            try:
-                server.shutdown(timeout=timeout)
-            finally:
-                _end = time.perf_counter()
-                if timeout is not None:
-                    timeout -= _end - _start
-                super().join(timeout=timeout)
-        else:
-            super().join(timeout=timeout)
+        _start = time.perf_counter()
+        self.__server.shutdown(timeout=timeout)
+        _end = time.perf_counter()
+        if timeout is not None:
+            timeout -= _end - _start
+        super().join(timeout=timeout)

--- a/tests/functional_test/test_communication/test_async/test_server/base.py
+++ b/tests/functional_test/test_communication/test_async/test_server/base.py
@@ -65,7 +65,7 @@ class BaseTestAsyncServer:
             await asyncio.sleep(0)
             assert not event.is_set()
             await server.shutdown()
-            assert event.is_set()
+            assert not event.is_set()
 
     async def test____serve_forever____server_close_during_setup(
         self,


### PR DESCRIPTION
- Added `typing.NoReturn` to `serve_forever()` methods
- Fixed logs with `exc_info=True` due to a regression in Python 3.11.5
- Fixed a bug in `easynetwork_asyncio.tasks.CancelScope` at context exit if there was a delayed cancellation to be scheduled for a parent scope