### PR TITLE
Implement zero copy writes for TCP socket (sync and async) transports

### DIFF
--- a/docs/source/howto/serializers.rst
+++ b/docs/source/howto/serializers.rst
@@ -204,11 +204,8 @@ Most of the time, you will have a single :keyword:`yield`. The goal is: each :ke
 
 .. note::
 
-   The endpoint implementation can (and most likely will) decide to concatenate all the pieces and do one big send.
-   This is the optimized way to send a large byte buffer.
-
-   However, it may be more attractive to do something else with the returned bytes.
-   :meth:`~.AbstractIncrementalPacketSerializer.incremental_serialize` is here to give endpoints this freedom.
+   The endpoint implementation can decide to concatenate all the pieces and do one big send. However, it may be more attractive to do something else
+   with the returned bytes. :meth:`~.AbstractIncrementalPacketSerializer.incremental_serialize` is here to give endpoints this freedom.
 
 
 The Purpose Of ``incremental_deserialize()``

--- a/src/easynetwork/lowlevel/api_async/transports/abc.py
+++ b/src/easynetwork/lowlevel/api_async/transports/abc.py
@@ -118,19 +118,15 @@ class AsyncStreamWriteTransport(AsyncBaseTransport):
         """
         An efficient way to send a bunch of data via the transport.
 
-        Currently, the default implementation concatenates the arguments and
-        calls :meth:`send_all` on the result.
+        Like :meth:`send_all`, this method continues to send data from bytes until either all data has been sent or an error
+        occurs. :data:`None` is returned on success. On error, an exception is raised, and there is no way to determine how much
+        data, if any, was successfully sent.
 
         Parameters:
             iterable_of_data: An :term:`iterable` yielding the bytes to send.
         """
-        iterable_of_data = list(iterable_of_data)
-        if len(iterable_of_data) == 1:
-            data = iterable_of_data[0]
-        else:
-            data = b"".join(iterable_of_data)
-        del iterable_of_data
-        return await self.send_all(data)
+        for data in iterable_of_data:
+            await self.send_all(data)
 
 
 class AsyncStreamTransport(AsyncStreamWriteTransport, AsyncStreamReadTransport):

--- a/src/easynetwork/lowlevel/asyncio/stream/socket.py
+++ b/src/easynetwork/lowlevel/asyncio/stream/socket.py
@@ -166,6 +166,12 @@ class RawStreamSocketAdapter(transports.AsyncStreamTransport):
     async def send_eof(self) -> None:
         await self.__socket.shutdown(_socket.SHUT_WR)
 
+    async def send_all_from_iterable(self, iterable_of_data: Iterable[bytes | bytearray | memoryview]) -> None:
+        try:
+            await self.__socket.sendmsg(iterable_of_data)
+        except UnsupportedOperation:
+            await super().send_all_from_iterable(iterable_of_data)
+
     @property
     def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         socket = self.__socket.socket

