### PR TITLE
tox.ini(mypy): Removed --no-incremental flag

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -149,7 +149,7 @@ allowlist_externals =
 setenv =
     {[base]setenv}
     MYPY_CACHE_DIR = {envtmpdir}{/}.mypy_cache
-    MYPY_OPTS = --no-incremental --config-file {toxinidir}{/}pyproject.toml --new-type-inference
+    MYPY_OPTS = --config-file {toxinidir}{/}pyproject.toml --new-type-inference
 commands_pre =
     {[pdm]sync} --dev --group=mypy
     test: {[pdm]sync} --dev --group=test


### PR DESCRIPTION
`.mypy_cache` is created in `envtmpdir` and therefore is deleted at each tox run.