### PR TITLE
TCP servers: the main loop is stopped after stop_listening() call

### DIFF
--- a/src/easynetwork/api_async/server/tcp.py
+++ b/src/easynetwork/api_async/server/tcp.py
@@ -69,6 +69,7 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         "__max_recv_size",
         "__servers_tasks",
         "__mainloop_task",
+        "__active_tasks",
         "__client_connection_log_level",
         "__logger",
     )
@@ -197,6 +198,7 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             self.__client_connection_log_level = logging.INFO
         else:
             self.__client_connection_log_level = logging.DEBUG
+        self.__active_tasks: int = 0
 
     @_utils.inherit_doc(AbstractAsyncNetworkServer)
     def is_serving(self) -> bool:
@@ -302,6 +304,7 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             ############################
 
             # Setup task group
+            self.__active_tasks = 0
             server_exit_stack.callback(self.__servers_tasks.clear)
             task_group = await server_exit_stack.enter_async_context(self.__backend.create_task_group())
             server_exit_stack.callback(self.__logger.info, "Server loop break, waiting for remaining tasks...")
@@ -333,8 +336,12 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
         server: lowlevel_stream_server.AsyncStreamServer[_RequestT, _ResponseT],
         task_group: TaskGroup,
     ) -> NoReturn:
-        async with contextlib.aclosing(server):
-            await server.serve(self.__client_coroutine, task_group)
+        self.__attach_server()
+        try:
+            async with contextlib.aclosing(server):
+                await server.serve(self.__client_coroutine, task_group)
+        finally:
+            self.__detach_server()
 
     async def __client_coroutine(
         self,
@@ -350,6 +357,9 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
 
         client_address = new_socket_address(client_address, lowlevel_client.extra(INETSocketAttribute.family))
         async with contextlib.AsyncExitStack() as client_exit_stack:
+            self.__attach_server()
+            client_exit_stack.callback(self.__detach_server)
+
             client_exit_stack.enter_context(self.__suppress_and_log_remaining_exception(client_address=client_address))
             # If the socket was not closed gracefully, (i.e. client.aclose() failed )
             # tell the OS to immediately abort the connection when calling socket.socket.close()
@@ -415,6 +425,17 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_RequestT, _Resp
             finally:
                 if request_handler_generator is not None:
                     await request_handler_generator.aclose()
+
+    def __attach_server(self) -> None:
+        self.__active_tasks += 1
+
+    def __detach_server(self) -> None:
+        self.__active_tasks -= 1
+        if self.__active_tasks < 0:
+            raise AssertionError("self.__active_tasks < 0")
+        if not self.__active_tasks:
+            if self.__mainloop_task is not None:
+                self.__mainloop_task.cancel()
 
     @staticmethod
     def __set_socket_linger_if_not_closed(socket: ISocket) -> None:
@@ -534,7 +555,8 @@ class _ConnectedClientAPI(AsyncStreamClient[_ResponseT]):
     @property
     def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         client = self.__client
-        return dict(client.extra_attributes) | {
+        return {
+            **client.extra_attributes,
             INETClientAttribute.socket: lambda: self.__proxy,
             INETClientAttribute.local_address: lambda: new_socket_address(
                 client.extra(INETSocketAttribute.sockname),

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -799,6 +799,7 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
     async def test____serve_forever____request_handler_ask_to_stop_accepting_new_connections(
         self,
         client_factory: Callable[[], Awaitable[tuple[asyncio.StreamReader, asyncio.StreamWriter]]],
+        server_task: asyncio.Task[None],
         server: MyAsyncTCPServer,
     ) -> None:
         reader, writer = await client_factory()
@@ -817,6 +818,11 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
         errors, exc = exc_info.value.split(ConnectionError)
         assert exc is None
         assert errors is not None
+
+        writer.close()
+        await writer.wait_closed()
+        async with asyncio.timeout(5):
+            await asyncio.wait({server_task})
 
     async def test____serve_forever____close_client_on_connection_hook(
         self,


### PR DESCRIPTION
### What's changed
When `stop_listening()` is called, the server loop is stopped when the last client is disconnected.