### PR TITLE
Serializers: Added buffer limit options

### DIFF
--- a/docs/source/api/serializers/index.rst
+++ b/docs/source/api/serializers/index.rst
@@ -30,3 +30,11 @@ Serializers
    wrappers/base64
    wrappers/compressor
    wrappers/encryptor
+
+-----
+
+.. toctree::
+   :caption: Miscellaneous
+   :maxdepth: 2
+
+   tools

--- a/docs/source/api/serializers/tools.rst
+++ b/docs/source/api/serializers/tools.rst
@@ -1,0 +1,7 @@
+*******************************
+Serializer implementation tools
+*******************************
+
+.. automodule:: easynetwork.serializers.tools
+   :members:
+   :no-docstring:

--- a/src/easynetwork/api_async/server/tcp.py
+++ b/src/easynetwork/api_async/server/tcp.py
@@ -656,7 +656,7 @@ class _ConnectedClientAPI(AsyncStreamClient[_ResponseT]):
         self.__check_closed()
         self.__logger.debug("A response will be sent to %s", self.address)
         producer = self.__producer
-        producer.queue(packet)
+        producer.enqueue(packet)
         del packet
         async with self.__send_lock:
             socket = self.__check_closed()

--- a/src/easynetwork/exceptions.py
+++ b/src/easynetwork/exceptions.py
@@ -25,6 +25,7 @@ __all__ = [
     "DatagramProtocolParseError",
     "DeserializeError",
     "IncrementalDeserializeError",
+    "LimitOverrunError",
     "PacketConversionError",
     "ServerAlreadyRunning",
     "ServerClosedError",
@@ -101,6 +102,9 @@ class LimitOverrunError(IncrementalDeserializeError):
             remaining_data = remaining_data.removeprefix(separator)
 
         super().__init__(message, remaining_data, error_info=None)
+
+        self.consumed: int = consumed
+        """Total number of to be consumed bytes."""
 
 
 class PacketConversionError(Exception):

--- a/src/easynetwork/exceptions.py
+++ b/src/easynetwork/exceptions.py
@@ -34,6 +34,8 @@ __all__ = [
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from _typeshed import ReadableBuffer
+
     from .tools.socket import SocketAddress
 
 
@@ -80,6 +82,25 @@ class IncrementalDeserializeError(DeserializeError):
 
         self.remaining_data: bytes = remaining_data
         """Unused trailing data."""
+
+
+class LimitOverrunError(IncrementalDeserializeError):
+    """Reached the buffer size limit while looking for a separator."""
+
+    def __init__(self, message: str, buffer: ReadableBuffer, consumed: int, separator: bytes = b"") -> None:
+        """
+        Parameters:
+            message: Error message.
+            buffer: Currently too big buffer.
+            consumed: Total number of to be consumed bytes.
+            separator: Searched separator.
+        """
+
+        remaining_data = memoryview(buffer)[consumed:].tobytes()
+        if separator and remaining_data.startswith(separator):
+            remaining_data = remaining_data.removeprefix(separator)
+
+        super().__init__(message, remaining_data, error_info=None)
 
 
 class PacketConversionError(Exception):

--- a/src/easynetwork/serializers/json.py
+++ b/src/easynetwork/serializers/json.py
@@ -175,21 +175,18 @@ class JSONSerializer(AbstractIncrementalPacketSerializer[Any]):
             all the parts of the JSON :term:`packet`.
         """
         data = self.__encoder.encode(packet).encode(self.__encoding, self.__unicode_errors)
-        newline = b"\n"
         if not data.startswith((b"{", b"[", b'"')):
-            data += newline
+            data += b"\n"
             yield data
-            return
-        if not self.__use_lines:
+        elif not self.__use_lines:
             yield data
-            return
-        if len(data) + len(newline) <= self.__limit // 2:
-            data += newline
+        elif len(data) + 1 <= self.__limit // 2:
+            data += b"\n"
             yield data
         else:
             yield data
             del data
-            yield newline
+            yield b"\n"
 
     @final
     def deserialize(self, data: bytes) -> Any:

--- a/src/easynetwork/serializers/line.py
+++ b/src/easynetwork/serializers/line.py
@@ -21,6 +21,7 @@ __all__ = ["StringLineSerializer"]
 from typing import Literal, assert_never, final
 
 from ..exceptions import DeserializeError
+from ..tools.constants import _DEFAULT_LIMIT
 from .base_stream import AutoSeparatedPacketSerializer
 
 
@@ -37,6 +38,7 @@ class StringLineSerializer(AutoSeparatedPacketSerializer[str]):
         *,
         encoding: str = "ascii",
         unicode_errors: str = "strict",
+        limit: int = _DEFAULT_LIMIT,
     ) -> None:
         r"""
         Parameters:
@@ -50,6 +52,7 @@ class StringLineSerializer(AutoSeparatedPacketSerializer[str]):
                      - ``"CRLF"``: Carriage return + line feed character sequence (``"\r\n"``).
             encoding: String encoding. Defaults to ``"ascii"``.
             unicode_errors: Controls how encoding errors are handled.
+            limit: Maximum buffer size. Used in incremental serialization context.
 
         See Also:
             :ref:`standard-encodings` and :ref:`error-handlers`.
@@ -64,7 +67,7 @@ class StringLineSerializer(AutoSeparatedPacketSerializer[str]):
                 separator = b"\r\n"
             case _:
                 assert_never(newline)
-        super().__init__(separator=separator, incremental_serialize_check_separator=False)
+        super().__init__(separator=separator, incremental_serialize_check_separator=False, limit=limit)
         self.__encoding: str = encoding
         self.__unicode_errors: str = unicode_errors
 

--- a/src/easynetwork/serializers/tools.py
+++ b/src/easynetwork/serializers/tools.py
@@ -1,0 +1,200 @@
+# Copyright 2021-2023, Francis Clairicia-Rose-Claire-Josephine
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+"""Serializer implementation tools module"""
+
+from __future__ import annotations
+
+__all__ = ["GeneratorStreamReader"]
+
+from collections.abc import Generator
+
+from ..exceptions import LimitOverrunError
+
+
+class GeneratorStreamReader:
+    """
+    A binary stream-like object using an in-memory bytes buffer.
+
+    The "blocking" operation is done with the generator's :keyword:`yield` statement. It is an helper for
+    :term:`incremental serializer` implementations.
+    """
+
+    __slots__ = ("__buffer",)
+
+    def __init__(self, initial_bytes: bytes = b"") -> None:
+        """
+        Parameters:
+            initial_bytes: a :class:`bytes` object that contains initial data.
+        """
+        self.__buffer: bytes = initial_bytes
+
+    def read_all(self) -> bytes:
+        """
+        Read and return all the bytes currently in the reader.
+
+        Returns:
+            a :class:`bytes` object.
+        """
+
+        data, self.__buffer = self.__buffer, b""
+        return data
+
+    def read(self, size: int) -> Generator[None, bytes, bytes]:
+        """
+        Read and return up to `size` bytes.
+
+        Example::
+
+            def incremental_deserialize(self) -> Generator[None, bytes, tuple[Packet, bytes]]:
+                reader = GeneratorStreamReader()
+
+                data: bytes = yield from reader.read(1024)  # Get at most 1024 bytes.
+
+                ...
+
+        Yields:
+            if there is no data in buffer.
+
+        Returns:
+            a :class:`bytes` object.
+        """
+
+        if size < 0:
+            raise ValueError("size must not be < 0")
+        if size == 0:
+            return b""
+
+        while not self.__buffer:
+            self.__buffer = yield
+
+        if len(self.__buffer) <= size:
+            data, self.__buffer = self.__buffer, b""
+        else:
+            data = self.__buffer[:size]
+            self.__buffer = self.__buffer[size:]
+
+        return data
+
+    def read_exactly(self, n: int) -> Generator[None, bytes, bytes]:
+        """
+        Read exactly `n` bytes.
+
+        Example::
+
+            def incremental_deserialize(self) -> Generator[None, bytes, tuple[Packet, bytes]]:
+                reader = GeneratorStreamReader()
+
+                header: bytes = yield from reader.read_exactly(32)
+                assert len(header) == 32
+
+                ...
+
+        Yields:
+            until `n` bytes is in the buffer.
+
+        Returns:
+            a :class:`bytes` object.
+        """
+
+        if n < 0:
+            raise ValueError("n must not be < 0")
+        if n == 0:
+            return b""
+
+        if not self.__buffer:
+            self.__buffer = yield
+        while (buflen := len(self.__buffer)) < n:
+            self.__buffer += yield
+
+        if buflen == n:
+            data, self.__buffer = self.__buffer, b""
+        else:
+            data = self.__buffer[:n]
+            self.__buffer = self.__buffer[n:]
+
+        return data
+
+    def read_until(self, separator: bytes, limit: int, *, keep_end: bool = True) -> Generator[None, bytes, bytes]:
+        r"""
+        Read data from the stream until `separator` is found.
+
+        On success, the data and separator will be removed from the internal buffer (consumed).
+
+        If the amount of data read exceeds `limit`, a :exc:`LimitOverrunError` exception is raised,
+        and the data is left in the internal buffer and can be read again.
+
+        Example::
+
+            def incremental_deserialize(self) -> Generator[None, bytes, tuple[Packet, bytes]]:
+                reader = GeneratorStreamReader()
+
+                line: bytes = yield from reader.read_until(b"\n", limit=65535)
+                assert line.endswith(b"\n")
+
+                ...
+
+        Parameters:
+            separator: The byte sequence to find.
+            limit: The maximum buffer size.
+            keep_end: If :data:`True` (the default), returned data will include the separator at the end.
+
+        Raises:
+            LimitOverrunError: Reached buffer size limit.
+
+        Yields:
+            until `separator` is found in the buffer.
+
+        Returns:
+            a :class:`bytes` object.
+        """
+
+        if limit <= 0:
+            raise ValueError("limit must be a positive integer")
+        seplen: int = len(separator)
+        if seplen < 1:
+            raise ValueError("Empty separator")
+
+        if not self.__buffer:
+            self.__buffer = yield
+
+        offset: int = 0
+        sepidx: int = -1
+        while True:
+            buflen = len(self.__buffer)
+
+            if buflen - offset >= seplen:
+                sepidx = self.__buffer.find(separator, offset)
+
+                if sepidx != -1:
+                    break
+
+                offset = buflen + 1 - seplen
+                if offset > limit:
+                    msg = "Separator is not found, and chunk exceed the limit"
+                    raise LimitOverrunError(msg, self.__buffer, offset, separator)
+
+            self.__buffer += yield
+
+        if sepidx > limit:
+            msg = "Separator is found, but chunk is longer than limit"
+            raise LimitOverrunError(msg, self.__buffer, sepidx, separator)
+
+        if keep_end:
+            data = self.__buffer[: sepidx + seplen]
+        else:
+            data = self.__buffer[:sepidx]
+        self.__buffer = self.__buffer[sepidx + seplen :]
+
+        return data

--- a/src/easynetwork/serializers/wrapper/base64.py
+++ b/src/easynetwork/serializers/wrapper/base64.py
@@ -26,6 +26,7 @@ from typing import Literal, assert_never, final
 
 from ..._typevars import _DTOPacketT
 from ...exceptions import DeserializeError
+from ...tools.constants import _DEFAULT_LIMIT
 from ..abc import AbstractPacketSerializer
 from ..base_stream import AutoSeparatedPacketSerializer
 
@@ -44,6 +45,7 @@ class Base64EncoderSerializer(AutoSeparatedPacketSerializer[_DTOPacketT]):
         alphabet: Literal["standard", "urlsafe"] = "urlsafe",
         checksum: bool | str | bytes = False,
         separator: bytes = b"\r\n",
+        limit: int = _DEFAULT_LIMIT,
     ) -> None:
         """
         Parameters:
@@ -58,12 +60,13 @@ class Base64EncoderSerializer(AutoSeparatedPacketSerializer[_DTOPacketT]):
             checksum: If `True`, appends a sha256 checksum to the serialized data.
                       `checksum` can also be a URL-safe base64-encoded 32-byte key for a signed checksum.
             separator: Token for :class:`AutoSeparatedPacketSerializer`. Used in incremental serialization context.
+            limit: Maximum buffer size. Used in incremental serialization context.
         """
         import base64
         import binascii
         from hmac import compare_digest
 
-        super().__init__(separator=separator, incremental_serialize_check_separator=not separator.isspace())
+        super().__init__(separator=separator, incremental_serialize_check_separator=not separator.isspace(), limit=limit)
         if not isinstance(serializer, AbstractPacketSerializer):
             raise TypeError(f"Expected a serializer instance, got {serializer!r}")
         self.__serializer: AbstractPacketSerializer[_DTOPacketT] = serializer

--- a/src/easynetwork/serializers/wrapper/compressor.py
+++ b/src/easynetwork/serializers/wrapper/compressor.py
@@ -186,7 +186,10 @@ class AbstractCompressorSerializer(AbstractIncrementalPacketSerializer[_DTOPacke
                 results.append(chunk)
             del chunk
 
-        data = b"".join(results)
+        if len(results) == 1:
+            data = results[0]
+        else:
+            data = b"".join(results)
         unused_data: bytes = decompressor.unused_data
         del results, decompressor
 

--- a/src/easynetwork/serializers/wrapper/encryptor.py
+++ b/src/easynetwork/serializers/wrapper/encryptor.py
@@ -24,6 +24,7 @@ from typing import final
 
 from ..._typevars import _DTOPacketT
 from ...exceptions import DeserializeError
+from ...tools.constants import _DEFAULT_LIMIT
 from ..abc import AbstractPacketSerializer
 from ..base_stream import AutoSeparatedPacketSerializer
 
@@ -44,6 +45,7 @@ class EncryptorSerializer(AutoSeparatedPacketSerializer[_DTOPacketT]):
         *,
         token_ttl: int | None = None,
         separator: bytes = b"\r\n",
+        limit: int = _DEFAULT_LIMIT,
     ) -> None:
         """
         Parameters:
@@ -51,13 +53,14 @@ class EncryptorSerializer(AutoSeparatedPacketSerializer[_DTOPacketT]):
             key: A URL-safe base64-encoded 32-byte key.
             token_ttl: Token time-to-live. See :meth:`cryptography.fernet.Fernet.decrypt` for details.
             separator: Token for :class:`AutoSeparatedPacketSerializer`. Used in incremental serialization context.
+            limit: Maximum buffer size. Used in incremental serialization context.
         """
         try:
             import cryptography.fernet
         except ModuleNotFoundError as exc:  # pragma: no cover
             raise ModuleNotFoundError("encryption dependencies are missing. Consider adding 'encryption' extra") from exc
 
-        super().__init__(separator=separator, incremental_serialize_check_separator=not separator.isspace())
+        super().__init__(separator=separator, incremental_serialize_check_separator=not separator.isspace(), limit=limit)
         if not isinstance(serializer, AbstractPacketSerializer):
             raise TypeError(f"Expected a serializer instance, got {serializer!r}")
         self.__serializer: AbstractPacketSerializer[_DTOPacketT] = serializer

--- a/src/easynetwork/tools/_stream.py
+++ b/src/easynetwork/tools/_stream.py
@@ -23,11 +23,14 @@ __all__ = [
 
 from collections import deque
 from collections.abc import Generator, Iterator
-from typing import Any, Generic, final
+from typing import TYPE_CHECKING, Any, Generic, final
 
 from .._typevars import _ReceivedPacketT, _SentPacketT
 from ..exceptions import StreamProtocolParseError
 from ..protocol import StreamProtocol
+
+if TYPE_CHECKING:
+    from _typeshed import ReadableBuffer
 
 
 @final
@@ -69,11 +72,10 @@ class StreamDataProducer(Generic[_SentPacketT]):
             else:
                 self.__g = None
             try:
-                chunk = next(filter(None, generator))
+                chunk = next(filter(None, map(_ensure_bytes, generator)))
             except StopIteration:
                 pass
             else:
-                _check_bytes(chunk)
                 self.__g = generator
                 return chunk
             finally:
@@ -83,7 +85,7 @@ class StreamDataProducer(Generic[_SentPacketT]):
     def pending_packets(self) -> bool:
         return self.__g is not None or bool(self.__q)
 
-    def queue(self, *packets: _SentPacketT) -> None:
+    def enqueue(self, *packets: _SentPacketT) -> None:
         self.__q.extend(packets)
 
     def clear(self) -> None:
@@ -140,9 +142,10 @@ class StreamDataConsumer(Generic[_ReceivedPacketT]):
             consumer.send(chunk)
         except StopIteration as exc:
             packet, remaining = exc.value
+            remaining = _ensure_bytes(remaining)
         except StreamProtocolParseError as exc:
             remaining, exc.remaining_data = exc.remaining_data, b""
-            _check_bytes(remaining)
+            remaining = _ensure_bytes(remaining)
             self.__b = remaining
             raise
         else:
@@ -150,12 +153,11 @@ class StreamDataConsumer(Generic[_ReceivedPacketT]):
             raise StopIteration
         finally:
             del consumer, chunk
-        _check_bytes(remaining)
         self.__b = remaining
         return packet
 
     def feed(self, chunk: bytes) -> None:
-        _check_bytes(chunk)
+        chunk = _ensure_bytes(chunk)
         if not chunk:
             return
         if self.__b:
@@ -178,6 +180,7 @@ def _check_protocol(p: StreamProtocol[Any, Any]) -> None:
         raise TypeError(f"Expected a StreamProtocol object, got {p!r}")
 
 
-def _check_bytes(b: bytes) -> None:
+def _ensure_bytes(b: ReadableBuffer) -> bytes:
     if type(b) is not bytes:
-        raise AssertionError(f"Expected bytes, got {b!r}")
+        b = memoryview(b).tobytes()
+    return b

--- a/src/easynetwork/tools/constants.py
+++ b/src/easynetwork/tools/constants.py
@@ -23,12 +23,16 @@ __all__ = [
     "MAX_STREAM_BUFSIZE",
     "SSL_HANDSHAKE_TIMEOUT",
     "SSL_SHUTDOWN_TIMEOUT",
+    "_DEFAULT_LIMIT",
 ]
 
 import errno as _errno
 from typing import Final
 
+# Buffer size for a recv(2) operation
 MAX_STREAM_BUFSIZE: Final[int] = 256 * 1024  # 256KiB
+
+# Buffer size for a recvfrom(2) operation
 MAX_DATAGRAM_BUFSIZE: Final[int] = 64 * 1024  # 64KiB
 
 # Errors that socket operations can return if the socket is closed
@@ -62,3 +66,6 @@ SSL_HANDSHAKE_TIMEOUT: Final[float] = 60.0
 # Number of seconds to wait for SSL shutdown to complete
 # The default timeout mimics lingering_time
 SSL_SHUTDOWN_TIMEOUT: Final[float] = 30.0
+
+# Buffer size limit when waiting for a byte sequence
+_DEFAULT_LIMIT: Final[int] = 64 * 1024  # 64 KiB

--- a/tests/functional_test/test_serializers/test_json.py
+++ b/tests/functional_test/test_serializers/test_json.py
@@ -43,7 +43,7 @@ class TestJSONSerializer(BaseTestIncrementalSerializer):
     def expected_complete_data(cls, packet_to_serialize: Any) -> bytes:
         import json
 
-        return json.dumps(packet_to_serialize, **dataclasses.asdict(cls.ENCODER_CONFIG)).encode("utf-8")
+        return json.dumps(packet_to_serialize, **dataclasses.asdict(cls.ENCODER_CONFIG), separators=(",", ":")).encode("utf-8")
 
     #### Incremental Serialize
 

--- a/tests/functional_test/test_serializers/test_json.py
+++ b/tests/functional_test/test_serializers/test_json.py
@@ -19,15 +19,20 @@ class TestJSONSerializer(BaseTestIncrementalSerializer):
 
     ENCODER_CONFIG = JSONEncoderConfig(ensure_ascii=False)
 
+    @pytest.fixture(scope="class", params=[False, True], ids=lambda p: f"use_lines=={p}")
+    @staticmethod
+    def use_lines(request: Any) -> bool:
+        return request.param
+
     @pytest.fixture(scope="class")
     @classmethod
-    def serializer_for_serialization(cls) -> JSONSerializer:
-        return JSONSerializer(encoder_config=cls.ENCODER_CONFIG)
+    def serializer_for_serialization(cls, use_lines: bool) -> JSONSerializer:
+        return JSONSerializer(encoder_config=cls.ENCODER_CONFIG, use_lines=use_lines)
 
     @pytest.fixture(scope="class")
     @staticmethod
-    def serializer_for_deserialization() -> JSONSerializer:
-        return JSONSerializer()
+    def serializer_for_deserialization(use_lines: bool) -> JSONSerializer:
+        return JSONSerializer(use_lines=use_lines)
 
     #### Packets to test
 
@@ -49,18 +54,24 @@ class TestJSONSerializer(BaseTestIncrementalSerializer):
 
     @pytest.fixture(scope="class")
     @staticmethod
-    def expected_joined_data(expected_complete_data: bytes) -> bytes:
-        return expected_complete_data + b"\n"
+    def expected_joined_data(expected_complete_data: bytes, use_lines: bool) -> bytes:
+        if use_lines or not expected_complete_data.startswith((b"{", b"[", b'"')):
+            return expected_complete_data + b"\n"
+        return expected_complete_data
 
     #### One-shot Deserialize
 
     @pytest.fixture(scope="class")
     @staticmethod
-    def complete_data(packet_to_serialize: Any) -> bytes:
+    def complete_data(packet_to_serialize: Any, use_lines: bool) -> bytes:
         import json
 
-        # Test with indentation to see whitespace handling
-        return json.dumps(packet_to_serialize, ensure_ascii=False, indent=2).encode("utf-8")
+        indent: int | None = None
+        if not use_lines:
+            # Test with indentation to see whitespace handling
+            indent = 4
+
+        return json.dumps(packet_to_serialize, ensure_ascii=False, indent=indent).encode("utf-8")
 
     #### Incremental Deserialize
 
@@ -73,17 +84,23 @@ class TestJSONSerializer(BaseTestIncrementalSerializer):
 
     @pytest.fixture(scope="class", params=[b"invalid", b"\0"])
     @staticmethod
-    def invalid_complete_data(request: Any) -> bytes:
-        return getattr(request, "param")
+    def invalid_complete_data(request: Any, use_lines: bool) -> bytes:
+        data: bytes = getattr(request, "param")
+        if use_lines:
+            data += b"\n"
+        return data
 
     @pytest.fixture(scope="class", params=[b"[ invalid ]", b"\0"])
     @staticmethod
-    def invalid_partial_data(request: Any) -> bytes:
-        return getattr(request, "param")
+    def invalid_partial_data(request: Any, use_lines: bool) -> bytes:
+        data: bytes = getattr(request, "param")
+        if use_lines:
+            data += b"\n"
+        return data
 
     @pytest.fixture
     @staticmethod
     def invalid_partial_data_extra_data(invalid_partial_data: bytes) -> bytes:
-        if invalid_partial_data == b"\0":
+        if invalid_partial_data.startswith(b"\0"):
             return b""
         return b"remaining_data"

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -28,6 +28,12 @@ def send_return(gen: Generator[Any, _T_contra, _V_co], value: _T_contra, /) -> _
     return exc_info.value.value
 
 
+def next_return(gen: Generator[Any, Any, _V_co], /) -> _V_co:
+    with pytest.raises(StopIteration) as exc_info:
+        gen.send(None)
+    return exc_info.value.value
+
+
 @final
 class TimeTest:
     def __init__(self, expected_time: float, approx: float | None = None) -> None:

--- a/tests/unit_test/test_serializers/test_json.py
+++ b/tests/unit_test/test_serializers/test_json.py
@@ -66,8 +66,6 @@ class TestJSONSerializer(BaseSerializerConfigInstanceCheck):
             check_circular=mocker.sentinel.check_circular,
             ensure_ascii=mocker.sentinel.ensure_ascii,
             allow_nan=mocker.sentinel.allow_nan,
-            indent=mocker.sentinel.indent,
-            separators=mocker.sentinel.separators,
             default=mocker.sentinel.object_default,
         )
 
@@ -108,8 +106,8 @@ class TestJSONSerializer(BaseSerializerConfigInstanceCheck):
             check_circular=mocker.sentinel.check_circular if encoder_config is not None else True,
             ensure_ascii=mocker.sentinel.ensure_ascii if encoder_config is not None else True,
             allow_nan=mocker.sentinel.allow_nan if encoder_config is not None else True,
-            indent=mocker.sentinel.indent if encoder_config is not None else None,
-            separators=mocker.sentinel.separators if encoder_config is not None else (",", ":"),
+            indent=None,
+            separators=(",", ":"),
             default=mocker.sentinel.object_default if encoder_config is not None else None,
         )
 

--- a/tests/unit_test/test_serializers/test_tools.py
+++ b/tests/unit_test/test_serializers/test_tools.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from easynetwork.exceptions import LimitOverrunError
+from easynetwork.serializers.tools import GeneratorStreamReader
+
+import pytest
+
+from ...tools import next_return, send_return
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+class TestGeneratorStreamReader:
+    def test____read_all____pop_buffer_without_copying(self, mocker: MockerFixture) -> None:
+        # Arrange
+        reader = GeneratorStreamReader(mocker.sentinel.initial_buffer)
+
+        # Act
+        data = reader.read_all()
+
+        # Assert
+        assert data is mocker.sentinel.initial_buffer
+        assert reader.read_all() == b""
+
+    def test____read____yield_if_buffer_is_empty(self) -> None:
+        # Arrange
+        reader = GeneratorStreamReader()
+
+        # Act
+        consumer = reader.read(1024)
+        next(consumer)
+        data = send_return(consumer, b"data")
+
+        # Assert
+        assert data == b"data"
+
+    def test____read____do_not_yield_if_buffer_is_not_empty(self) -> None:
+        # Arrange
+        reader = GeneratorStreamReader(b"data")
+
+        # Act
+        consumer = reader.read(1024)
+        data = next_return(consumer)
+
+        # Assert
+        assert data == b"data"
+
+    def test____read____no_data_copy____in_use_buffer(self) -> None:
+        # Arrange
+        value = b"data"
+        reader = GeneratorStreamReader(value)
+
+        # Act
+        consumer = reader.read(1024)
+        data = next_return(consumer)
+
+        # Assert
+        assert data is value
+
+    def test____read____no_data_copy____sent_value(self) -> None:
+        # Arrange
+        value = b"data"
+        reader = GeneratorStreamReader()
+
+        # Act
+        consumer = reader.read(1024)
+        next(consumer)
+        data = send_return(consumer, value)
+
+        # Assert
+        assert data is value
+
+    @pytest.mark.parametrize("initial", [False, True], ids=lambda p: f"initial=={p}")
+    def test____read____shrink_too_big_buffer(self, initial: bool) -> None:
+        # Arrange
+        value = b"data"
+        reader = GeneratorStreamReader(value if initial else b"")
+
+        # Act
+        consumer = reader.read(2)
+        if initial:
+            data = next_return(consumer)
+        else:
+            next(consumer)
+            data = send_return(consumer, value)
+
+        # Assert
+        assert data == b"da"
+        assert reader.read_all() == b"ta"
+
+    def test____read____null_nbytes(self) -> None:
+        # Arrange
+        reader = GeneratorStreamReader()
+
+        # Act
+        consumer = reader.read(0)
+        data = next_return(consumer)
+
+        # Assert
+        assert data == b""
+
+    def test____read____negative_nbytes(self) -> None:
+        # Arrange
+        reader = GeneratorStreamReader()
+
+        # Act & Assert
+        consumer = reader.read(-1)
+        with pytest.raises(ValueError, match=r"^size must not be < 0$"):
+            next_return(consumer)
+
+    def test____read_exactly____yield_until_size_has_been_reached(self) -> None:
+        # Arrange
+        reader = GeneratorStreamReader()
+
+        # Act
+        consumer = reader.read_exactly(4)
+        next(consumer)
+        consumer.send(b"d")
+        consumer.send(b"a")
+        consumer.send(b"t")
+        data = send_return(consumer, b"a")
+
+        # Assert
+        assert data == b"data"
+
+    @pytest.mark.parametrize("initial", [False, True], ids=lambda p: f"initial=={p}")
+    def test____read_exactly____size_already_fit(self, initial: bool) -> None:
+        # Arrange
+        value = b"data"
+        reader = GeneratorStreamReader(value if initial else b"")
+
+        # Act
+        consumer = reader.read_exactly(4)
+        if initial:
+            data = next_return(consumer)
+        else:
+            next(consumer)
+            data = send_return(consumer, value)
+
+        # Assert
+        assert data is value
+
+    @pytest.mark.parametrize("initial", [False, True], ids=lambda p: f"initial=={p}")
+    def test____read_exactly____shrink_too_big_buffer(self, initial: bool) -> None:
+        # Arrange
+        prefix = b"dat"
+        reader = GeneratorStreamReader(prefix if initial else b"")
+
+        # Act
+        consumer = reader.read_exactly(4)
+        next(consumer)
+        if not initial:
+            consumer.send(prefix)
+        data = send_return(consumer, b"abc")
+
+        # Assert
+        assert data == b"data"
+        assert reader.read_all() == b"bc"
+
+    def test____read_exactly____null_nbytes(self) -> None:
+        # Arrange
+        reader = GeneratorStreamReader()
+
+        # Act
+        consumer = reader.read_exactly(0)
+        data = next_return(consumer)
+
+        # Assert
+        assert data == b""
+
+    def test____read_exactly____negative_nbytes(self) -> None:
+        # Arrange
+        reader = GeneratorStreamReader()
+
+        # Act & Assert
+        consumer = reader.read_exactly(-1)
+        with pytest.raises(ValueError, match=r"^n must not be < 0$"):
+            next_return(consumer)
+
+    @pytest.mark.parametrize(
+        "expected_remaining_data",
+        [
+            pytest.param(b"", id="without remaining data"),
+            pytest.param(b"remaining", id="with remaining data"),
+            pytest.param(b"remaining\r\nother", id="with remaining data including separator"),
+        ],
+    )
+    @pytest.mark.parametrize("keep_end", [False, True], ids=lambda p: f"keep_end=={p}")
+    def test____read_until____one_shot_chunk(self, expected_remaining_data: bytes, keep_end: bool) -> None:
+        # Arrange
+        reader = GeneratorStreamReader()
+        data_to_test: bytes = b"data\r\n"
+
+        # Act
+        consumer = reader.read_until(b"\r\n", limit=1024, keep_end=keep_end)
+        next(consumer)
+        data = send_return(consumer, data_to_test + expected_remaining_data)
+
+        # Assert
+        if keep_end:
+            assert data == b"data\r\n"
+        else:
+            assert data == b"data"
+        assert reader.read_all() == expected_remaining_data
+
+    @pytest.mark.parametrize(
+        "expected_remaining_data",
+        [
+            pytest.param(b"", id="without remaining data"),
+            pytest.param(b"remaining", id="with remaining data"),
+            pytest.param(b"remaining\r\nother", id="with remaining data including separator"),
+        ],
+    )
+    @pytest.mark.parametrize("keep_end", [False, True], ids=lambda p: f"keep_end=={p}")
+    def test____read_until____several_chunks(self, expected_remaining_data: bytes, keep_end: bool) -> None:
+        # Arrange
+        reader = GeneratorStreamReader(b"d")
+
+        # Act
+        consumer = reader.read_until(b"\r\n", limit=1024, keep_end=keep_end)
+        next(consumer)
+        consumer.send(b"ata\r")
+        data = send_return(consumer, b"\n" + expected_remaining_data)
+
+        # Assert
+        if keep_end:
+            assert data == b"data\r\n"
+        else:
+            assert data == b"data"
+        assert reader.read_all() == expected_remaining_data
+
+    @pytest.mark.parametrize("separator_found", [False, True], ids=lambda p: f"separator_found=={p}")
+    def test____read_until____reached_limit(self, separator_found: bytes) -> None:
+        # Arrange
+        reader = GeneratorStreamReader()
+        data_to_test: bytes = b"data\r"
+        if separator_found:
+            data_to_test += b"\n"
+
+        # Act
+        consumer = reader.read_until(b"\r\n", limit=1)
+        next(consumer)
+        with pytest.raises(LimitOverrunError) as exc_info:
+            consumer.send(data_to_test)
+
+        # Assert
+        if separator_found:
+            assert str(exc_info.value) == "Separator is found, but chunk is longer than limit"
+            assert exc_info.value.remaining_data == b""
+        else:
+            assert str(exc_info.value) == "Separator is not found, and chunk exceed the limit"
+            assert exc_info.value.remaining_data == b"\r"
+
+    def test____read_until____empty_separator(self) -> None:
+        # Arrange
+        reader = GeneratorStreamReader()
+
+        # Act & Assert
+        consumer = reader.read_until(b"", limit=1024)
+        with pytest.raises(ValueError, match=r"^Empty separator$"):
+            next_return(consumer)
+
+    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit=={p}")
+    def test____read_until____invalid_limit(self, limit: int) -> None:
+        # Arrange
+        reader = GeneratorStreamReader()
+
+        # Act & Assert
+        consumer = reader.read_until(b"\n", limit)
+        with pytest.raises(ValueError, match=r"^limit must be a positive integer$"):
+            next_return(consumer)


### PR DESCRIPTION
## What's changed
- Added `limit` parameters to `AutoSeparatedPacketSerializers` and its subclasses
- Added `limit` parameter to `JSONSerializer`
- Added `GeneratorStreamReader` class in `easynetwork.serializers.tool`