### PR TITLE
Added `BufferedIncrementalPacketSerializer` base class

### DIFF
--- a/docs/source/_include/examples/howto/serializers/buffered_incremental_serializer/example1.py
+++ b/docs/source/_include/examples/howto/serializers/buffered_incremental_serializer/example1.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any
+
+from easynetwork.exceptions import DeserializeError, IncrementalDeserializeError
+from easynetwork.serializers.abc import BufferedIncrementalPacketSerializer
+
+if TYPE_CHECKING:
+    from _typeshed import ReadableBuffer
+
+
+class MyJSONSerializer(BufferedIncrementalPacketSerializer[Any, bytearray]):
+    def __init__(self, *, ensure_ascii: bool = True) -> None:
+        self._ensure_ascii: bool = ensure_ascii
+
+        self._encoding: str
+        if self._ensure_ascii:
+            self._encoding = "ascii"
+        else:
+            self._encoding = "utf-8"
+
+    def _dump(self, packet: Any) -> bytes:
+        document = json.dumps(packet, ensure_ascii=self._ensure_ascii)
+        return document.encode(self._encoding)
+
+    def _load(self, data: bytes | bytearray) -> Any:
+        document = data.decode(self._encoding)
+        return json.loads(document)
+
+    def serialize(self, packet: Any) -> bytes:
+        return self._dump(packet)
+
+    def deserialize(self, data: bytes) -> Any:
+        try:
+            return self._load(data)
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise DeserializeError("JSON decode error") from exc
+
+    def incremental_serialize(self, packet: Any) -> Generator[bytes, None, None]:
+        yield self._dump(packet) + b"\r\n"
+
+    def incremental_deserialize(self) -> Generator[None, bytes, tuple[Any, bytes]]:
+        data = yield
+        newline = b"\r\n"
+        while (index := data.find(newline)) < 0:
+            data += yield
+
+        remainder = data[index + len(newline) :]
+        data = data[:index]
+
+        try:
+            document = self._load(data)
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise IncrementalDeserializeError("JSON decode error", remainder) from exc
+
+        return document, remainder
+
+    def create_deserializer_buffer(self, sizehint: int) -> bytearray:
+        buffer_size: int = max(sizehint, 65536)
+        return bytearray(buffer_size)
+
+    def buffered_incremental_deserialize(
+        self,
+        buffer: bytearray,
+    ) -> Generator[int | None, int, tuple[Any, ReadableBuffer]]:
+        buffer_size = len(buffer)
+        newline = b"\r\n"
+        separator_length = len(newline)
+
+        nb_written_bytes: int = (yield None)
+
+        while (index := buffer.find(newline, 0, nb_written_bytes)) < 0:
+            start_idx: int = nb_written_bytes
+            if start_idx > buffer_size - separator_length:
+                raise IncrementalDeserializeError("Too long line", remaining_data=b"")
+            nb_written_bytes += yield start_idx
+
+        remainder: bytearray = buffer[index + separator_length : nb_written_bytes]
+        data: bytearray = buffer[:index]
+
+        try:
+            document = self._load(data)
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise IncrementalDeserializeError("JSON decode error", remainder) from exc
+
+        return document, remainder

--- a/docs/source/_include/examples/howto/serializers/buffered_incremental_serializer/example2.py
+++ b/docs/source/_include/examples/howto/serializers/buffered_incremental_serializer/example2.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import io
+from collections.abc import Generator
+from typing import Any
+
+from easynetwork.serializers.abc import BufferedIncrementalPacketSerializer
+
+
+class MySerializer(BufferedIncrementalPacketSerializer[Any, memoryview]):
+    ...
+
+    # It can receive either 'bytes' from endpoint or 'memoryviews' from buffered_incremental_deserialize()
+    def incremental_deserialize(self) -> Generator[None, bytes | memoryview, tuple[Any, bytes]]:
+        initial_bytes = yield
+        with io.BytesIO(initial_bytes) as buffer:
+            while True:
+                try:
+                    packet = self._load_from_file(buffer)
+                except EOFError:
+                    pass
+                else:
+                    break
+                buffer.write((yield))
+                buffer.seek(0)
+
+            remainder = buffer.read()
+            return packet, remainder
+
+    def _load_from_file(self, file: io.IOBase) -> Any:
+        ...
+
+    def create_deserializer_buffer(self, sizehint: int) -> memoryview:
+        # Don't care about buffer size
+        buffer = bytearray(sizehint)
+        return memoryview(buffer)
+
+    def buffered_incremental_deserialize(self, buffer: memoryview) -> Generator[None, int, tuple[Any, bytes]]:
+        incremental_deserialize = self.incremental_deserialize()
+        # Start the generator
+        next(incremental_deserialize)
+
+        while True:
+            nb_bytes_written: int = yield
+            try:
+                incremental_deserialize.send(buffer[:nb_bytes_written])
+            except StopIteration as exc:
+                # incremental_deserialize() returned
+                return exc.value

--- a/docs/source/_static/css/details.css
+++ b/docs/source/_static/css/details.css
@@ -1,0 +1,3 @@
+details {
+    margin-bottom: 1rem;
+}

--- a/docs/source/api/serializers/abc.rst
+++ b/docs/source/api/serializers/abc.rst
@@ -12,11 +12,6 @@ Top-Level Base Classes
 
 .. automodule:: easynetwork.serializers.abc
    :no-docstring:
-
-.. autoclass:: AbstractPacketSerializer
-   :members:
-
-.. autoclass:: AbstractIncrementalPacketSerializer
    :members:
 
 
@@ -25,16 +20,8 @@ Top-Level Base Classes
 Stream Base Classes
 ===================
 
-.. automodule:: easynetwork.serializers.base_stream
-   :no-docstring:
-
 Here are abstract classes that implement common stream protocol patterns.
 
-.. autoclass:: AutoSeparatedPacketSerializer
-   :members:
-
-.. autoclass:: FixedSizePacketSerializer
-   :members:
-
-.. autoclass:: FileBasedPacketSerializer
+.. automodule:: easynetwork.serializers.base_stream
+   :no-docstring:
    :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,6 +34,7 @@ extensions = [
     "enum_tools.autoenum",
     "sphinx_rtd_theme",
     "sphinx_tabs.tabs",
+    "sphinx_toolbox.collapse",
     "sphinx_toolbox.github",
     "sphinx_toolbox.sidebar_links",
     "sphinx_toolbox.more_autodoc.genericalias",
@@ -134,7 +135,12 @@ github_repository = "EasyNetwork"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_rtd_theme"
-html_static_path = []
+html_static_path = [
+    "_static",
+]
+html_css_files = [
+    "css/details.css",
+]
 
 # -- sphinx-rtd-theme configuration ------------------------------------------
 # https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,6 +80,7 @@ autodoc_type_aliases = {
     "_socket._RetAddress": "typing.Any",
     "_socket.socket": "socket.socket",
     "contextvars.Context": "contextvars.Context",
+    "ReadableBuffer": "bytes | bytearray | memoryview",
     "WriteableBuffer": "bytearray | memoryview",
 }
 autodoc_inherit_docstrings = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,6 +79,7 @@ autodoc_type_aliases = {
     "_socket._RetAddress": "typing.Any",
     "_socket.socket": "socket.socket",
     "contextvars.Context": "contextvars.Context",
+    "WriteableBuffer": "bytearray | memoryview",
 }
 autodoc_inherit_docstrings = False
 autodoc_mock_imports = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,6 +81,9 @@ autodoc_type_aliases = {
     "contextvars.Context": "contextvars.Context",
 }
 autodoc_inherit_docstrings = False
+autodoc_mock_imports = [
+    "_typesched",
+]
 
 # -- sphinx.ext.intersphinx configuration ------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -5,6 +5,9 @@ Glossary
 .. glossary::
    :sorted:
 
+   buffered serializer
+      See :term:`serializer`.
+
    communication protocol
       A set of formal rules describing how to transmit or exchange data, especially across a network.
 
@@ -57,7 +60,7 @@ Glossary
 
       Ideally, a serializer should only handle :ref:`primitive types <bltin-types>` and :ref:`constants <built-in-consts>`.
 
-      There are 2 types of serializers:
+      There are 3 types of serializers:
 
       * one-shot serializers
 
@@ -71,6 +74,11 @@ Glossary
 
         During deserialization, they have the ability **to know when the** :term:`packet` **is complete** (and wait if incomplete)
         and which bytes are not part of the initial :term:`packet`.
+
+      * buffered serializers
+
+        An incremental serializer specialization that allows the use of a custom in-memory byte buffer,
+        if supported by the underlying transport layer.
 
    serializer wrapper
       A :term:`serializer` that transforms data coming from another :term:`serializer`.

