### PR TITLE
tox: Do not use {posargs} in setenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,14 +41,14 @@ allowlist_externals =
 setenv =
     {[base]setenv}
     {[base-pytest]setenv}
-    PYTEST_ADDOPTS = {[base-pytest]addopts} --no-cov {posargs}
+    PYTEST_ADDOPTS = {[base-pytest]addopts} --no-cov
 commands_pre =
     {[pdm]sync} --dev --group=test
 commands =
-    tests: pytest -m "not unit and not functional"
-    docstrings: pytest --doctest-modules {toxinidir}{/}src
-    docstrings: pytest --doctest-modules {[docs]examples_dir}{/}tutorials{/}ftp_server
-    docstrings: pytest --doctest-glob="*.rst" {[docs]source_dir}
+    tests: pytest -m "not unit and not functional" {posargs}
+    docstrings: pytest --doctest-modules {posargs} {toxinidir}{/}src
+    docstrings: pytest --doctest-modules {posargs} {[docs]examples_dir}{/}tutorials{/}ftp_server
+    docstrings: pytest --doctest-glob="*.rst" {posargs} {[docs]source_dir}
 
 [testenv:{py311,py312}-{unit,functional}-{__standard__,cbor,msgpack,encryption,sniffio}]
 package = wheel
@@ -57,7 +57,7 @@ allowlist_externals =
 setenv =
     {[base]setenv}
     {[base-pytest]setenv}
-    PYTEST_ADDOPTS = {[base-pytest]addopts} --cov --cov-report='' {posargs}
+    PYTEST_ADDOPTS = {[base-pytest]addopts} --cov --cov-report=''
     COVERAGE_FILE = .coverage.{envname}
     unit: TESTS_ROOTDIR = {[base-pytest]unit_tests_rootdir}
     functional: TESTS_ROOTDIR = {[base-pytest]functional_tests_rootdir}
@@ -70,11 +70,11 @@ commands_pre =
     sniffio: {[pdm]sync} --prod --group=sniffio
     {[pdm]sync} --dev --group=test
 commands =
-    __standard__: pytest -n "{env:PYTEST_MAX_WORKERS:auto}" --dist={[base-pytest]xdist_dist} -m "not feature" {env:TESTS_ROOTDIR}
-    cbor: pytest -m "feature_cbor" {env:TESTS_ROOTDIR}
-    msgpack: pytest -m "feature_msgpack" {env:TESTS_ROOTDIR}
-    encryption: pytest -m "feature_encryption" {env:TESTS_ROOTDIR}
-    sniffio: pytest -m "feature_sniffio" {env:TESTS_ROOTDIR}
+    __standard__: pytest -n "{env:PYTEST_MAX_WORKERS:auto}" --dist={[base-pytest]xdist_dist} -m "not feature" {posargs} {env:TESTS_ROOTDIR}
+    cbor: pytest -m "feature_cbor" {posargs} {env:TESTS_ROOTDIR}
+    msgpack: pytest -m "feature_msgpack" {posargs} {env:TESTS_ROOTDIR}
+    encryption: pytest -m "feature_encryption" {posargs} {env:TESTS_ROOTDIR}
+    sniffio: pytest -m "feature_sniffio" {posargs} {env:TESTS_ROOTDIR}
 
 [testenv:{py311,py312}-functional-{asyncio_proactor,uvloop}]
 package = wheel
@@ -86,7 +86,7 @@ allowlist_externals =
 setenv =
     {[base]setenv}
     {[base-pytest]setenv}
-    PYTEST_ADDOPTS = {[base-pytest]addopts} --cov --cov-report='' {posargs}
+    PYTEST_ADDOPTS = {[base-pytest]addopts} --cov --cov-report=''
     COVERAGE_FILE = .coverage.{envname}
     TESTS_ROOTDIR = {[base-pytest]functional_tests_rootdir}
     asyncio_proactor: ASYNCIO_EVENTLOOP = asyncio-proactor
@@ -97,7 +97,7 @@ commands_pre =
     {[pdm]sync} --dev --group=test
     uvloop: {[pdm]sync} --dev --group=uvloop
 commands =
-    pytest -n "{env:PYTEST_MAX_WORKERS:auto}" --dist={[base-pytest]xdist_dist} --asyncio-event-loop="{env:ASYNCIO_EVENTLOOP}" -m "asyncio and not feature" {env:TESTS_ROOTDIR}
+    pytest -n "{env:PYTEST_MAX_WORKERS:auto}" --dist={[base-pytest]xdist_dist} --asyncio-event-loop="{env:ASYNCIO_EVENTLOOP}" -m "asyncio and not feature" {posargs} {env:TESTS_ROOTDIR}
 
 [testenv:coverage]
 skip_install = True


### PR DESCRIPTION
Use `{posargs}` in `setenv` breaks `tox exec` command.