### PR TITLE
Updated release workflow

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,6 +5,7 @@ serialize =
 	{major}.{minor}.{patch}{release}{serial}
 	{major}.{minor}.{patch}
 message = Bump version: {current_version} -> {new_version}
+tag_name = {new_version}
 
 [bumpversion:part:release]
 first_value = rc

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -23,4 +23,4 @@ changelog:
         - '*'
       exclude:
         labels:
-          - development
+          - development-process

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -3,7 +3,7 @@ name: Prepare a draft release for a new version
 on:
   push:
     tags:
-      - v*.*.*
+      - "[0-9]+.[0-9]+.*"
 
 jobs:
   draft-release:
@@ -16,6 +16,6 @@ jobs:
       - name: Create Github Release
         uses: softprops/action-gh-release@v0.1.15
         with:
-          name: easynetwork ${{ github.ref_name }}
+          name: easynetwork v${{ github.ref_name }}
           draft: true
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The easiest way to use sockets in Python!
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/easynetwork)
 
 [![Test](https://github.com/francis-clairicia/EasyNetwork/actions/workflows/test.yml/badge.svg)](https://github.com/francis-clairicia/EasyNetwork/actions/workflows/test.yml)
+[![Documentation Status](https://readthedocs.org/projects/easynetwork/badge/?version=latest)](https://easynetwork.readthedocs.io/en/latest/?badge=latest)
 [![Codecov](https://img.shields.io/codecov/c/github/francis-clairicia/EasyNetwork)](https://codecov.io/gh/francis-clairicia/EasyNetwork)
 [![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/francis-clairicia/EasyNetwork)](https://www.codefactor.io/repository/github/francis-clairicia/easynetwork)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,6 +27,7 @@ extensions = [
     # Built-in
     "sphinx.ext.autodoc",
     "sphinx.ext.duration",
+    "sphinx.ext.ifconfig",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
@@ -51,7 +52,15 @@ highlight_language = "python3"
 manpages_url = "https://manpages.debian.org/{path}"
 
 templates_path = []
-exclude_patterns = ["_include", "_extensions"]
+exclude_patterns = ["_include", "_extensions", "_static"]
+
+rst_prolog = """
+.. ifconfig:: '.dev' in release or html_context.get('current_version') == 'latest'
+
+   .. warning::
+
+      This is the documentation for the latest unstable version.
+"""
 
 
 # -- sphinx.ext.autodoc configuration ----------------------------------------
@@ -149,8 +158,3 @@ html_css_files = [
 html_theme_options = {
     "navigation_depth": -1,  # Unlimited
 }
-
-# -- Options for the linkcheck builder ---------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
-
-linkcheck_timeout = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,9 @@ packages = ["src/easynetwork"]
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.version.raw-options]  # setuptools_scm options
+local_scheme =  "no-local-version"
+
 [tool.hatch.build.hooks.vcs]
 version-file = "src/easynetwork/version.py"
 template = '''


### PR DESCRIPTION
### Builds
- Removed local scheme `+g{commit}.d{date}`
- Removed `v` prefix to tags
  - Next tag will `1.0.0rc7`
- Added previously removed documentation build status

### CI
- Renamed `development` label to `development-process`

### Documentation
- Added prolog for documentation of unstable builds