### PR TITLE
Added 'family' parameter to UDP clients

### DIFF
--- a/src/easynetwork/api_async/client/udp.py
+++ b/src/easynetwork/api_async/client/udp.py
@@ -76,6 +76,7 @@ class AsyncUDPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
         protocol: DatagramProtocol[_SentPacketT, _ReceivedPacketT],
         *,
         local_address: tuple[str, int] | None = ...,
+        family: int = ...,
         backend: str | AsyncBackend | None = ...,
         backend_kwargs: Mapping[str, Any] | None = ...,
     ) -> None:
@@ -147,6 +148,8 @@ class AsyncUDPNetworkClient(AbstractAsyncNetworkClient[_SentPacketT, _ReceivedPa
             case (str(host), int(port)):
                 if kwargs.get("local_address") is None:
                     kwargs["local_address"] = ("localhost", 0)
+                if (family := kwargs.get("family", _socket.AF_UNSPEC)) != _socket.AF_UNSPEC:
+                    _utils.check_socket_family(family)
                 socket_factory = _utils.make_callback(backend.create_udp_endpoint, host, port, **kwargs)
             case _:  # pragma: no cover
                 raise TypeError("Invalid arguments")

--- a/src/easynetwork/lowlevel/api_async/backend/abc.py
+++ b/src/easynetwork/lowlevel/api_async/backend/abc.py
@@ -1046,6 +1046,7 @@ class AsyncBackend(metaclass=ABCMeta):
         remote_port: int,
         *,
         local_address: tuple[str, int] | None = ...,
+        family: int = ...,
     ) -> transports.AsyncDatagramTransport:
         """
         Opens an endpoint using the UDP protocol.

--- a/src/easynetwork/lowlevel/asyncio/backend.py
+++ b/src/easynetwork/lowlevel/asyncio/backend.py
@@ -42,7 +42,12 @@ else:
 from ...exceptions import UnsupportedOperation
 from ..api_async.backend.abc import AsyncBackend as AbstractAsyncBackend
 from ..api_async.backend.sniffio import current_async_library_cvar as _sniffio_current_async_library_cvar
-from ._asyncio_utils import create_connection, open_listener_sockets_from_getaddrinfo_result, resolve_local_addresses
+from ._asyncio_utils import (
+    create_connection,
+    create_datagram_connection,
+    open_listener_sockets_from_getaddrinfo_result,
+    resolve_local_addresses,
+)
 from .datagram.endpoint import create_datagram_endpoint
 from .datagram.listener import AsyncioTransportDatagramListenerSocketAdapter, RawDatagramListenerSocketAdapter
 from .datagram.socket import AsyncioTransportDatagramSocketAdapter, RawDatagramSocketAdapter
@@ -309,14 +314,15 @@ class AsyncIOBackend(AbstractAsyncBackend):
         remote_port: int,
         *,
         local_address: tuple[str, int] | None = None,
+        family: int = _socket.AF_UNSPEC,
     ) -> AsyncioTransportDatagramSocketAdapter | RawDatagramSocketAdapter:
         loop = asyncio.get_running_loop()
-        socket = await create_connection(
+        socket = await create_datagram_connection(
             remote_host,
             remote_port,
             loop,
             local_address=local_address,
-            socktype=_socket.SOCK_DGRAM,
+            family=family,
         )
         return await self.wrap_connected_datagram_socket(socket)
 

--- a/tests/unit_test/_utils.py
+++ b/tests/unit_test/_utils.py
@@ -96,7 +96,11 @@ def get_all_socket_families() -> frozenset[str]:
 def _get_all_socket_families() -> frozenset[str]:
     import socket
 
-    return frozenset(v for v in dir(socket) if v.startswith("AF_"))
+    to_exclude = {
+        "AF_UNSPEC",
+    }
+
+    return frozenset(v for v in dir(socket) if v.startswith("AF_") and v not in to_exclude)
 
 
 def __addrinfo_list(


### PR DESCRIPTION
### What's changed
- Added `family` parameter to `AsyncUDPNetworkClient` and `UDPNetworkClient` constructors
- Added `family` parameter to `AsyncBackend.create_udp_endpoint()`