### PR TITLE
CI: Force to fetch tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
       - name: Setup tox
         uses: ./.github/actions/setup-tox
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,8 @@ jobs:
       SOURCE_DATE_EPOCH: ${{ inputs.SOURCE_DATE_EPOCH }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Setup tox
         uses: ./.github/actions/setup-tox
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Setup tox
         uses: ./.github/actions/setup-tox
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,8 +45,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-tags: true
       - name: Setup tox
         uses: ./.github/actions/setup-tox
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup tox
         uses: ./.github/actions/setup-tox
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,8 +52,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-tags: true
       - name: Setup tox (python ${{ matrix.python_version }})
         uses: ./.github/actions/setup-tox
         with:
@@ -87,8 +85,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-tags: true
       - name: Setup tox (python ${{ matrix.python_version }})
         uses: ./.github/actions/setup-tox
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup tox (python ${{ matrix.python_version }})
         uses: ./.github/actions/setup-tox
         with:
@@ -85,6 +87,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup tox (python ${{ matrix.python_version }})
         uses: ./.github/actions/setup-tox
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Setup tox (python ${{ matrix.python_version }})
         uses: ./.github/actions/setup-tox
         with:
@@ -85,6 +87,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Setup tox (python ${{ matrix.python_version }})
         uses: ./.github/actions/setup-tox
         with:


### PR DESCRIPTION
Because the package version is determined with tagged commits (#162), all the tags should be fetched.

Otherwise the resolved version is always `0.1.devX`

EDIT: `fetch-tags` seems to be broken:
- https://github.com/pypa/setuptools_scm/issues/952
- https://github.com/actions/checkout/issues/1471