### PR TITLE
Serializers and converters exceptions are now converted to RuntimeErrors

### DIFF
--- a/src/easynetwork/lowlevel/_stream.py
+++ b/src/easynetwork/lowlevel/_stream.py
@@ -135,6 +135,8 @@ class StreamDataConsumer(Generic[_ReceivedPacketT]):
                 next(consumer)
             except StopIteration:
                 raise RuntimeError("protocol.build_packet_from_chunks() did not yield") from None
+            except Exception as exc:
+                raise RuntimeError("protocol.build_packet_from_chunks() crashed") from exc
         self.__b = b""
         packet: _ReceivedPacketT
         remaining: bytes
@@ -148,6 +150,8 @@ class StreamDataConsumer(Generic[_ReceivedPacketT]):
             remaining = _ensure_bytes(remaining)
             self.__b = remaining
             raise
+        except Exception as exc:
+            raise RuntimeError("protocol.build_packet_from_chunks() crashed") from exc
         else:
             self.__c = consumer
             raise StopIteration


### PR DESCRIPTION
### What's changed
- The following functions now raise a `RuntimeError` if the protocol raised an exception:
  - `AsyncStreamEndpoint.recv_packet()`
    - Therefore `AsyncTCPNetworkClient.recv_packet()` too.
  - `AsyncDatagramEndpoint.recv_packet()`
    - Therefore `AsyncUDPNetworkClient.recv_packet()` too.
  - `StreamEndpoint.recv_packet()`
    - Therefore `TCPNetworkClient.recv_packet()` too.
  - `DatagramEndpoint.recv_packet()`
    - Therefore `UDPNetworkClient.recv_packet()` too.
- For servers, the exception thrown at the `yield` statement is also a `RuntimeError`.

The original error can be retrieved through the `__cause__` attribute.