--- a/docs/source/howto/advanced/buffered_serializers.rst
+++ b/docs/source/howto/advanced/buffered_serializers.rst
@@ -1,0 +1,209 @@
+*****************************
+How-to — Buffered Serializers
+*****************************
+
+.. note::
+
+   This section assumes that you have read the :doc:`../serializers` page.
+
+.. contents:: Table of Contents
+   :local:
+
+------
+
+Introduction
+============
+
+:meth:`~.AbstractIncrementalPacketSerializer.incremental_deserialize` is useful to wait for all data parts of a packet,
+but there is a small problem with it: the memory consumption.
+
+The Actual Behavior
+-------------------
+
+What happens when you hit a :keyword:`yield` statement:
+
+* A large enough byte buffer is allocated (one call to :manpage:`malloc(3)`).
+
+* :manpage:`recv(2)` will write as much as possible to this buffer.
+
+* The byte buffer is shrunk to fit the bytes actually written (one call to :manpage:`realloc(3)`).
+
+* This finished :class:`bytes` instance is sent to the generator.
+
+What are you likely to do with this byte buffer:
+
+* Append the content to an existing byte buffer, which can be:
+
+  * a :class:`bytes` (involves a call to :manpage:`malloc(3)` and then :manpage:`free(3)`).
+
+  * a :class:`bytearray` (involves a call to :manpage:`realloc(3)`).
+
+  * a custom stream-like API such as :class:`io.BytesIO` (involves a call to :manpage:`realloc(3)`).
+
+  * or something else, but which will somehow do one of the things above.
+
+* Drop the reference to the given byte buffer, since you no longer need it (one call to :manpage:`free(3)`).
+
+Now Imagine That...
+-------------------
+
+...you want :manpage:`recv(2)` to write directly to *your* byte buffer (and perhaps at a given position).
+
+It might look like this:
+
+* :manpage:`recv(2)` will write as much as possible to the byte buffer *you* provided.
+
+* The number of bytes written is sent to the generator.
+
+This principle involves several things:
+
+* The byte buffer can be reused (so there is no more buffer allocation per :manpage:`recv(2)` call).
+
+* It is no longer necessary to copy the content to another location.
+
+This is what the :class:`.BufferedIncrementalPacketSerializer` is designed for.
+
+The benefits?
+-------------
+
+This model exists for performance purposes only. However, it requires careful consideration of the needs to be met.
+It's not a quick fix that will solve application performance problems. In fact, it may not be convenient.
+
+The scenario described above is a real problem for **servers** with high workloads and/or low bandwidth
+that exchange large amounts of data with their clients. In such a situation, the slightest typo can bring
+the whole thing crashing down. Under "normal" conditions, the basic implementation is more than enough
+to keep a server running with acceptable performance.
+
+------
+
+Writing A Buffered Serializer
+=============================
+
+To write a :term:`buffered serializer`, you must create a subclass of :class:`~.BufferedIncrementalPacketSerializer` and override
+its :meth:`~.BufferedIncrementalPacketSerializer.create_deserializer_buffer` and
+:meth:`~.BufferedIncrementalPacketSerializer.buffered_incremental_deserialize` methods.
+
+.. note::
+
+   You still need to implement :class:`.AbstractIncrementalPacketSerializer` methods.
+   Writing input directly to an external object that implements the :ref:`buffer protocol <bufferobjects>` is not supported by
+   all transport layer implementations.
+
+Let's see how we can use it for ``MyJSONSerializer`` (from :doc:`../serializers`):
+
+.. collapse:: Click here to expand/collapse the full code
+
+   .. literalinclude:: ../../_include/examples/howto/serializers/buffered_incremental_serializer/example1.py
+      :linenos:
+      :emphasize-lines: 8,14,60-
+
+
+Choose the buffer type
+----------------------
+
+When subclassing :class:`.BufferedIncrementalPacketSerializer`, you must pass the buffer type. This should be the type of the instance returned
+by :meth:`~.BufferedIncrementalPacketSerializer.create_deserializer_buffer`.
+
+A buffer object is an object that implements the :ref:`buffer protocol <bufferobjects>`.
+
+.. tip::
+
+   As of Python 3.12, a buffer object can also be an object that implements the :class:`collections.abc.Buffer` interface.
+
+For the tutorial, we use a :class:`bytearray`:
+
+.. literalinclude:: ../../_include/examples/howto/serializers/buffered_incremental_serializer/example1.py
+   :end-at: class MyJSONSerializer
+   :dedent:
+   :lineno-match:
+   :emphasize-lines: 8,14
+
+.. _buffer-instantiation:
+
+Buffer Instantiation
+--------------------
+
+.. literalinclude:: ../../_include/examples/howto/serializers/buffered_incremental_serializer/example1.py
+   :pyobject: MyJSONSerializer.create_deserializer_buffer
+   :dedent:
+   :lineno-match:
+
+.. note::
+
+   ``sizehint`` is the *recommended* buffer size, but the buffer can be of any size.
+
+   In the example, we assume that a JSON line can be up to 64KiB. Therefore, the minimum buffer size must be 64KiB.
+
+.. important::
+
+   This function is called **only once per connection**. This means that
+   :meth:`~.BufferedIncrementalPacketSerializer.buffered_incremental_deserialize` will reuse the same buffer for a given stream.
+
+The Purpose Of ``buffered_incremental_deserialize()``
+-----------------------------------------------------
+
+:meth:`~.BufferedIncrementalPacketSerializer.buffered_incremental_deserialize` must be a :term:`generator` function
+(or at least return a :term:`generator iterator`) that yields until all the data parts of the packet have been retrieved and parsed.
+
+The value yielded is the position to start writing to the buffer. It can be:
+
+* :data:`None`: Just use the whole buffer. Therefore, ``yield`` and ``yield None`` are equivalent to ``yield 0``.
+
+* A positive integer (starting at ``0``): Skips the first *n* bytes.
+
+* A negative integer: Skips until the last *n* bytes. For example, ``yield -10`` means to write from the last 10th byte of the buffer.
+
+This generator must return a pair of ``(packet, remainder)`` where ``packet`` is the deserialized packet and ``remainder`` is any
+superfluous trailing bytes that was useless.
+The remainder can be a :class:`memoryview` pointing to ``buffer`` or an external :term:`bytes-like object`.
+
+At each :keyword:`yield` checkpoint, the endpoint implementation sends to the generator the number of bytes written to the ``buffer``
+**from the given start position**.
+
+.. literalinclude:: ../../_include/examples/howto/serializers/buffered_incremental_serializer/example1.py
+   :pyobject: MyJSONSerializer.buffered_incremental_deserialize
+   :dedent:
+   :lineno-match:
+
+.. warning::
+
+   Buffer consistency
+      Because of buffer reuse, it is up to you to reset the buffer state upon entry and exit of the generator.
+      If you are relying only on the area that has already been written, you can skip this step (as in the example above).
+
+   Growing buffers
+      It is not officially supported to increase/decrease the buffer size during deserialization. But if you want to,
+      remember to reset it to its initial size for consistency.
+
+.. tip::
+
+   Buffer initialization
+      :meth:`~.BufferedIncrementalPacketSerializer.buffered_incremental_deserialize` is called *before* the read.
+      You can reinitialize the buffer (for example, by filling it to zero) before the first read::
+
+         def buffered_incremental_deserialize(self, buffer: bytearray) -> Generator:
+             for i in range(len(buffer)):
+                 buffer[i] = 0
+
+             nbytes = yield
+
+             ...
+
+   Start writing anytime, anywhere
+      It is **not** mandatory to yield :data:`None` or ``0`` for the first yield.
+
+   Avoid copying data as much as possible
+      :class:`memoryview` is your best friend, use it.
+
+
+Tips & Tricks
+=============
+
+Common implementations between ``incremental_deserialize()`` and ``buffered_incremental_deserialize()``
+-------------------------------------------------------------------------------------------------------
+
+If the API you are using does not care about using :class:`bytes` or :class:`memoryview`,
+you can write a single function that handles any byte buffer:
+
+.. literalinclude:: ../../_include/examples/howto/serializers/buffered_incremental_serializer/example2.py
+   :linenos:

--- a/docs/source/howto/advanced/index.rst
+++ b/docs/source/howto/advanced/index.rst
@@ -1,0 +1,8 @@
+**************
+Advanced Guide
+**************
+
+.. toctree::
+   :maxdepth: 1
+
+   buffered_serializers

--- a/docs/source/howto/protocols.rst
+++ b/docs/source/howto/protocols.rst
@@ -142,7 +142,7 @@ For example:
 
 .. warning::
 
-   The :meth:`~.AbstractPacketConverter.create_from_dto_packet` function must raise a :exc:`PacketConversionError` to indicate that
+   The :meth:`~.AbstractPacketConverter.create_from_dto_packet` function must raise a :exc:`.PacketConversionError` to indicate that
    a parsing error was "expected" so that the received data is considered invalid.
 
    Otherwise, any other error is considered a crash.

--- a/docs/source/howto/serializers.rst
+++ b/docs/source/howto/serializers.rst
@@ -217,7 +217,7 @@ The Purpose Of ``incremental_deserialize()``
 This generator must return a pair of ``(packet, remainder)`` where ``packet`` is the deserialized packet and ``remainder`` is any
 superfluous trailing bytes that was useless.
 
-At each :keyword:`yield` checkpoint, the endpoint implementation sends the data received from the remote endpoint to the generator.
+At each :keyword:`yield` checkpoint, the endpoint implementation sends to the generator the data received from the remote endpoint.
 
 .. literalinclude:: ../_include/examples/howto/serializers/incremental_serializer/example2.py
    :pyobject: MyJSONSerializer.incremental_deserialize

--- a/docs/source/howto/tcp_clients.rst
+++ b/docs/source/howto/tcp_clients.rst
@@ -334,6 +334,12 @@ You can control this value by setting the ``max_recv_size`` parameter:
          :linenos:
 
 
+.. note::
+
+   ``max_recv_size`` is also used as a size hint for :term:`buffered serializers <buffered serializer>`.
+   See :ref:`this section <buffer-instantiation>` for details.
+
+
 SSL/TLS Connection
 ------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ Welcome to EasyNetwork's documentation!
    quickstart/index
    tutorials/index
    howto/index
+   howto/advanced/index
    api/index
    glossary
 

--- a/src/easynetwork/_typevars.py
+++ b/src/easynetwork/_typevars.py
@@ -30,6 +30,9 @@ import typing
 
 if typing.TYPE_CHECKING:
     from _typeshed import WriteableBuffer
+else:  # pragma: no cover
+    # Needed for sphinx-autodoc
+    WriteableBuffer = bytearray | memoryview
 
 _DTOPacketT = typing.TypeVar("_DTOPacketT")
 