--- a/src/easynetwork/lowlevel/constants.py
+++ b/src/easynetwork/lowlevel/constants.py
@@ -22,6 +22,7 @@ __all__ = [
     "DEFAULT_STREAM_BUFSIZE",
     "MAX_DATAGRAM_BUFSIZE",
     "NOT_CONNECTED_SOCKET_ERRNOS",
+    "SC_IOV_MAX",
     "SSL_HANDSHAKE_TIMEOUT",
     "SSL_SHUTDOWN_TIMEOUT",
     "_DEFAULT_LIMIT",
@@ -80,3 +81,20 @@ SSL_SHUTDOWN_TIMEOUT: Final[float] = 30.0
 
 # Buffer size limit when waiting for a byte sequence
 _DEFAULT_LIMIT: Final[int] = 64 * 1024  # 64 KiB
+
+
+def __get_sysconf(name: str, /) -> int:
+    import os
+
+    try:
+        # os.sysconf() can return a negative value if 'name' is not defined
+        return os.sysconf(name)  # type: ignore[attr-defined,unused-ignore]
+    except (AttributeError, OSError):
+        return -1
+
+
+# Maximum number of buffer that can accept sendmsg(2)
+# Can be a negative value
+SC_IOV_MAX: Final[int] = __get_sysconf("SC_IOV_MAX")
+
+del __get_sysconf

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -283,7 +283,7 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
             case "USE_SSL":
                 return True
             case _:
-                raise SystemError
+                pytest.fail(f"Invalid parameter: {request.param}")
 
     @pytest.fixture
     @staticmethod

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import sys
 import time
 from collections.abc import Generator
@@ -56,3 +57,11 @@ class TimeTest:
             return
         assert self.start_time >= 0
         assert end_time - self.start_time == pytest.approx(self.expected_time, rel=self.approx)
+
+
+def is_proactor_event_loop(event_loop: asyncio.AbstractEventLoop) -> bool:
+    try:
+        ProactorEventLoop: type[asyncio.AbstractEventLoop] = getattr(asyncio, "ProactorEventLoop")
+    except AttributeError:
+        return False
+    return isinstance(event_loop, ProactorEventLoop)

--- a/tests/unit_test/test_async/test_api/test_client/test_tcp.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_tcp.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import errno
 import os
+from collections.abc import Generator
 from socket import AF_INET6, IPPROTO_TCP, SO_ERROR, SO_KEEPALIVE, SOL_SOCKET, TCP_NODELAY
 from typing import TYPE_CHECKING, Any
 
@@ -126,9 +127,10 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
     @pytest.fixture  # DO NOT set autouse=True
     @staticmethod
     def setup_producer_mock(mock_stream_protocol: MagicMock) -> None:
-        mock_stream_protocol.generate_chunks.side_effect = lambda packet: iter(
-            [str(packet).encode("ascii").removeprefix(b"sentinel.") + b"\n"]
-        )
+        def generate_chunks_side_effect(packet: Any) -> Generator[bytes, None, None]:
+            yield str(packet).removeprefix("sentinel.").encode("ascii") + b"\n"
+
+        mock_stream_protocol.generate_chunks.side_effect = generate_chunks_side_effect
 
     @pytest.fixture  # DO NOT set autouse=True
     @staticmethod

--- a/tests/unit_test/test_async/test_lowlevel_api/test_transports/test_abc.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_transports/test_abc.py
@@ -22,6 +22,7 @@ class TestAsyncStreamTransport:
     async def test____send_all_from_iterable____concatenates_chunks_and_call_send_all(
         self,
         mock_transport: MagicMock,
+        mocker: MockerFixture,
     ) -> None:
         # Arrange
         mock_transport.send_all.return_value = None
@@ -31,7 +32,7 @@ class TestAsyncStreamTransport:
         await AsyncStreamTransport.send_all_from_iterable(mock_transport, chunks)
 
         # Assert
-        mock_transport.send_all.assert_awaited_once_with(b"abc")
+        assert mock_transport.send_all.await_args_list == list(map(mocker.call, chunks))
 
     async def test____send_all_from_iterable____single_yield____no_copy(
         self,

--- a/tests/unit_test/test_sync/test_client/test_tcp.py
+++ b/tests/unit_test/test_sync/test_client/test_tcp.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 from ..._utils import DummyLock
-from ...base import UNSUPPORTED_FAMILIES
+from ...base import UNSUPPORTED_FAMILIES, MixinTestSocketSendMSG
 from .base import BaseTestClient
 
 
@@ -37,7 +37,7 @@ def remove_ssl_OP_IGNORE_UNEXPECTED_EOF(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.delattr("ssl.OP_IGNORE_UNEXPECTED_EOF", raising=False)
 
 
-class TestTCPNetworkClient(BaseTestClient):
+class TestTCPNetworkClient(BaseTestClient, MixinTestSocketSendMSG):
     @pytest.fixture(scope="class", params=["AF_INET", "AF_INET6"])
     @staticmethod
     def socket_family(request: Any) -> Any:
@@ -76,6 +76,8 @@ class TestTCPNetworkClient(BaseTestClient):
     def mock_tcp_socket(mock_tcp_socket: MagicMock, socket_family: int, socket_fileno: int) -> MagicMock:
         mock_tcp_socket.family = socket_family
         mock_tcp_socket.fileno.return_value = socket_fileno
+        with contextlib.suppress(AttributeError):
+            del mock_tcp_socket.sendmsg
         return mock_tcp_socket
 
     @pytest.fixture


### PR DESCRIPTION
### What's changed
- Default implementations of `send_all_from_iterable()` do not concatenate received iterable in one byte buffer.
- Implementations of `send_all_from_iterable()` for TCP sockets (without SSL) use `sendmsg(2)` on platforms supporting it (UNIX systems currently).

### Unchanged behaviors
- `asyncio.Transport.writelines()` concatenates the iterable of data by default. `AsyncioTransportStreamSocketAdapter` will continue to use it.
  - Since CPython 3.12, UNIX implementations of `asyncio.Transport` use zero-copy writes (see https://github.com/python/cpython/issues/91166)