### PR TITLE
Packet send exceptions are now converted to RuntimeErrors

### DIFF
--- a/src/easynetwork/api_async/server/udp.py
+++ b/src/easynetwork/api_async/server/udp.py
@@ -409,7 +409,8 @@ class _ClientAPI(AsyncDatagramClient[_ResponseT]):
             return {}
         server = server_ref
         del server_ref
-        return dict(server.extra_attributes) | {
+        return {
+            **server.extra_attributes,
             INETClientAttribute.socket: lambda: self.__socket_proxy,
             INETClientAttribute.local_address: lambda: new_socket_address(
                 server.extra(INETSocketAttribute.sockname),

--- a/src/easynetwork/lowlevel/_stream.py
+++ b/src/easynetwork/lowlevel/_stream.py
@@ -75,6 +75,8 @@ class StreamDataProducer(Generic[_SentPacketT]):
                 chunk = next(filter(None, map(bytes, generator)))
             except StopIteration:
                 pass
+            except Exception as exc:
+                raise RuntimeError("protocol.generate_chunks() crashed") from exc
             else:
                 self.__g = generator
                 return chunk

--- a/src/easynetwork/lowlevel/api_async/endpoints/datagram.py
+++ b/src/easynetwork/lowlevel/api_async/endpoints/datagram.py
@@ -100,7 +100,14 @@ class AsyncDatagramEndpoint(typed_attr.TypedAttributeProvider, Generic[_SentPack
             if not self.__supports_write(transport):
                 raise UnsupportedOperation("transport does not support sending data")
 
-            await transport.send(protocol.make_datagram(packet))
+            try:
+                datagram: bytes = protocol.make_datagram(packet)
+            except Exception as exc:
+                raise RuntimeError("protocol.make_datagram() crashed") from exc
+            finally:
+                del packet
+
+            await transport.send(datagram)
 
     async def recv_packet(self) -> _ReceivedPacketT:
         """

--- a/src/easynetwork/lowlevel/api_async/servers/datagram.py
+++ b/src/easynetwork/lowlevel/api_async/servers/datagram.py
@@ -107,6 +107,8 @@ class AsyncDatagramServer(typed_attr.TypedAttributeProvider, Generic[_RequestT, 
 
                 try:
                     datagram: bytes = protocol.make_datagram(packet)
+                except Exception as exc:
+                    raise RuntimeError("protocol.make_datagram() crashed") from exc
                 finally:
                     del packet
                 try:

--- a/src/easynetwork/lowlevel/api_sync/endpoints/datagram.py
+++ b/src/easynetwork/lowlevel/api_sync/endpoints/datagram.py
@@ -112,7 +112,14 @@ class DatagramEndpoint(typed_attr.TypedAttributeProvider, Generic[_SentPacketT, 
         if not self.__supports_write(transport):
             raise UnsupportedOperation("transport does not support sending data")
 
-        transport.send(protocol.make_datagram(packet), timeout)
+        try:
+            datagram: bytes = protocol.make_datagram(packet)
+        except Exception as exc:
+            raise RuntimeError("protocol.make_datagram() crashed") from exc
+        finally:
+            del packet
+
+        transport.send(datagram, timeout)
 
     def recv_packet(self, *, timeout: float | None = None) -> _ReceivedPacketT:
         """

--- a/src/easynetwork/lowlevel/std_asyncio/stream/socket.py
+++ b/src/easynetwork/lowlevel/std_asyncio/stream/socket.py
@@ -168,9 +168,10 @@ class RawStreamSocketAdapter(transports.AsyncStreamTransport, transports.AsyncBu
 
     async def send_all_from_iterable(self, iterable_of_data: Iterable[bytes | bytearray | memoryview]) -> None:
         try:
-            await self.__socket.sendmsg(iterable_of_data)
+            return await self.__socket.sendmsg(iterable_of_data)
         except UnsupportedOperation:
-            await super().send_all_from_iterable(iterable_of_data)
+            pass
+        return await super().send_all_from_iterable(iterable_of_data)
 
     @property
     def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:

--- a/src/easynetwork/lowlevel/std_asyncio/tasks.py
+++ b/src/easynetwork/lowlevel/std_asyncio/tasks.py
@@ -311,8 +311,10 @@ class CancelScope(AbstractCancelScope):
 @final
 class TaskUtils:
     @staticmethod
-    def check_current_asyncio_task(loop: asyncio.AbstractEventLoop | None = None) -> None:
-        _ = TaskUtils.current_asyncio_task(loop=loop)
+    def check_current_event_loop(loop: asyncio.AbstractEventLoop) -> None:
+        running_loop = asyncio.get_running_loop()
+        if running_loop is not loop:
+            raise RuntimeError(f"{running_loop=!r} is not {loop=!r}")
 
     @staticmethod
     def current_asyncio_task(loop: asyncio.AbstractEventLoop | None = None) -> asyncio.Task[Any]:

--- a/tests/functional_test/test_communication/conftest.py
+++ b/tests/functional_test/test_communication/conftest.py
@@ -12,7 +12,13 @@ from easynetwork.protocol import DatagramProtocol, StreamProtocol
 import pytest
 import trustme
 
-from .serializer import BufferedStringSerializer, NotGoodBufferedStringSerializer, NotGoodStringSerializer, StringSerializer
+from .serializer import (
+    BadSerializeStringSerializer,
+    BufferedStringSerializer,
+    NotGoodBufferedStringSerializer,
+    NotGoodStringSerializer,
+    StringSerializer,
+)
 
 _FAMILY_TO_LOCALHOST: dict[int, str] = {
     AF_INET: "127.0.0.1",
@@ -68,6 +74,8 @@ def one_shot_serializer(request: pytest.FixtureRequest) -> StringSerializer:
             return StringSerializer()
         case "invalid":
             return NotGoodStringSerializer()
+        case "bad_serialize":
+            return BadSerializeStringSerializer()
         case _:
             pytest.fail("Invalid parameter")
 
@@ -83,6 +91,8 @@ def incremental_serializer(request: pytest.FixtureRequest) -> StringSerializer:
             return NotGoodStringSerializer()
         case "invalid_buffered":
             return NotGoodBufferedStringSerializer()
+        case "bad_serialize":
+            return BadSerializeStringSerializer()
         case _:
             pytest.fail("Invalid parameter")
 

--- a/tests/functional_test/test_communication/serializer.py
+++ b/tests/functional_test/test_communication/serializer.py
@@ -98,3 +98,14 @@ class NotGoodBufferedStringSerializer(NotGoodStringSerializer, BufferedStringSer
     def buffered_incremental_deserialize(self, write_buffer: bytearray) -> Generator[int, int, tuple[str, bytearray]]:
         yield 0
         raise SystemError("CRASH")
+
+
+class BadSerializeStringSerializer(StringSerializer):
+    __slots__ = ()
+
+    def serialize(self, packet: str) -> bytes:
+        raise SystemError("CRASH")
+
+    def incremental_serialize(self, packet: str) -> Generator[bytes, None, None]:
+        raise SystemError("CRASH")
+        yield b"chunk"  # type: ignore[unreachable]

--- a/tests/functional_test/test_communication/test_async/test_client/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_client/test_udp.py
@@ -192,8 +192,13 @@ class TestAsyncUDPNetworkClient:
         server: DatagramEndpoint,
     ) -> None:
         await server.sendto(b"ABCDEF", client.get_local_address())
-        with pytest.raises(RuntimeError, match=r"^protocol\.build_packet_from_datagram\(\) crashed$"):
+        try:
             await client.recv_packet()
+        except NotImplementedError:
+            raise
+        except Exception:
+            with pytest.raises(RuntimeError, match=r"^protocol\.build_packet_from_datagram\(\) crashed$"):
+                raise
 
     @use_asyncio_transport_xfail_uvloop
     async def test____iter_received_packets____yields_available_packets_until_close(

--- a/tests/functional_test/test_communication/test_async/test_client/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_client/test_udp.py
@@ -185,6 +185,7 @@ class TestAsyncUDPNetworkClient:
                 await client.recv_packet()
 
     @pytest.mark.parametrize("one_shot_serializer", [pytest.param("invalid", id="serializer_crash")], indirect=True)
+    @use_asyncio_transport_xfail_uvloop
     async def test____recv_packet____protocol_crashed(
         self,
         client: AsyncUDPNetworkClient[str, str],

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -71,6 +71,7 @@ class MyAsyncTCPRequestHandler(AsyncStreamRequestHandler[str, str]):
     request_received: collections.defaultdict[tuple[Any, ...], list[str]]
     request_count: collections.Counter[tuple[Any, ...]]
     bad_request_received: collections.defaultdict[tuple[Any, ...], list[BaseProtocolParseError]]
+    milk_handshake: bool = True
     close_all_clients_on_connection: bool = False
     close_client_after_n_request: int = -1
     server: AsyncTCPNetworkServer[str, str]
@@ -96,7 +97,8 @@ class MyAsyncTCPRequestHandler(AsyncStreamRequestHandler[str, str]):
     async def on_connection(self, client: AsyncStreamClient[str]) -> None:
         assert client_address(client) not in self.connected_clients
         self.connected_clients[client_address(client)] = client
-        await client.send_packet("milk")
+        if self.milk_handshake:
+            await client.send_packet("milk")
         if self.close_all_clients_on_connection:
             await self.backend.sleep(0.1)
             await client.aclose()
@@ -145,7 +147,14 @@ class MyAsyncTCPRequestHandler(AsyncStreamRequestHandler[str, str]):
                 await client.send_packet(f"After wait: {request}")
             case _:
                 self.request_received[client_address(client)].append(request)
-                await client.send_packet(request.upper())
+                try:
+                    await client.send_packet(request.upper())
+                except Exception as exc:
+                    msg = f"{exc.__class__.__name__}: {exc}"
+                    if exc.__cause__:
+                        msg = f"{msg} (caused by {exc.__cause__.__class__.__name__}: {exc.__cause__})"
+                    self.server.logger.error(msg, exc_info=exc)
+                    await client.aclose()
 
     @contextlib.asynccontextmanager
     async def handle_bad_requests(self, client: AsyncStreamClient[str]) -> AsyncIterator[None]:
@@ -348,7 +357,7 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
 
     @pytest_asyncio.fixture
     @staticmethod
-    async def client_factory(
+    async def client_factory_no_handshake(
         server_address: tuple[str, int],
         event_loop: asyncio.AbstractEventLoop,
         use_ssl: bool,
@@ -368,10 +377,21 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
                     )
                     stack.push_async_callback(lambda: asyncio.wait_for(writer.wait_closed(), 3))
                     stack.callback(writer.close)
-                    assert await reader.readline() == b"milk\n"
                 return reader, writer
 
             yield factory
+
+    @pytest.fixture
+    @staticmethod
+    def client_factory(
+        client_factory_no_handshake: Callable[[], Awaitable[tuple[asyncio.StreamReader, asyncio.StreamWriter]]],
+    ) -> Callable[[], Awaitable[tuple[asyncio.StreamReader, asyncio.StreamWriter]]]:
+        async def factory() -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+            reader, writer = await client_factory_no_handshake()
+            assert await reader.readline() == b"milk\n"
+            return reader, writer
+
+        return factory
 
     @staticmethod
     async def _wait_client_disconnected(writer: asyncio.StreamWriter, request_handler: MyAsyncTCPRequestHandler) -> None:
@@ -720,6 +740,29 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
             assert await reader.read() == b""
             raise ConnectionResetError
         assert len(caplog.records) == 3
+
+    @pytest.mark.parametrize("incremental_serializer", [pytest.param("bad_serialize", id="serializer_crash")], indirect=True)
+    async def test____serve_forever____unexpected_error_during_response_serialization(
+        self,
+        client_factory_no_handshake: Callable[[], Awaitable[tuple[asyncio.StreamReader, asyncio.StreamWriter]]],
+        caplog: pytest.LogCaptureFixture,
+        server: MyAsyncTCPServer,
+        request_handler: MyAsyncTCPRequestHandler,
+    ) -> None:
+        request_handler.milk_handshake = False
+        caplog.set_level(logging.ERROR, server.logger.name)
+        reader, writer = await client_factory_no_handshake()
+
+        while not request_handler.connected_clients:
+            await asyncio.sleep(0.1)
+
+        writer.write(b"request\n")
+        await asyncio.sleep(0.1)
+
+        assert await reader.read() == b""
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == logging.ERROR
+        assert caplog.records[0].message == "RuntimeError: protocol.generate_chunks() crashed (caused by SystemError: CRASH)"
 
     async def test____serve_forever____os_error(
         self,

--- a/tests/unit_test/test_async/test_asyncio_backend/test_tasks.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_tasks.py
@@ -162,7 +162,7 @@ class TestTaskUtils:
 
             def callback() -> None:
                 try:
-                    _ = TaskUtils.current_asyncio_task()
+                    _ = TaskUtils.current_asyncio_task(loop)
                     future.set_result(None)
                 except BaseException as exc:
                     future.set_exception(exc)
@@ -176,3 +176,23 @@ class TestTaskUtils:
 
         # Act & Assert
         asyncio.run(main())
+
+    def test____check_current_event_loop____default(self) -> None:
+        # Arrange
+        async def main() -> None:
+            loop = asyncio.get_running_loop()
+            TaskUtils.check_current_event_loop(loop)
+
+        # Act & Assert
+        asyncio.run(main())
+
+    def test____check_current_event_loop____called_in_another_event_loop(self) -> None:
+        # Arrange
+        async def main() -> None:
+            # Create a fake event loop
+            loop = asyncio.new_event_loop()
+            TaskUtils.check_current_event_loop(loop)
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match=r"^running_loop=.+ is not loop=.+$"):
+            asyncio.run(main())


### PR DESCRIPTION
### What's changed
- The same kind of development was done in the PR #169.
- The following functions now raise a `RuntimeError` if the protocol raised an exception:
  - `AsyncStreamEndpoint.send_packet()`
    - Therefore `AsyncTCPNetworkClient.send_packet()` too.
  - `AsyncDatagramEndpoint.send_packet()`
    - Therefore `AsyncUDPNetworkClient.send_packet()` too.
  - `StreamEndpoint.send_packet()`
    - Therefore `TCPNetworkClient.send_packet()` too.
  - `DatagramEndpoint.send_packet()`
    - Therefore `UDPNetworkClient.send_packet()` too.

The original error can be retrieved through the `__cause__` attribute.