--- a/src/easynetwork/_typevars.py
+++ b/src/easynetwork/_typevars.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 __all__ = [
+    "_BufferT",
     "_DTOPacketT",
     "_PacketT",
     "_ReceivedPacketT",
@@ -27,6 +28,9 @@ __all__ = [
 
 import typing
 
+if typing.TYPE_CHECKING:
+    from _typeshed import WriteableBuffer
+
 _DTOPacketT = typing.TypeVar("_DTOPacketT")
 
 _SentPacketT = typing.TypeVar("_SentPacketT")
@@ -35,3 +39,5 @@ _PacketT = typing.TypeVar("_PacketT")
 
 _RequestT = typing.TypeVar("_RequestT")
 _ResponseT = typing.TypeVar("_ResponseT")
+
+_BufferT = typing.TypeVar("_BufferT", bound="WriteableBuffer")

--- a/src/easynetwork/exceptions.py
+++ b/src/easynetwork/exceptions.py
@@ -115,9 +115,6 @@ class LimitOverrunError(IncrementalDeserializeError):
 
         super().__init__(message, remaining_data, error_info=None)
 
-        self.remaining_data: memoryview
-        """Unused trailing data."""
-
         self.consumed: int = consumed
         """Total number of to be consumed bytes."""
 

--- a/src/easynetwork/exceptions.py
+++ b/src/easynetwork/exceptions.py
@@ -108,10 +108,12 @@ class LimitOverrunError(IncrementalDeserializeError):
 
         remaining_data = memoryview(buffer)[consumed:]
         seplen = len(separator)
-        if seplen and remaining_data[:seplen] == separator:
-            remaining_data = remaining_data[seplen:]
-        else:
-            remaining_data = remaining_data[1:]
+        if seplen:
+            if remaining_data[:seplen] == separator:
+                remaining_data = remaining_data[seplen:]
+            else:
+                while remaining_data.nbytes and remaining_data[:seplen] != separator[: remaining_data.nbytes]:
+                    remaining_data = remaining_data[1:]
 
         super().__init__(message, remaining_data, error_info=None)
 

--- a/src/easynetwork/lowlevel/_stream.py
+++ b/src/easynetwork/lowlevel/_stream.py
@@ -284,6 +284,9 @@ class BufferedStreamDataConsumer(Generic[_ReceivedPacketT]):
         if self.__already_written:
             buffer = buffer[self.__already_written :]
 
+        if not buffer:
+            raise RuntimeError("The start position is set to the end of the buffer")
+
         self.__buffer_view = buffer
         return buffer
 

--- a/src/easynetwork/lowlevel/_stream.py
+++ b/src/easynetwork/lowlevel/_stream.py
@@ -248,7 +248,7 @@ class BufferedStreamDataConsumer(Generic[_ReceivedPacketT]):
             self.__save_remainder_in_buffer(exc.remaining_data)
             raise
         except Exception as exc:
-            # Reset buffer, since we do not know the buffer state is still valid
+            # Reset buffer, since we do not know if the buffer state is still valid
             self.__buffer = None
             raise RuntimeError("protocol.build_packet_from_buffer() crashed") from exc
         else:
@@ -273,7 +273,7 @@ class BufferedStreamDataConsumer(Generic[_ReceivedPacketT]):
             except StopIteration:
                 raise RuntimeError("protocol.build_packet_from_buffer() did not yield") from None
             except Exception as exc:
-                # Reset buffer, since we do not know the buffer state is still valid
+                # Reset buffer, since we do not know if the buffer state is still valid
                 self.__buffer = None
                 raise RuntimeError("protocol.build_packet_from_buffer() crashed") from exc
             self.__consumer = consumer

--- a/src/easynetwork/lowlevel/_stream.py
+++ b/src/easynetwork/lowlevel/_stream.py
@@ -157,7 +157,7 @@ class StreamDataConsumer(Generic[_ReceivedPacketT]):
         finally:
             del consumer, chunk
 
-    def feed(self, chunk: bytes) -> None:
+    def feed(self, chunk: ReadableBuffer) -> None:
         chunk = bytes(chunk)
         if not chunk:
             return

--- a/src/easynetwork/lowlevel/_utils.py
+++ b/src/easynetwork/lowlevel/_utils.py
@@ -324,7 +324,6 @@ class ResourceGuard:
     __slots__ = (
         "__semaphore",
         "__msg",
-        "__held",
     )
 
     def __init__(self, message: str) -> None:

--- a/src/easynetwork/lowlevel/api_async/endpoints/stream.py
+++ b/src/easynetwork/lowlevel/api_async/endpoints/stream.py
@@ -67,12 +67,12 @@ class AsyncStreamEndpoint(typed_attr.TypedAttributeProvider, Generic[_SentPacket
             self.__sender = _DataSenderImpl(transport, _stream.StreamDataProducer(protocol))
 
         self.__receiver: _DataReceiverImpl[_ReceivedPacketT] | _BufferedReceiverImpl[_ReceivedPacketT] | None = None
-        try:
-            if not isinstance(transport, transports.AsyncBufferedStreamReadTransport):
-                raise UnsupportedOperation
-            self.__receiver = _BufferedReceiverImpl(transport, _stream.BufferedStreamDataConsumer(protocol, max_recv_size))
-        except UnsupportedOperation:
-            if isinstance(transport, transports.AsyncStreamReadTransport):
+        if isinstance(transport, transports.AsyncStreamReadTransport):
+            try:
+                if not isinstance(transport, transports.AsyncBufferedStreamReadTransport):
+                    raise UnsupportedOperation
+                self.__receiver = _BufferedReceiverImpl(transport, _stream.BufferedStreamDataConsumer(protocol, max_recv_size))
+            except UnsupportedOperation:
                 self.__receiver = _DataReceiverImpl(transport, _stream.StreamDataConsumer(protocol), max_recv_size)
 
         self.__transport: transports.AsyncStreamReadTransport | transports.AsyncStreamWriteTransport = transport

--- a/src/easynetwork/lowlevel/api_async/transports/abc.py
+++ b/src/easynetwork/lowlevel/api_async/transports/abc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 __all__ = [
     "AsyncBaseTransport",
+    "AsyncBufferedStreamReadTransport",
     "AsyncDatagramListener",
     "AsyncDatagramReadTransport",
     "AsyncDatagramTransport",
@@ -35,6 +36,8 @@ from typing import TYPE_CHECKING, Any, Generic, NoReturn, TypeVar
 from ... import typed_attr
 
 if TYPE_CHECKING:
+    from _typeshed import WriteableBuffer
+
     from ..backend.abc import TaskGroup
 
 _T_co = TypeVar("_T_co", covariant=True)
@@ -73,7 +76,7 @@ class AsyncBaseTransport(typed_attr.TypedAttributeProvider, metaclass=ABCMeta):
 
 class AsyncStreamReadTransport(AsyncBaseTransport):
     """
-    An asynchronous continous stream data reader transport.
+    An asynchronous continuous stream data reader transport.
     """
 
     __slots__ = ()
@@ -97,9 +100,32 @@ class AsyncStreamReadTransport(AsyncBaseTransport):
         raise NotImplementedError
 
 
+class AsyncBufferedStreamReadTransport(AsyncStreamReadTransport):
+    """
+    An asynchronous continuous stream data reader transport that supports externally allocated buffers.
+    """
+
+    __slots__ = ()
+
+    @abstractmethod
+    async def recv_into(self, buffer: WriteableBuffer) -> int:
+        """
+        Read into the given `buffer`.
+
+        Parameters:
+            buffer: where to write the received bytes.
+
+        Returns:
+            the number of bytes written.
+
+            Returning ``0`` for a non-zero buffer indicates an EOF.
+        """
+        raise NotImplementedError
+
+
 class AsyncStreamWriteTransport(AsyncBaseTransport):
     """
-    An asynchronous continous stream data writer transport.
+    An asynchronous continuous stream data writer transport.
     """
 
     __slots__ = ()
@@ -131,7 +157,7 @@ class AsyncStreamWriteTransport(AsyncBaseTransport):
 
 class AsyncStreamTransport(AsyncStreamWriteTransport, AsyncStreamReadTransport):
     """
-    An asynchronous continous stream data transport.
+    An asynchronous continuous stream data transport.
     """
 
     __slots__ = ()

--- a/src/easynetwork/lowlevel/api_sync/endpoints/stream.py
+++ b/src/easynetwork/lowlevel/api_sync/endpoints/stream.py
@@ -67,12 +67,12 @@ class StreamEndpoint(typed_attr.TypedAttributeProvider, Generic[_SentPacketT, _R
             self.__sender = _DataSenderImpl(transport, _stream.StreamDataProducer(protocol))
 
         self.__receiver: _DataReceiverImpl[_ReceivedPacketT] | _BufferedReceiverImpl[_ReceivedPacketT] | None = None
-        try:
-            if not isinstance(transport, transports.BufferedStreamReadTransport):
-                raise UnsupportedOperation
-            self.__receiver = _BufferedReceiverImpl(transport, _stream.BufferedStreamDataConsumer(protocol, max_recv_size))
-        except UnsupportedOperation:
-            if isinstance(transport, transports.StreamReadTransport):
+        if isinstance(transport, transports.StreamReadTransport):
+            try:
+                if not isinstance(transport, transports.BufferedStreamReadTransport):
+                    raise UnsupportedOperation
+                self.__receiver = _BufferedReceiverImpl(transport, _stream.BufferedStreamDataConsumer(protocol, max_recv_size))
+            except UnsupportedOperation:
                 self.__receiver = _DataReceiverImpl(transport, _stream.StreamDataConsumer(protocol), max_recv_size)
 
         self.__transport: transports.StreamReadTransport | transports.StreamWriteTransport = transport

--- a/src/easynetwork/lowlevel/api_sync/transports/abc.py
+++ b/src/easynetwork/lowlevel/api_sync/transports/abc.py
@@ -96,6 +96,8 @@ class BufferedStreamReadTransport(StreamReadTransport):
     A continuous stream data reader transport that supports externally allocated buffers.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def recv_into(self, buffer: WriteableBuffer, timeout: float) -> int:
         """

--- a/src/easynetwork/lowlevel/api_sync/transports/abc.py
+++ b/src/easynetwork/lowlevel/api_sync/transports/abc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 __all__ = [
     "BaseTransport",
+    "BufferedStreamReadTransport",
     "DatagramReadTransport",
     "DatagramTransport",
     "DatagramWriteTransport",
@@ -28,8 +29,12 @@ __all__ = [
 
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from ... import _utils, typed_attr
+
+if TYPE_CHECKING:
+    from _typeshed import WriteableBuffer
 
 
 class BaseTransport(typed_attr.TypedAttributeProvider, metaclass=ABCMeta):
@@ -59,7 +64,7 @@ class BaseTransport(typed_attr.TypedAttributeProvider, metaclass=ABCMeta):
 
 class StreamReadTransport(BaseTransport):
     """
-    A continous stream data reader transport.
+    A continuous stream data reader transport.
     """
 
     __slots__ = ()
@@ -86,9 +91,35 @@ class StreamReadTransport(BaseTransport):
         raise NotImplementedError
 
 
+class BufferedStreamReadTransport(StreamReadTransport):
+    """
+    A continuous stream data reader transport that supports externally allocated buffers.
+    """
+
+    @abstractmethod
+    def recv_into(self, buffer: WriteableBuffer, timeout: float) -> int:
+        """
+        Read into the given `buffer`.
+
+        Parameters:
+            buffer: where to write the received bytes.
+            timeout: the allowed time (in seconds) for blocking operations. Can be set to :data:`math.inf`.
+
+        Raises:
+            ValueError: Negative `timeout`.
+            TimeoutError: Operation timed out.
+
+        Returns:
+            the number of bytes written.
+
+            Returning ``0`` for a non-zero buffer indicates an EOF.
+        """
+        raise NotImplementedError
+
+
 class StreamWriteTransport(BaseTransport):
     """
-    A continous stream data writer transport.
+    A continuous stream data writer transport.
     """
 
     __slots__ = ()
@@ -168,7 +199,7 @@ class StreamWriteTransport(BaseTransport):
 
 class StreamTransport(StreamWriteTransport, StreamReadTransport):
     """
-    A continous stream data transport.
+    A continuous stream data transport.
     """
 
     __slots__ = ()

--- a/src/easynetwork/lowlevel/api_sync/transports/base_selector.py
+++ b/src/easynetwork/lowlevel/api_sync/transports/base_selector.py
@@ -186,6 +186,8 @@ class SelectorBufferedStreamReadTransport(SelectorStreamReadTransport, transport
     that supports externally allocated buffers.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def recv_noblock_into(self, buffer: WriteableBuffer) -> int:
         """

--- a/src/easynetwork/lowlevel/api_sync/transports/base_selector.py
+++ b/src/easynetwork/lowlevel/api_sync/transports/base_selector.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 __all__ = [
     "SelectorBaseTransport",
+    "SelectorBufferedStreamReadTransport",
     "SelectorDatagramReadTransport",
     "SelectorDatagramTransport",
     "SelectorDatagramWriteTransport",
@@ -33,10 +34,13 @@ import math
 import selectors
 from abc import abstractmethod
 from collections.abc import Callable
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from ... import _utils
 from . import abc as transports
+
+if TYPE_CHECKING:
+    from _typeshed import WriteableBuffer
 
 _R = TypeVar("_R")
 
@@ -142,7 +146,7 @@ class SelectorBaseTransport(transports.BaseTransport):
 
 class SelectorStreamReadTransport(SelectorBaseTransport, transports.StreamReadTransport):
     """
-    A continous stream data reader transport using the :mod:`selectors` module for blocking operations polling.
+    A continuous stream data reader transport using the :mod:`selectors` module for blocking operations polling.
     """
 
     __slots__ = ()
@@ -156,6 +160,7 @@ class SelectorStreamReadTransport(SelectorBaseTransport, transports.StreamReadTr
             bufsize: the maximum buffer size.
 
         Raises:
+            ValueError: Negative `bufsize`.
             WouldBlockOnRead: the operation would block when reading the pipe.
             WouldBlockOnWrite: the operation would block when writing on the pipe.
 
@@ -175,9 +180,43 @@ class SelectorStreamReadTransport(SelectorBaseTransport, transports.StreamReadTr
         return self._retry(lambda: self.recv_noblock(bufsize), timeout)
 
 
+class SelectorBufferedStreamReadTransport(SelectorStreamReadTransport, transports.BufferedStreamReadTransport):
+    """
+    A continuous stream data reader transport using the :mod:`selectors` module for blocking operations polling
+    that supports externally allocated buffers.
+    """
+
+    @abstractmethod
+    def recv_noblock_into(self, buffer: WriteableBuffer) -> int:
+        """
+        Read into the given `buffer`.
+
+        Parameters:
+            buffer: where to write the received bytes.
+
+        Raises:
+            WouldBlockOnRead: the operation would block when reading the pipe.
+            WouldBlockOnWrite: the operation would block when writing on the pipe.
+
+        Returns:
+            the number of bytes written.
+
+            Returning ``0`` for a non-zero buffer indicates an EOF.
+        """
+        raise NotImplementedError
+
+    def recv_into(self, buffer: WriteableBuffer, timeout: float) -> int:
+        """
+        Read into the given `buffer`.
+
+        The default implementation will retry to call :meth:`recv_noblock_into` until it succeeds under the given `timeout`.
+        """
+        return self._retry(lambda: self.recv_noblock_into(buffer), timeout)
+
+
 class SelectorStreamWriteTransport(SelectorBaseTransport, transports.StreamWriteTransport):
     """
-    A continous stream data writer transport using the :mod:`selectors` module for blocking operations polling.
+    A continuous stream data writer transport using the :mod:`selectors` module for blocking operations polling.
     """
 
     __slots__ = ()
@@ -207,7 +246,7 @@ class SelectorStreamWriteTransport(SelectorBaseTransport, transports.StreamWrite
 
 class SelectorStreamTransport(SelectorStreamWriteTransport, SelectorStreamReadTransport, transports.StreamTransport):
     """
-    A continous stream data transport using the :mod:`selectors` module for blocking operations polling.
+    A continuous stream data transport using the :mod:`selectors` module for blocking operations polling.
     """
 
     __slots__ = ()

--- a/src/easynetwork/lowlevel/asyncio/socket.py
+++ b/src/easynetwork/lowlevel/asyncio/socket.py
@@ -38,7 +38,7 @@ from .tasks import CancelScope, TaskUtils
 if TYPE_CHECKING:
     from types import TracebackType
 
-    from _typeshed import ReadableBuffer
+    from _typeshed import ReadableBuffer, WriteableBuffer
 
 
 _SocketTaskId: TypeAlias = Literal["accept", "send", "recv"]
@@ -153,6 +153,11 @@ class AsyncSocket:
         with self.__conflict_detection("recv", abort_errno=_errno.ECONNABORTED):
             socket = self.__check_not_closed()
             return await self.__loop.sock_recv(socket, bufsize)
+
+    async def recv_into(self, buffer: WriteableBuffer, /) -> int:
+        with self.__conflict_detection("recv", abort_errno=_errno.ECONNABORTED):
+            socket = self.__check_not_closed()
+            return await self.__loop.sock_recv_into(socket, buffer)
 
     async def recvfrom(self, bufsize: int, /) -> tuple[bytes, _socket._RetAddress]:
         with self.__conflict_detection("recv", abort_errno=_errno.ECONNABORTED):

--- a/src/easynetwork/lowlevel/asyncio/stream/socket.py
+++ b/src/easynetwork/lowlevel/asyncio/stream/socket.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
     import asyncio.trsock
     import ssl as _typing_ssl
 
+    from _typeshed import WriteableBuffer
+
 
 @final
 class AsyncioTransportStreamSocketAdapter(transports.AsyncStreamTransport):
@@ -126,7 +128,7 @@ class AsyncioTransportStreamSocketAdapter(transports.AsyncStreamTransport):
 
 
 @final
-class RawStreamSocketAdapter(transports.AsyncStreamTransport):
+class RawStreamSocketAdapter(transports.AsyncStreamTransport, transports.AsyncBufferedStreamReadTransport):
     __slots__ = ("__socket",)
 
     def __init__(
@@ -154,6 +156,9 @@ class RawStreamSocketAdapter(transports.AsyncStreamTransport):
 
     async def recv(self, bufsize: int) -> bytes:
         return await self.__socket.recv(bufsize)
+
+    async def recv_into(self, buffer: WriteableBuffer) -> int:
+        return await self.__socket.recv_into(buffer)
 
     async def send_all(self, data: bytes | bytearray | memoryview) -> None:
         await self.__socket.sendall(data)

--- a/src/easynetwork/protocol.py
+++ b/src/easynetwork/protocol.py
@@ -167,10 +167,7 @@ class BufferedStreamReceiver(Generic[_ReceivedPacketT, _BufferT]):
         try:
             packet, remaining_data = yield from self.__serializer.buffered_incremental_deserialize(buffer)
         except IncrementalDeserializeError as exc:
-            try:
-                raise StreamProtocolParseError(exc.remaining_data, exc) from exc
-            finally:
-                exc.remaining_data = b""
+            raise StreamProtocolParseError(exc.remaining_data, exc) from exc
         except DeserializeError as exc:
             raise RuntimeError("DeserializeError raised instead of IncrementalDeserializeError") from exc
 

--- a/src/easynetwork/protocol.py
+++ b/src/easynetwork/protocol.py
@@ -153,7 +153,7 @@ class BufferedStreamReceiver(Generic[_ReceivedPacketT, _BufferT]):
         """
 
         if not isinstance(serializer, BufferedIncrementalPacketSerializer):
-            raise TypeError(f"Expected an incremental serializer instance, got {serializer!r}")
+            raise TypeError(f"Expected a buffered incremental serializer instance, got {serializer!r}")
         if converter is not None and not isinstance(converter, AbstractPacketConverterComposite):
             raise TypeError(f"Expected a converter instance, got {converter!r}")
         self.__serializer: BufferedIncrementalPacketSerializer[Any, _BufferT] = serializer

--- a/src/easynetwork/serializers/abc.py
+++ b/src/easynetwork/serializers/abc.py
@@ -108,6 +108,9 @@ class AbstractIncrementalPacketSerializer(AbstractPacketSerializer[_DTOPacketT])
         Yields:
             :data:`None` until the whole :term:`packet` has been deserialized.
 
+            At each :keyword:`yield` checkpoint, the endpoint implementation sends to the generator the data received
+            from the remote endpoint.
+
         Returns:
             a tuple with the deserialized Python object and the unused trailing data.
         """
@@ -201,7 +204,7 @@ class BufferedIncrementalPacketSerializer(AbstractIncrementalPacketSerializer[_D
         Yields:
             until the whole :term:`packet` has been deserialized.
 
-            The value returned is the position to start writing to the buffer. It can be:
+            The value yielded is the position to start writing to the buffer. It can be:
 
             * :data:`None`: Just use the whole buffer. Therefore, ``yield`` and ``yield None`` are equivalent to ``yield 0``.
 
@@ -209,6 +212,9 @@ class BufferedIncrementalPacketSerializer(AbstractIncrementalPacketSerializer[_D
 
             * A negative integer: Skips until the last `n` bytes.
               For example, ``yield -10`` means to write from the last 10th byte of the buffer.
+
+            At each :keyword:`yield` checkpoint, the endpoint implementation sends to the generator
+            the number of bytes written to the `buffer`.
 
         Returns:
             a tuple with the deserialized Python object and the unused trailing data.

--- a/src/easynetwork/serializers/json.py
+++ b/src/easynetwork/serializers/json.py
@@ -412,13 +412,13 @@ class _JSONParser:
 
     @staticmethod
     def _split_partial_document(partial_document: bytes, consumed: int, limit: int) -> tuple[bytes, bytes]:
-        consumed = _JSONParser._whitespaces_match(partial_document, consumed).end()
         if consumed > limit:
             raise LimitOverrunError(
                 "JSON object's end frame is found, but chunk is longer than limit",
                 partial_document,
                 consumed,
             )
+        consumed = _JSONParser._whitespaces_match(partial_document, consumed).end()
         if consumed == len(partial_document):
             # The following bytes are only spaces
             # Do not slice the document, the trailing spaces will be ignored by JSONDecoder

--- a/src/easynetwork/serializers/line.py
+++ b/src/easynetwork/serializers/line.py
@@ -129,7 +129,7 @@ class StringLineSerializer(AutoSeparatedPacketSerializer[str]):
 
         Raises:
             DeserializeError: :class:`UnicodeError` raised when decoding `data`.
-            DeserializeError: Newline found in `data` (excluding those at the end of the sequence).
+            DeserializeError: Newline found in `data` (except those at the end of the sequence).
 
         Returns:
             the string.

--- a/src/easynetwork/serializers/struct.py
+++ b/src/easynetwork/serializers/struct.py
@@ -138,7 +138,7 @@ class AbstractStructSerializer(FixedSizePacketSerializer[_DTOPacketT]):
         return self.__s.pack(*self.iter_values(packet))
 
     @final
-    def deserialize(self, data: bytes) -> _DTOPacketT:
+    def deserialize(self, data: bytes | memoryview) -> _DTOPacketT:
         """
         Creates a Python object representing the structure from `data`.
 

--- a/src/easynetwork/serializers/tools.py
+++ b/src/easynetwork/serializers/tools.py
@@ -38,7 +38,7 @@ class GeneratorStreamReader:
         Parameters:
             initial_bytes: a :class:`bytes` object that contains initial data.
         """
-        self.__buffer: bytes = initial_bytes
+        self.__buffer: bytes = bytes(initial_bytes)
 
     def read_all(self) -> bytes:
         """
@@ -77,13 +77,10 @@ class GeneratorStreamReader:
             return b""
 
         while not self.__buffer:
-            self.__buffer = yield
+            self.__buffer = bytes((yield))
 
-        if len(self.__buffer) <= size:
-            data, self.__buffer = self.__buffer, b""
-        else:
-            data = self.__buffer[:size]
-            self.__buffer = self.__buffer[size:]
+        data = self.__buffer[:size]
+        self.__buffer = self.__buffer[size:]
 
         return data
 
@@ -114,15 +111,12 @@ class GeneratorStreamReader:
             return b""
 
         while not self.__buffer:
-            self.__buffer = yield
-        while (buflen := len(self.__buffer)) < n:
+            self.__buffer = bytes((yield))
+        while len(self.__buffer) < n:
             self.__buffer += yield
 
-        if buflen == n:
-            data, self.__buffer = self.__buffer, b""
-        else:
-            data = self.__buffer[:n]
-            self.__buffer = self.__buffer[n:]
+        data = self.__buffer[:n]
+        self.__buffer = self.__buffer[n:]
 
         return data
 
@@ -167,7 +161,7 @@ class GeneratorStreamReader:
             raise ValueError("Empty separator")
 
         while not self.__buffer:
-            self.__buffer = yield
+            self.__buffer = bytes((yield))
 
         offset: int = 0
         sepidx: int = -1
@@ -193,13 +187,9 @@ class GeneratorStreamReader:
 
         offset = sepidx + seplen
         if keep_end:
-            if offset == buflen:
-                data, self.__buffer = self.__buffer, b""
-            else:
-                data = self.__buffer[:offset]
-                self.__buffer = self.__buffer[offset:]
+            data = self.__buffer[:offset]
         else:
             data = self.__buffer[:sepidx]
-            self.__buffer = self.__buffer[offset:]
+        self.__buffer = self.__buffer[offset:]
 
         return data

--- a/tests/functional_test/test_communication/conftest.py
+++ b/tests/functional_test/test_communication/conftest.py
@@ -12,7 +12,7 @@ from easynetwork.protocol import DatagramProtocol, StreamProtocol
 import pytest
 import trustme
 
-from .serializer import NotGoodStringSerializer, StringSerializer
+from .serializer import BufferedStringSerializer, NotGoodBufferedStringSerializer, NotGoodStringSerializer, StringSerializer
 
 _FAMILY_TO_LOCALHOST: dict[int, str] = {
     AF_INET: "127.0.0.1",
@@ -61,21 +61,40 @@ def udp_socket_factory(socket_factory: Callable[[int], Socket]) -> Callable[[], 
     return partial(socket_factory, SOCK_DGRAM)
 
 
-@pytest.fixture
-def serializer(request: pytest.FixtureRequest) -> StringSerializer:
-    if getattr(request, "param", "") == "invalid":
-        return NotGoodStringSerializer()
-    return StringSerializer()
+@pytest.fixture(params=["data"])
+def one_shot_serializer(request: pytest.FixtureRequest) -> StringSerializer:
+    match request.param:
+        case "data":
+            return StringSerializer()
+        case "invalid":
+            return NotGoodStringSerializer()
+        case _:
+            pytest.fail("Invalid parameter")
+
+
+@pytest.fixture(params=["data", "buffered"])
+def incremental_serializer(request: pytest.FixtureRequest) -> StringSerializer:
+    match request.param:
+        case "data":
+            return StringSerializer()
+        case "buffered":
+            return BufferedStringSerializer()
+        case "invalid":
+            return NotGoodStringSerializer()
+        case "invalid_buffered":
+            return NotGoodBufferedStringSerializer()
+        case _:
+            pytest.fail("Invalid parameter")
 
 
 @pytest.fixture
-def stream_protocol(serializer: StringSerializer) -> StreamProtocol[str, str]:
-    return StreamProtocol(serializer)
+def stream_protocol(incremental_serializer: StringSerializer) -> StreamProtocol[str, str]:
+    return StreamProtocol(incremental_serializer)
 
 
 @pytest.fixture
-def datagram_protocol(serializer: StringSerializer) -> DatagramProtocol[str, str]:
-    return DatagramProtocol(serializer)
+def datagram_protocol(one_shot_serializer: StringSerializer) -> DatagramProtocol[str, str]:
+    return DatagramProtocol(one_shot_serializer)
 
 
 # Origin: https://gist.github.com/4325783, by Geert Jansen.  Public domain.

--- a/tests/functional_test/test_communication/test_async/test_server/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_udp.py
@@ -358,7 +358,7 @@ class TestAsyncUDPNetworkServer(BaseTestAsyncServer):
 
     @pytest.mark.parametrize("mute_thrown_exception", [False, True])
     @pytest.mark.parametrize("request_handler", [ErrorInRequestHandler], indirect=True)
-    @pytest.mark.parametrize("serializer", [pytest.param("invalid", id="serializer_crash")], indirect=True)
+    @pytest.mark.parametrize("one_shot_serializer", [pytest.param("invalid", id="serializer_crash")], indirect=True)
     async def test____serve_forever____internal_error(
         self,
         mute_thrown_exception: bool,

--- a/tests/functional_test/test_serializers/test_base64.py
+++ b/tests/functional_test/test_serializers/test_base64.py
@@ -129,10 +129,10 @@ class BaseTestBase64EncoderSerializer(BaseTestIncrementalSerializer):
 
     @pytest.fixture(scope="class")
     @classmethod
-    def invalid_partial_data_extra_data(cls, invalid_partial_data: bytes) -> bytes:
-        if len(invalid_partial_data) > cls.BUFFER_LIMIT:
-            return b""
-        return b"remaining_data"
+    def invalid_partial_data_extra_data(cls, invalid_partial_data: bytes) -> tuple[bytes, bytes]:
+        if len(invalid_partial_data) > cls.BUFFER_LIMIT and not invalid_partial_data.endswith(b"\r\n"):
+            return (b"remaining_data", b"")
+        return (b"remaining_data", b"remaining_data")
 
     #### Other
 

--- a/tests/functional_test/test_serializers/test_cbor.py
+++ b/tests/functional_test/test_serializers/test_cbor.py
@@ -9,13 +9,13 @@ from easynetwork.serializers.cbor import CBOREncoderConfig, CBORSerializer
 
 import pytest
 
-from .base import BaseTestIncrementalSerializer
+from .base import BaseTestBufferedIncrementalSerializer
 from .samples.json import SAMPLES
 
 
 @final
 @pytest.mark.feature_cbor
-class TestCBORSerializer(BaseTestIncrementalSerializer):
+class TestCBORSerializer(BaseTestBufferedIncrementalSerializer):
     #### Serializers
 
     ENCODER_CONFIG = CBOREncoderConfig()

--- a/tests/functional_test/test_serializers/test_compressors.py
+++ b/tests/functional_test/test_serializers/test_compressors.py
@@ -66,8 +66,8 @@ class BaseTestCompressorSerializer(BaseTestBufferedIncrementalSerializer):
 
     @pytest.fixture(scope="class")
     @staticmethod
-    def invalid_partial_data_expected_extra_data() -> bytes:
-        return b""
+    def invalid_partial_data_extra_data() -> tuple[bytes, bytes]:
+        return (b"remaining_data", b"")
 
 
 @final

--- a/tests/functional_test/test_serializers/test_compressors.py
+++ b/tests/functional_test/test_serializers/test_compressors.py
@@ -9,7 +9,7 @@ from easynetwork.serializers.wrapper.compressor import BZ2CompressorSerializer, 
 
 import pytest
 
-from .base import BaseTestIncrementalSerializer, NoSerialization
+from .base import BaseTestBufferedIncrementalSerializer, NoSerialization
 
 SAMPLES = [
     (b"", "empty bytes"),
@@ -24,7 +24,7 @@ def _make_data_invalid(token: bytes) -> bytes:
     return token[:-2] + random.randbytes(5) + token[-2:]
 
 
-class BaseTestCompressorSerializer(BaseTestIncrementalSerializer):
+class BaseTestCompressorSerializer(BaseTestBufferedIncrementalSerializer):
     #### Serializers: To be defined in subclass
 
     #### Packets to test

--- a/tests/functional_test/test_serializers/test_encryptor.py
+++ b/tests/functional_test/test_serializers/test_encryptor.py
@@ -115,10 +115,10 @@ class TestEncryptorSerializer(BaseTestIncrementalSerializer):
 
     @pytest.fixture(scope="class")
     @classmethod
-    def invalid_partial_data_extra_data(cls, invalid_partial_data: bytes) -> bytes:
-        if len(invalid_partial_data) > cls.BUFFER_LIMIT:
-            return b""
-        return b"remaining_data"
+    def invalid_partial_data_extra_data(cls, invalid_partial_data: bytes) -> tuple[bytes, bytes]:
+        if len(invalid_partial_data) > cls.BUFFER_LIMIT and not invalid_partial_data.endswith(b"\r\n"):
+            return (b"remaining_data", b"")
+        return (b"remaining_data", b"remaining_data")
 
     #### Other
 

--- a/tests/functional_test/test_serializers/test_line.py
+++ b/tests/functional_test/test_serializers/test_line.py
@@ -111,10 +111,14 @@ class TestStringLineSerializer(BaseTestIncrementalSerializer):
 
     @pytest.fixture(scope="class")
     @classmethod
-    def invalid_partial_data_extra_data(cls, invalid_partial_data: bytes) -> bytes:
-        if len(invalid_partial_data) > cls.BUFFER_LIMIT:
-            return b""
-        return b"remaining_data"
+    def invalid_partial_data_extra_data(
+        cls,
+        invalid_partial_data: bytes,
+        newline: Literal["CR", "LF", "CRLF"],
+    ) -> tuple[bytes, bytes]:
+        if len(invalid_partial_data) > cls.BUFFER_LIMIT and not invalid_partial_data.endswith(_NEWLINES[newline]):
+            return (b"remaining_data", b"")
+        return (b"remaining_data", b"remaining_data")
 
     #### Other
 

--- a/tests/functional_test/test_serializers/test_namedtuple.py
+++ b/tests/functional_test/test_serializers/test_namedtuple.py
@@ -9,7 +9,7 @@ from easynetwork.serializers.struct import NamedTupleStructSerializer
 
 import pytest
 
-from .base import BaseTestIncrementalSerializer
+from .base import BaseTestBufferedIncrementalSerializer
 
 
 class Point(NamedTuple):
@@ -33,7 +33,7 @@ def pack_point(p: Point, *, encoding: str = "utf-8") -> bytes:
 
 
 @final
-class TestNamedTupleStructSerializer(BaseTestIncrementalSerializer):
+class TestNamedTupleStructSerializer(BaseTestBufferedIncrementalSerializer):
     #### Serializers
 
     @pytest.fixture(scope="class")

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -6,6 +6,7 @@ from ssl import SSLContext, SSLSocket
 from typing import TYPE_CHECKING, Any
 
 from easynetwork.converter import AbstractPacketConverterComposite
+from easynetwork.exceptions import UnsupportedOperation
 from easynetwork.protocol import BufferedStreamReceiver, DatagramProtocol, StreamProtocol
 from easynetwork.serializers.abc import (
     AbstractIncrementalPacketSerializer,
@@ -194,7 +195,7 @@ def mock_datagram_protocol(mock_datagram_protocol_factory: Callable[[], Any]) ->
 
 @pytest.fixture
 def mock_stream_protocol_factory(mocker: MockerFixture) -> Callable[[], Any]:
-    return lambda: mocker.NonCallableMagicMock(spec=StreamProtocol)
+    return lambda: mocker.NonCallableMagicMock(spec=StreamProtocol, **{"buffered_receiver.side_effect": UnsupportedOperation})
 
 
 @pytest.fixture

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -6,7 +6,7 @@ from ssl import SSLContext, SSLSocket
 from typing import TYPE_CHECKING, Any
 
 from easynetwork.converter import AbstractPacketConverterComposite
-from easynetwork.protocol import DatagramProtocol, StreamProtocol
+from easynetwork.protocol import BufferedStreamReceiver, DatagramProtocol, StreamProtocol
 from easynetwork.serializers.abc import (
     AbstractIncrementalPacketSerializer,
     AbstractPacketSerializer,
@@ -200,3 +200,18 @@ def mock_stream_protocol_factory(mocker: MockerFixture) -> Callable[[], Any]:
 @pytest.fixture
 def mock_stream_protocol(mock_stream_protocol_factory: Callable[[], Any]) -> Any:
     return mock_stream_protocol_factory()
+
+
+@pytest.fixture
+def mock_buffered_stream_receiver_factory(mocker: MockerFixture) -> Callable[[], Any]:
+    return lambda: mocker.NonCallableMagicMock(
+        spec=BufferedStreamReceiver,
+        **{
+            "create_buffer.side_effect": lambda sizehint: memoryview(bytearray(sizehint)),
+        },
+    )
+
+
+@pytest.fixture
+def mock_buffered_stream_receiver(mock_buffered_stream_receiver_factory: Callable[[], Any]) -> Any:
+    return mock_buffered_stream_receiver_factory()

--- a/tests/unit_test/test_async/test_api/test_client/test_tcp.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_tcp.py
@@ -347,9 +347,11 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
 
     @pytest.mark.parametrize("max_recv_size", [None, 1, 2**64], ids=lambda p: f"max_recv_size=={p}")
     @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("endpoint_connected", [False, True], ids=lambda p: f"endpoint_connected=={p}")
     async def test____dunder_init____max_recv_size____valid_value(
         self,
         request: pytest.FixtureRequest,
+        endpoint_connected: bool,
         max_recv_size: int | None,
         use_socket: bool,
         mock_stream_protocol: MagicMock,
@@ -371,6 +373,8 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
                 protocol=mock_stream_protocol,
                 max_recv_size=max_recv_size,
             )
+        if endpoint_connected:
+            await client.wait_connected()
 
         # Assert
         assert client.max_recv_size == expected_size

--- a/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
@@ -971,6 +971,28 @@ class TestRawStreamSocketAdapter(BaseTestSocket):
         assert data == b"data"
         mock_async_socket.recv.assert_awaited_once_with(123456789)
 
+    async def test____recv_into____returns_data_from_async_socket(
+        self,
+        socket: RawStreamSocketAdapter,
+        mock_async_socket: MagicMock,
+    ) -> None:
+        # Arrange
+        def recv_into_side_effect(buf: bytearray | memoryview) -> int:
+            with memoryview(buf) as buf:
+                buf[:4] = b"data"
+                return 4
+
+        mock_async_socket.recv_into.side_effect = recv_into_side_effect
+        buffer = bytearray(1024)
+
+        # Act
+        nbytes = await socket.recv_into(buffer)
+
+        # Assert
+        assert nbytes == 4
+        assert buffer[:nbytes] == b"data"
+        mock_async_socket.recv_into.assert_awaited_once_with(buffer)
+
     async def test____send_all____sends_data_to_async_socket(
         self,
         socket: RawStreamSocketAdapter,

--- a/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream.py
@@ -101,7 +101,6 @@ class TestAsyncStreamEndpoint:
         mock_buffered_stream_receiver.build_packet_from_buffer.side_effect = build_packet_from_buffer_side_effect
         return mock_buffered_stream_receiver
 
-    # @pytest.fixture(params=["data"])
     @pytest.fixture(params=["data", "buffer"])
     @staticmethod
     def stream_protocol_mode(request: pytest.FixtureRequest) -> str:
@@ -420,7 +419,7 @@ class TestAsyncStreamEndpoint:
         packet: Any = await endpoint.recv_packet()
 
         # Assert
-        assert mock_stream_transport.recv_into.await_count == 2
+        assert mock_stream_transport.recv_into.await_args_list == [mocker.call(mocker.ANY) for _ in range(2)]
         assert consumer_buffer_updated.call_args_list == [
             mocker.call(mocker.ANY, len(b"pac")),
             mocker.call(mocker.ANY, len(b"ket\n")),

--- a/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Generator
-from typing import TYPE_CHECKING, Any
+from collections.abc import Awaitable, Callable, Generator
+from typing import TYPE_CHECKING, Any, Literal
 
 from easynetwork.exceptions import IncrementalDeserializeError, StreamProtocolParseError, UnsupportedOperation
-from easynetwork.lowlevel._stream import StreamDataConsumer
+from easynetwork.lowlevel._stream import BufferedStreamDataConsumer, StreamDataConsumer
 from easynetwork.lowlevel.api_async.endpoints.stream import AsyncStreamEndpoint
 from easynetwork.lowlevel.api_async.transports.abc import (
+    AsyncBufferedStreamReadTransport,
     AsyncStreamReadTransport,
     AsyncStreamTransport,
     AsyncStreamWriteTransport,
@@ -21,6 +22,34 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
+def make_recv_into_side_effect(to_write: bytes | list[bytes]) -> Callable[[memoryview], Awaitable[int]]:
+    def write_in_buffer(buffer: memoryview, to_write: bytes) -> int:
+        nbytes = len(to_write)
+        buffer[:nbytes] = to_write
+        return nbytes
+
+    match to_write:
+        case bytes():
+
+            async def recv_into_side_effect(buffer: bytearray | memoryview) -> int:
+                return write_in_buffer(memoryview(buffer), to_write)
+
+        case list() if all(isinstance(b, bytes) for b in to_write):
+            iterator = iter(to_write)
+
+            async def recv_into_side_effect(buffer: bytearray | memoryview) -> int:
+                try:
+                    to_write = next(iterator)
+                except StopIteration:
+                    raise StopAsyncIteration from None
+                return write_in_buffer(memoryview(buffer), to_write)
+
+        case _:
+            pytest.fail("Invalid setup")
+
+    return recv_into_side_effect
+
+
 @pytest.mark.asyncio
 class TestAsyncStreamEndpoint:
     @pytest.fixture
@@ -28,7 +57,19 @@ class TestAsyncStreamEndpoint:
     def consumer_feed(mocker: MockerFixture) -> MagicMock:
         return mocker.patch.object(StreamDataConsumer, "feed", autospec=True, side_effect=StreamDataConsumer.feed)
 
-    @pytest.fixture(params=[AsyncStreamReadTransport, AsyncStreamWriteTransport, AsyncStreamTransport])
+    @pytest.fixture
+    @staticmethod
+    def consumer_buffer_updated(mocker: MockerFixture) -> MagicMock:
+        return mocker.patch.object(
+            BufferedStreamDataConsumer,
+            "buffer_updated",
+            autospec=True,
+            side_effect=BufferedStreamDataConsumer.buffer_updated,
+        )
+
+    @pytest.fixture(
+        params=[AsyncStreamReadTransport, AsyncBufferedStreamReadTransport, AsyncStreamWriteTransport, AsyncStreamTransport]
+    )
     @staticmethod
     def mock_stream_transport(request: pytest.FixtureRequest, mocker: MockerFixture) -> MagicMock:
         mock_stream_transport = mocker.NonCallableMagicMock(spec=request.param)
@@ -42,7 +83,39 @@ class TestAsyncStreamEndpoint:
 
     @pytest.fixture
     @staticmethod
-    def mock_stream_protocol(mock_stream_protocol: MagicMock, mocker: MockerFixture) -> MagicMock:
+    def mock_buffered_stream_receiver(
+        mock_buffered_stream_receiver: MagicMock,
+        mocker: MockerFixture,
+    ) -> MagicMock:
+        def build_packet_from_buffer_side_effect(buffer: memoryview) -> Generator[None, int, tuple[Any, bytes]]:
+            chunk: bytes = b""
+            while True:
+                nbytes = yield
+                chunk += buffer[:nbytes]
+                if b"\n" not in chunk:
+                    continue
+                del buffer
+                data, chunk = chunk.split(b"\n", 1)
+                return getattr(mocker.sentinel, data.decode(encoding="ascii")), chunk
+
+        mock_buffered_stream_receiver.build_packet_from_buffer.side_effect = build_packet_from_buffer_side_effect
+        return mock_buffered_stream_receiver
+
+    # @pytest.fixture(params=["data"])
+    @pytest.fixture(params=["data", "buffer"])
+    @staticmethod
+    def stream_protocol_mode(request: pytest.FixtureRequest) -> str:
+        assert request.param in ("data", "buffer")
+        return request.param
+
+    @pytest.fixture
+    @staticmethod
+    def mock_stream_protocol(
+        stream_protocol_mode: str,
+        mock_stream_protocol: MagicMock,
+        mock_buffered_stream_receiver: MagicMock,
+        mocker: MockerFixture,
+    ) -> MagicMock:
         def generate_chunks_side_effect(packet: Any) -> Generator[bytes, None, None]:
             yield str(packet).removeprefix("sentinel.").encode("ascii") + b"\n"
 
@@ -57,6 +130,16 @@ class TestAsyncStreamEndpoint:
 
         mock_stream_protocol.generate_chunks.side_effect = generate_chunks_side_effect
         mock_stream_protocol.build_packet_from_chunks.side_effect = build_packet_from_chunks_side_effect
+
+        match stream_protocol_mode:
+            case "data":
+                mock_stream_protocol.buffered_receiver.side_effect = UnsupportedOperation
+            case "buffer":
+                mock_stream_protocol.buffered_receiver.side_effect = None
+                mock_stream_protocol.buffered_receiver.return_value = mock_buffered_stream_receiver
+            case _:
+                pytest.fail("Invalid parameter")
+
         return mock_stream_protocol
 
     @pytest.fixture
@@ -99,7 +182,7 @@ class TestAsyncStreamEndpoint:
         with pytest.raises(TypeError, match=r"^Expected a StreamProtocol object, got .*$"):
             _ = AsyncStreamEndpoint(mock_stream_transport, mock_invalid_protocol, max_recv_size)
 
-    @pytest.mark.parametrize("max_recv_size", [1, 2**64], ids=lambda p: f"max_recv_size=={p}")
+    @pytest.mark.parametrize("max_recv_size", [1, 2**16], ids=lambda p: f"max_recv_size=={p}")
     async def test____dunder_init____max_recv_size____valid_value(
         self,
         mock_stream_transport: MagicMock,
@@ -112,7 +195,10 @@ class TestAsyncStreamEndpoint:
         endpoint: AsyncStreamEndpoint[Any, Any] = AsyncStreamEndpoint(mock_stream_transport, mock_stream_protocol, max_recv_size)
 
         # Assert
-        assert endpoint.max_recv_size == max_recv_size
+        if isinstance(mock_stream_transport, AsyncStreamReadTransport):
+            assert endpoint.max_recv_size == max_recv_size
+        else:
+            assert endpoint.max_recv_size == 0
 
     @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size=={p}")
     async def test____dunder_init____max_recv_size____invalid_value(
@@ -254,25 +340,42 @@ class TestAsyncStreamEndpoint:
         max_recv_size: int,
         mock_stream_transport: MagicMock,
         consumer_feed: MagicMock,
+        consumer_buffer_updated: MagicMock,
+        stream_protocol_mode: Literal["data", "buffer"],
         mocker: MockerFixture,
     ) -> None:
         # Arrange
         with contextlib.suppress(AttributeError):
             mock_stream_transport.recv.side_effect = [b"packet\n"]
+        with contextlib.suppress(AttributeError):
+            mock_stream_transport.recv_into.side_effect = make_recv_into_side_effect([b"packet\n"])
 
         # Act
         packet: Any = mocker.sentinel.packet_not_received
         with (
             pytest.raises(UnsupportedOperation, match=r"^transport does not support receiving data$")
-            if mock_stream_transport.__class__ not in (AsyncStreamReadTransport, AsyncStreamTransport)
+            if mock_stream_transport.__class__
+            not in (AsyncStreamReadTransport, AsyncBufferedStreamReadTransport, AsyncStreamTransport)
             else contextlib.nullcontext()
         ):
             packet = await endpoint.recv_packet()
 
         # Assert
-        if mock_stream_transport.__class__ in (AsyncStreamReadTransport, AsyncStreamTransport):
+        if mock_stream_transport.__class__ is AsyncBufferedStreamReadTransport:
+            if stream_protocol_mode == "buffer":
+                mock_stream_transport.recv_into.assert_awaited_once_with(mocker.ANY)
+                mock_stream_transport.recv.assert_not_called()
+                consumer_buffer_updated.assert_called_once_with(mocker.ANY, len(b"packet\n"))
+                consumer_feed.assert_not_called()
+            else:
+                mock_stream_transport.recv.assert_awaited_once_with(max_recv_size)
+                mock_stream_transport.recv_into.assert_not_called()
+                consumer_feed.assert_called_once_with(mocker.ANY, b"packet\n")
+                consumer_buffer_updated.assert_not_called()
+        elif mock_stream_transport.__class__ in (AsyncStreamReadTransport, AsyncStreamTransport):
             mock_stream_transport.recv.assert_awaited_once_with(max_recv_size)
             consumer_feed.assert_called_once_with(mocker.ANY, b"packet\n")
+            consumer_buffer_updated.assert_not_called()
             assert packet is mocker.sentinel.packet
         else:
             consumer_feed.assert_not_called()
@@ -301,6 +404,29 @@ class TestAsyncStreamEndpoint:
         ]
         assert packet is mocker.sentinel.packet
 
+    @pytest.mark.parametrize("mock_stream_transport", [AsyncBufferedStreamReadTransport], indirect=True)
+    @pytest.mark.parametrize("stream_protocol_mode", ["buffer"], indirect=True)
+    async def test____recv_packet____buffered____partial_data(
+        self,
+        endpoint: AsyncStreamEndpoint[Any, Any],
+        mock_stream_transport: MagicMock,
+        consumer_buffer_updated: MagicMock,
+        mocker: MockerFixture,
+    ) -> None:
+        # Arrange
+        mock_stream_transport.recv_into.side_effect = make_recv_into_side_effect([b"pac", b"ket\n"])
+
+        # Act
+        packet: Any = await endpoint.recv_packet()
+
+        # Assert
+        assert mock_stream_transport.recv_into.await_count == 2
+        assert consumer_buffer_updated.call_args_list == [
+            mocker.call(mocker.ANY, len(b"pac")),
+            mocker.call(mocker.ANY, len(b"ket\n")),
+        ]
+        assert packet is mocker.sentinel.packet
+
     @pytest.mark.parametrize("mock_stream_transport", [AsyncStreamReadTransport], indirect=True)
     async def test____recv_packet____extra_data(
         self,
@@ -322,6 +448,28 @@ class TestAsyncStreamEndpoint:
         assert packet_1 is mocker.sentinel.packet_1
         assert packet_2 is mocker.sentinel.packet_2
 
+    @pytest.mark.parametrize("mock_stream_transport", [AsyncBufferedStreamReadTransport], indirect=True)
+    @pytest.mark.parametrize("stream_protocol_mode", ["buffer"], indirect=True)
+    async def test____recv_packet____buffered____extra_data(
+        self,
+        endpoint: AsyncStreamEndpoint[Any, Any],
+        mock_stream_transport: MagicMock,
+        consumer_buffer_updated: MagicMock,
+        mocker: MockerFixture,
+    ) -> None:
+        # Arrange
+        mock_stream_transport.recv_into.side_effect = make_recv_into_side_effect([b"packet_1\npacket_2\n"])
+
+        # Act
+        packet_1: Any = await endpoint.recv_packet()
+        packet_2: Any = await endpoint.recv_packet()
+
+        # Assert
+        mock_stream_transport.recv_into.assert_awaited_once()
+        consumer_buffer_updated.assert_called_once_with(mocker.ANY, len(b"packet_1\npacket_2\n"))
+        assert packet_1 is mocker.sentinel.packet_1
+        assert packet_2 is mocker.sentinel.packet_2
+
     @pytest.mark.parametrize("mock_stream_transport", [AsyncStreamReadTransport], indirect=True)
     async def test____recv_packet____eof_error(
         self,
@@ -340,8 +488,27 @@ class TestAsyncStreamEndpoint:
         mock_stream_transport.recv.assert_awaited_once()
         consumer_feed.assert_not_called()
 
+    @pytest.mark.parametrize("mock_stream_transport", [AsyncBufferedStreamReadTransport], indirect=True)
+    @pytest.mark.parametrize("stream_protocol_mode", ["buffer"], indirect=True)
+    async def test____recv_packet____buffered____eof_error(
+        self,
+        endpoint: AsyncStreamEndpoint[Any, Any],
+        mock_stream_transport: MagicMock,
+        consumer_buffer_updated: MagicMock,
+    ) -> None:
+        # Arrange
+        mock_stream_transport.recv_into.side_effect = make_recv_into_side_effect([b""])
+
+        # Act
+        with pytest.raises(EOFError, match=r"^end-of-stream$"):
+            _ = await endpoint.recv_packet()
+
+        # Assert
+        mock_stream_transport.recv_into.assert_awaited_once()
+        consumer_buffer_updated.assert_not_called()
+
     @pytest.mark.parametrize("mock_stream_transport", [AsyncStreamReadTransport], indirect=True)
-    async def test____recv_packet____blocking_or_not____protocol_parse_error(
+    async def test____recv_packet____protocol_parse_error(
         self,
         endpoint: AsyncStreamEndpoint[Any, Any],
         mock_stream_transport: MagicMock,
@@ -364,9 +531,34 @@ class TestAsyncStreamEndpoint:
         # Assert
         assert exc_info.value is expected_error
 
+    @pytest.mark.parametrize("mock_stream_transport", [AsyncBufferedStreamReadTransport], indirect=True)
+    @pytest.mark.parametrize("stream_protocol_mode", ["buffer"], indirect=True)
+    async def test____recv_packet____buffered____protocol_parse_error(
+        self,
+        endpoint: AsyncStreamEndpoint[Any, Any],
+        mock_stream_transport: MagicMock,
+        mock_buffered_stream_receiver: MagicMock,
+    ) -> None:
+        # Arrange
+        mock_stream_transport.recv_into.side_effect = make_recv_into_side_effect([b"packet\n"])
+        expected_error = StreamProtocolParseError(b"", IncrementalDeserializeError("Error", b""))
+
+        def side_effect(buffer: memoryview) -> Generator[None, int, tuple[Any, bytes]]:
+            yield
+            raise expected_error
+
+        mock_buffered_stream_receiver.build_packet_from_buffer.side_effect = side_effect
+
+        # Act
+        with pytest.raises(StreamProtocolParseError) as exc_info:
+            _ = await endpoint.recv_packet()
+
+        # Assert
+        assert exc_info.value is expected_error
+
     @pytest.mark.parametrize("mock_stream_transport", [AsyncStreamReadTransport], indirect=True)
     @pytest.mark.parametrize("before_transport_reading", [False, True], ids=lambda p: f"before_transport_reading=={p}")
-    async def test____recv_packet____blocking_or_not____protocol_crashed(
+    async def test____recv_packet____protocol_crashed(
         self,
         before_transport_reading: bool,
         endpoint: AsyncStreamEndpoint[Any, Any],
@@ -393,6 +585,36 @@ class TestAsyncStreamEndpoint:
         # Assert
         assert exc_info.value.__cause__ is expected_error
 
+    @pytest.mark.parametrize("mock_stream_transport", [AsyncBufferedStreamReadTransport], indirect=True)
+    @pytest.mark.parametrize("stream_protocol_mode", ["buffer"], indirect=True)
+    @pytest.mark.parametrize("before_transport_reading", [False, True], ids=lambda p: f"before_transport_reading=={p}")
+    async def test____recv_packet____buffered____protocol_crashed(
+        self,
+        before_transport_reading: bool,
+        endpoint: AsyncStreamEndpoint[Any, Any],
+        mock_stream_transport: MagicMock,
+        mock_buffered_stream_receiver: MagicMock,
+    ) -> None:
+        # Arrange
+        mock_stream_transport.recv_into.side_effect = make_recv_into_side_effect([b"packet_1\n", b"packet_2\n"])
+        expected_error = Exception("Error")
+
+        if before_transport_reading:
+            await endpoint.recv_packet()
+
+        def side_effect(buffer: memoryview) -> Generator[None, int, tuple[Any, bytes]]:
+            yield
+            raise expected_error
+
+        mock_buffered_stream_receiver.build_packet_from_buffer.side_effect = side_effect
+
+        # Act
+        with pytest.raises(RuntimeError, match=r"^protocol\.build_packet_from_buffer\(\) crashed$") as exc_info:
+            _ = await endpoint.recv_packet()
+
+        # Assert
+        assert exc_info.value.__cause__ is expected_error
+
     @pytest.mark.parametrize("mock_stream_transport", [AsyncStreamReadTransport], indirect=True)
     async def test____special_case____recv_packet____eof_error____do_not_try_socket_recv_on_next_call(
         self,
@@ -412,3 +634,24 @@ class TestAsyncStreamEndpoint:
 
         # Assert
         mock_stream_transport.recv.assert_not_called()
+
+    @pytest.mark.parametrize("mock_stream_transport", [AsyncBufferedStreamReadTransport], indirect=True)
+    @pytest.mark.parametrize("stream_protocol_mode", ["buffer"], indirect=True)
+    async def test____special_case____recv_packet____buffered____eof_error____do_not_try_socket_recv_on_next_call(
+        self,
+        endpoint: AsyncStreamEndpoint[Any, Any],
+        mock_stream_transport: MagicMock,
+    ) -> None:
+        # Arrange
+        mock_stream_transport.recv_into.side_effect = make_recv_into_side_effect([b""])
+        with pytest.raises(EOFError, match=r"^end-of-stream$"):
+            _ = await endpoint.recv_packet()
+
+        mock_stream_transport.recv_into.reset_mock()
+
+        # Act
+        with pytest.raises(EOFError, match=r"^end-of-stream$"):
+            _ = await endpoint.recv_packet()
+
+        # Assert
+        mock_stream_transport.recv_into.assert_not_called()

--- a/tests/unit_test/test_async/test_lowlevel_api/test_servers/test_stream.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_servers/test_stream.py
@@ -167,21 +167,6 @@ class TestAsyncStreamServer:
         with pytest.raises(TypeError, match=r"^Expected a StreamProtocol object, got .*$"):
             _ = AsyncStreamServer(mock_listener, mock_invalid_protocol, max_recv_size)
 
-    @pytest.mark.parametrize("max_recv_size", [1, 2**64], ids=lambda p: f"max_recv_size=={p}")
-    async def test____dunder_init____max_recv_size____valid_value(
-        self,
-        mock_listener: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-    ) -> None:
-        # Arrange
-
-        # Act
-        server: AsyncStreamServer[Any, Any] = AsyncStreamServer(mock_listener, mock_stream_protocol, max_recv_size)
-
-        # Assert
-        assert server.max_recv_size == max_recv_size
-
     @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size=={p}")
     async def test____dunder_init____max_recv_size____invalid_value(
         self,

--- a/tests/unit_test/test_protocol.py
+++ b/tests/unit_test/test_protocol.py
@@ -16,6 +16,8 @@ from easynetwork.serializers.abc import AbstractIncrementalPacketSerializer, Buf
 
 import pytest
 
+from ..tools import send_return
+
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
@@ -353,9 +355,7 @@ class TestStreamProtocol:
         # Act
         gen = protocol_without_converter.build_packet_from_chunks()
         next(gen)
-        with pytest.raises(StopIteration) as exc_info:
-            gen.send(mocker.sentinel.chunk)
-        packet, remaining_data = exc_info.value.value
+        packet, remaining_data = send_return(gen, mocker.sentinel.chunk)
 
         # Assert
         mock_incremental_deserialize_func.assert_called_once_with()
@@ -378,9 +378,7 @@ class TestStreamProtocol:
         # Act
         gen = protocol_with_converter.build_packet_from_chunks()
         next(gen)
-        with pytest.raises(StopIteration) as exc_info:
-            gen.send(mocker.sentinel.chunk)
-        packet, remaining_data = exc_info.value.value
+        packet, remaining_data = send_return(gen, mocker.sentinel.chunk)
 
         # Assert
         mock_incremental_deserialize_func.assert_called_once_with()
@@ -593,9 +591,7 @@ class TestBufferedStreamReceiver:
         assert next(gen) == 0
         nbytes = 34
         buffer[:nbytes] = b"a" * nbytes
-        with pytest.raises(StopIteration) as exc_info:
-            gen.send(nbytes)
-        packet, remaining_data = exc_info.value.value
+        packet, remaining_data = send_return(gen, nbytes)
 
         # Assert
         mock_incremental_deserialize_func.assert_called_once_with(buffer)
@@ -621,9 +617,7 @@ class TestBufferedStreamReceiver:
         assert next(gen) == 0
         nbytes = 34
         buffer[:nbytes] = b"a" * nbytes
-        with pytest.raises(StopIteration) as exc_info:
-            gen.send(nbytes)
-        packet, remaining_data = exc_info.value.value
+        packet, remaining_data = send_return(gen, nbytes)
 
         # Assert
         mock_incremental_deserialize_func.assert_called_once_with(buffer)

--- a/tests/unit_test/test_protocol.py
+++ b/tests/unit_test/test_protocol.py
@@ -650,8 +650,8 @@ class TestBufferedStreamReceiver:
         # Assert
         mock_convert_func.assert_not_called()
         assert isinstance(exception.error, IncrementalDeserializeError)
-        assert exception.remaining_data == b"a" * nbytes
-        assert exception.error.remaining_data == b"a" * nbytes
+        assert bytes(exception.remaining_data) == b"a" * nbytes
+        assert bytes(exception.error.remaining_data) == b"a" * nbytes
         assert isinstance(exception.__cause__, IncrementalDeserializeError)
 
     def test____build_packet_from_buffer____wrong_deserialize_error(
@@ -709,5 +709,5 @@ class TestBufferedStreamReceiver:
         # Assert
         mock_convert_func.assert_called_once()
         assert isinstance(exception.error, PacketConversionError)
-        assert exception.remaining_data == b"a" * nbytes
+        assert bytes(exception.remaining_data) == b"a" * nbytes
         assert exception.__cause__ is mock_convert_func.side_effect

--- a/tests/unit_test/test_serializers/test_compressor.py
+++ b/tests/unit_test/test_serializers/test_compressor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from easynetwork.exceptions import DeserializeError, IncrementalDeserializeError
 from easynetwork.serializers.wrapper.compressor import (
@@ -12,9 +12,12 @@ from easynetwork.serializers.wrapper.compressor import (
 
 import pytest
 
+from ...tools import send_return, write_in_buffer
+
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
+    from _typeshed import ReadableBuffer
     from pytest_mock import MockerFixture
 
 
@@ -72,6 +75,12 @@ class TestAbstractCompressorSerializer:
         yield mock
         del type(mock).eof
         del type(mock).unused_data
+
+    @pytest.fixture(params=["data", "buffer"])
+    @staticmethod
+    def incremental_deserialize_mode(request: pytest.FixtureRequest) -> str:
+        assert request.param in ("data", "buffer")
+        return request.param
 
     def test____properties____right_values(self, mock_serializer: MagicMock, debug_mode: bool) -> None:
         # Arrange
@@ -283,6 +292,7 @@ class TestAbstractCompressorSerializer:
 
     def test____incremental_deserialize____decompress_chunks(
         self,
+        incremental_deserialize_mode: Literal["data", "buffer"],
         mock_serializer: MagicMock,
         mock_serializer_new_decompressor_stream: MagicMock,
         mock_decompressor_stream: MagicMock,
@@ -291,33 +301,50 @@ class TestAbstractCompressorSerializer:
         mocker: MockerFixture,
     ) -> None:
         # Arrange
+        given_chunks: list[bytes] = []
+
+        def decompress_side_effect(b: ReadableBuffer) -> bytes:
+            given_chunks.append(bytes(b))
+            return b"decompressed " + b
+
         serializer = _CompressorSerializerForTest(mock_serializer, ())
         mock_decompressor_stream_eof.side_effect = [False, False, True]
-        mock_decompressor_stream_unused_data.return_value = mocker.sentinel.unused_data
-        mock_decompressor_stream.decompress.side_effect = [b"decompressed chunk 1 ", b"decompressed chunk 2"]
+        mock_decompressor_stream_unused_data.return_value = b"some extra data"
+        mock_decompressor_stream.decompress.side_effect = decompress_side_effect
         mock_serializer.deserialize.return_value = mocker.sentinel.packet
 
         # Act
-        consumer = serializer.incremental_deserialize()
-        next(consumer)
-        consumer.send(b"chunk 1")
-        with pytest.raises(StopIteration) as exc_info:
-            consumer.send(b"chunk 2")
-        packet, remaining_data = exc_info.value.value
+        remaining_data: ReadableBuffer
+        match incremental_deserialize_mode:
+            case "data":
+                data_consumer = serializer.incremental_deserialize()
+                next(data_consumer)
+                data_consumer.send(b"chunk 1")
+                packet, remaining_data = send_return(data_consumer, b"chunk 2")
+            case "buffer":
+                buffer = serializer.create_deserializer_buffer(1024)
+                buffered_consumer = serializer.buffered_incremental_deserialize(buffer)
+                next(buffered_consumer)
+                buffered_consumer.send(write_in_buffer(buffer, b"chunk 1"))
+                packet, remaining_data = send_return(buffered_consumer, write_in_buffer(buffer, b"chunk 2"))
+            case _:
+                pytest.fail("Invalid fixture argument")
 
         # Assert
         mock_serializer_new_decompressor_stream.assert_called_once_with()
-        assert mock_decompressor_stream.decompress.call_args_list == [mocker.call(b"chunk 1"), mocker.call(b"chunk 2")]
+        assert mock_decompressor_stream.decompress.call_count == 2
+        assert given_chunks == [b"chunk 1", b"chunk 2"]
         assert len(mock_decompressor_stream_eof.call_args_list) == 3
         mock_decompressor_stream_unused_data.assert_called_once()
-        mock_serializer.deserialize.assert_called_once_with(b"decompressed chunk 1 decompressed chunk 2")
+        mock_serializer.deserialize.assert_called_once_with(b"decompressed chunk 1decompressed chunk 2")
         assert packet is mocker.sentinel.packet
-        assert remaining_data is mocker.sentinel.unused_data
+        assert remaining_data == b"some extra data"
 
     @pytest.mark.parametrize("give_as_tuple", [False, True], ids=lambda boolean: f"give_as_tuple=={boolean}")
     def test____incremental_deserialize____translate_given_exceptions(
         self,
         give_as_tuple: bool,
+        incremental_deserialize_mode: Literal["data", "buffer"],
         mock_serializer: MagicMock,
         mock_serializer_new_decompressor_stream: MagicMock,
         mock_decompressor_stream: MagicMock,
@@ -350,10 +377,21 @@ class TestAbstractCompressorSerializer:
         mock_decompressor_stream.decompress.side_effect = MyStreamAPIValueError()
 
         # Act
-        consumer = serializer.incremental_deserialize()
-        next(consumer)
-        with pytest.raises(IncrementalDeserializeError) as exc_info:
-            consumer.send(b"chunk")
+        match incremental_deserialize_mode:
+            case "data":
+                data_consumer = serializer.incremental_deserialize()
+                next(data_consumer)
+                with pytest.raises(IncrementalDeserializeError) as exc_info:
+                    data_consumer.send(b"chunk")
+            case "buffer":
+                buffer = serializer.create_deserializer_buffer(1024)
+                buffered_consumer = serializer.buffered_incremental_deserialize(buffer)
+                next(buffered_consumer)
+                with pytest.raises(IncrementalDeserializeError) as exc_info:
+                    buffered_consumer.send(write_in_buffer(buffer, b"chunk"))
+            case _:
+                pytest.fail("Invalid fixture argument")
+
         exception = exc_info.value
 
         # Assert
@@ -374,6 +412,7 @@ class TestAbstractCompressorSerializer:
 
     def test____incremental_deserialize____translate_deserialize_errors(
         self,
+        incremental_deserialize_mode: Literal["data", "buffer"],
         mock_serializer: MagicMock,
         mock_serializer_new_decompressor_stream: MagicMock,
         mock_decompressor_stream: MagicMock,
@@ -390,10 +429,20 @@ class TestAbstractCompressorSerializer:
         mock_serializer.deserialize.side_effect = DeserializeError("Bad news", error_info=mocker.sentinel.error_info)
 
         # Act
-        consumer = serializer.incremental_deserialize()
-        next(consumer)
-        with pytest.raises(IncrementalDeserializeError) as exc_info:
-            consumer.send(b"chunk")
+        match incremental_deserialize_mode:
+            case "data":
+                data_consumer = serializer.incremental_deserialize()
+                next(data_consumer)
+                with pytest.raises(IncrementalDeserializeError) as exc_info:
+                    data_consumer.send(b"chunk")
+            case "buffer":
+                buffer = serializer.create_deserializer_buffer(1024)
+                buffered_consumer = serializer.buffered_incremental_deserialize(buffer)
+                next(buffered_consumer)
+                with pytest.raises(IncrementalDeserializeError) as exc_info:
+                    buffered_consumer.send(write_in_buffer(buffer, b"chunk"))
+            case _:
+                pytest.fail("Invalid fixture argument")
         exception = exc_info.value
 
         # Assert

--- a/tests/unit_test/test_serializers/test_compressor.py
+++ b/tests/unit_test/test_serializers/test_compressor.py
@@ -401,7 +401,7 @@ class TestAbstractCompressorSerializer:
         mock_decompressor_stream_unused_data.assert_not_called()
         mock_serializer.deserialize.assert_not_called()
         assert exception.__cause__ is mock_decompressor_stream.decompress.side_effect
-        assert exception.remaining_data == b""
+        assert bytes(exception.remaining_data) == b""
         if debug_mode:
             assert exception.error_info == {
                 "already_decompressed_chunks": deque([]),

--- a/tests/unit_test/test_serializers/test_json.py
+++ b/tests/unit_test/test_serializers/test_json.py
@@ -630,9 +630,9 @@ class TestJSONParser:
     @pytest.mark.parametrize(
         ["start_frame", "end_frame"],
         [
-            pytest.param(b'{"data":', b'"something"}', id="object frame"),
-            pytest.param(b'["data",', b'"something"]', id="list frame"),
-            pytest.param(b'"data', b' something"', id="string frame"),
+            pytest.param(b'{"data":', b'"something"}\n', id="object frame"),
+            pytest.param(b'["data",', b'"something"]\n', id="list frame"),
+            pytest.param(b'"data', b' something"\n', id="string frame"),
             pytest.param(b"123", b"45\n", id="plain value"),
         ],
     )
@@ -652,6 +652,7 @@ class TestJSONParser:
         # Assert
         if end_frame_found:
             assert str(exc_info.value) == "JSON object's end frame is found, but chunk is longer than limit"
+            assert bytes(exc_info.value.remaining_data) == b"\n"
         else:
             assert str(exc_info.value) == "JSON object's end frame is not found, and chunk exceed the limit"
-        assert exc_info.value.remaining_data == b""
+            assert bytes(exc_info.value.remaining_data) == b""

--- a/tests/unit_test/test_serializers/test_tools.py
+++ b/tests/unit_test/test_serializers/test_tools.py
@@ -245,9 +245,10 @@ class TestGeneratorStreamReader:
         # Assert
         if separator_found:
             assert str(exc_info.value) == "Separator is found, but chunk is longer than limit"
+            assert bytes(exc_info.value.remaining_data) == b""
         else:
             assert str(exc_info.value) == "Separator is not found, and chunk exceed the limit"
-        assert exc_info.value.remaining_data == b""
+            assert bytes(exc_info.value.remaining_data) == b"\r"
 
     def test____read_until____empty_separator(self) -> None:
         # Arrange

--- a/tests/unit_test/test_serializers/test_tools.py
+++ b/tests/unit_test/test_serializers/test_tools.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from easynetwork.exceptions import LimitOverrunError
 from easynetwork.serializers.tools import GeneratorStreamReader
 
@@ -9,20 +7,18 @@ import pytest
 
 from ...tools import next_return, send_return
 
-if TYPE_CHECKING:
-    from pytest_mock import MockerFixture
-
 
 class TestGeneratorStreamReader:
-    def test____read_all____pop_buffer_without_copying(self, mocker: MockerFixture) -> None:
+    def test____read_all____pop_buffer_without_copying(self) -> None:
         # Arrange
-        reader = GeneratorStreamReader(mocker.sentinel.initial_buffer)
+        initial_buffer = b"initial_buffer"
+        reader = GeneratorStreamReader(initial_buffer)
 
         # Act
         data = reader.read_all()
 
         # Assert
-        assert data is mocker.sentinel.initial_buffer
+        assert data is initial_buffer
         assert reader.read_all() == b""
 
     def test____read____yield_if_buffer_is_empty(self) -> None:

--- a/tests/unit_test/test_tools/test_stream.py
+++ b/tests/unit_test/test_tools/test_stream.py
@@ -648,6 +648,23 @@ class TestBufferedStreamDataConsumer:
         # Act & Assert
         assert consumer.get_write_buffer() is consumer.get_write_buffer()
 
+    def test____get_write_buffer____buffer_start_set_to_end(
+        self,
+        consumer: BufferedStreamDataConsumer[Any],
+        mock_buffered_stream_receiver: MagicMock,
+    ) -> None:
+        # Arrange
+        def side_effect(buffer: memoryview) -> Generator[int, int, tuple[Any, bytes]]:
+            yield len(buffer)
+            pytest.fail("Should not arrive here")
+
+        mock_build_packet_from_buffer_func: MagicMock = mock_buffered_stream_receiver.build_packet_from_buffer
+        mock_build_packet_from_buffer_func.side_effect = side_effect
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match=r"^The start position is set to the end of the buffer$"):
+            consumer.get_write_buffer()
+
     def test____buffer_updated____error_negative_nbytes(
         self,
         consumer: BufferedStreamDataConsumer[Any],

--- a/tests/unit_test/test_tools/test_stream.py
+++ b/tests/unit_test/test_tools/test_stream.py
@@ -601,6 +601,7 @@ class TestBufferedStreamDataConsumer:
             _ = consumer.get_write_buffer()
 
         mock_buffered_stream_receiver.build_packet_from_buffer.assert_not_called()
+        assert consumer.get_value() is None
 
     def test____get_write_buffer____protocol_create_buffer_validation____not_a_byte_buffer(
         self,
@@ -617,6 +618,7 @@ class TestBufferedStreamDataConsumer:
             _ = consumer.get_write_buffer()
 
         mock_buffered_stream_receiver.build_packet_from_buffer.assert_not_called()
+        assert consumer.get_value() is None
 
     def test____get_write_buffer____protocol_create_buffer_validation____empty_byte_buffer(
         self,
@@ -631,6 +633,7 @@ class TestBufferedStreamDataConsumer:
             _ = consumer.get_write_buffer()
 
         mock_buffered_stream_receiver.build_packet_from_buffer.assert_not_called()
+        assert consumer.get_value() is None
 
     def test____get_write_buffer____do_not_recompute_buffer_view(
         self,
@@ -1093,7 +1096,7 @@ class TestBufferedStreamDataConsumer:
             with pytest.raises(RuntimeError, match=r"^protocol\.build_packet_from_buffer\(\) crashed$") as exc_info:
                 self.write_in_consumer(consumer, b"Hello")
 
-            assert consumer.get_value() == b""
+            assert consumer.get_value() is None
 
             with pytest.raises(StopIteration):
                 next(consumer)
@@ -1104,7 +1107,7 @@ class TestBufferedStreamDataConsumer:
             with pytest.raises(RuntimeError, match=r"^protocol\.build_packet_from_buffer\(\) crashed$") as exc_info:
                 next(consumer)
 
-            assert consumer.get_value() == b""
+            assert consumer.get_value() is None
 
         # Assert
         assert exc_info.value.__cause__ is expected_error

--- a/tests/unit_test/test_tools/test_stream.py
+++ b/tests/unit_test/test_tools/test_stream.py
@@ -537,6 +537,7 @@ class TestBufferedStreamDataConsumer:
     @pytest.fixture
     @staticmethod
     def mock_stream_protocol(mock_stream_protocol: MagicMock, mock_buffered_stream_receiver: MagicMock) -> MagicMock:
+        mock_stream_protocol.buffered_receiver.side_effect = None
         mock_stream_protocol.buffered_receiver.return_value = mock_buffered_stream_receiver
         return mock_stream_protocol
 

--- a/tests/unit_test/test_tools/test_stream.py
+++ b/tests/unit_test/test_tools/test_stream.py
@@ -441,7 +441,7 @@ class TestStreamDataConsumer:
         # Assert
         mock_build_packet_from_chunks_func.assert_called_once_with()
         assert consumer.get_buffer() == b"World"
-        assert exception.remaining_data == b"World"
+        assert bytes(exception.remaining_data) == b"World"
 
     def test____next____generator_did_not_yield(
         self,
@@ -1046,7 +1046,7 @@ class TestBufferedStreamDataConsumer:
 
         # Assert
         assert consumer.get_value() == b"world"
-        assert exception.remaining_data == b"world"
+        assert bytes(exception.remaining_data) == b"world"
 
     def test____next____generator_did_not_yield(
         self,


### PR DESCRIPTION
### What's changed
- Added `BufferedIncrementalPacketSerializer` base class
  - `FixedSizePacketSerializer` now derives from `BufferedIncrementalPacketSerializer`
  - `FileBasedSizePacketSerializer` now derives from `BufferedIncrementalPacketSerializer`
  - `AbstractCompressorSerializer` now derives from `BufferedIncrementalPacketSerializer`
- Added `BufferedStreamReceiver` in `easynetwork.protocol`
  - Added new method `StreamProtocol.buffered_receiver()`
- New buffer API in `easynetwork.lowlevel`
  - Added `BufferedStreamReadTransport` base class
    - Added `SelectorBufferedStreamReadTransport` deriving from `BufferedStreamReadTransport`
    - `SocketStreamTransport` derives from `SelectorBufferedStreamReadTransport` in addition to `SelectorStreamTransport`
    - `SSLStreamTransport` derives from `SelectorBufferedStreamReadTransport` in addition to `SelectorStreamTransport`
  - Added `AsyncBufferedStreamReadTransport` base class
    - `easynetwork.lowlevel.asyncio.RawStreamSocketAdapter` derives from `AsyncBufferedStreamReadTransport` in addition to `AsyncStreamTransport`
  - Added support of buffered read in `StreamEndpoint` and `AsyncStreamEndpoint`
  - Added support of buffered read in `AsyncStreamServer`
- `IncrementalDeserializeError.remaining_data` and `StreamProtocolParseError.remaining_data` can now be any byte buffer (e.g. `memoryview`).