### PR TITLE
AsyncIOBackend: Use asyncio transport/protocol system by setting an environment variable

### DIFF
--- a/tests/functional_test/test_async/test_backend/test_asyncio_backend.py
+++ b/tests/functional_test/test_async/test_backend/test_asyncio_backend.py
@@ -54,8 +54,8 @@ class TestAsyncioBackend:
         assert isinstance(backend, AsyncIOBackend)
         return backend
 
-    async def test____use_asyncio_transport____True_by_default(self, backend: AsyncIOBackend) -> None:
-        assert backend.using_asyncio_transport()
+    async def test____use_asyncio_transport____False_by_default(self, backend: AsyncIOBackend) -> None:
+        assert not backend.using_asyncio_transports()
 
     async def test____cancel_shielded_coro_yield____mute_cancellation(
         self,

--- a/tests/functional_test/test_communication/test_async/conftest.py
+++ b/tests/functional_test/test_communication/test_async/conftest.py
@@ -1,12 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
-
-from easynetwork.lowlevel.std_asyncio import AsyncIOBackend
-
 import pytest
-
-from ....tools import temporary_backend
 
 use_asyncio_transport_xfail_uvloop = pytest.mark.parametrize(
     "use_asyncio_transport",
@@ -20,9 +14,12 @@ use_asyncio_transport_xfail_uvloop = pytest.mark.parametrize(
 
 
 @pytest.fixture(params=[False, True], ids=lambda boolean: f"use_asyncio_transport=={boolean}")
-def use_asyncio_transport(request: pytest.FixtureRequest) -> Iterator[bool]:
-    use_asyncio_transport: bool = getattr(request, "param")
+def use_asyncio_transport(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> bool:
+    use_asyncio_transport: bool = bool(getattr(request, "param"))
 
-    # TODO: Do not use temporary_backend() when env variable will be implemented
-    with temporary_backend(AsyncIOBackend(transport=use_asyncio_transport)):
-        yield use_asyncio_transport
+    if use_asyncio_transport:
+        monkeypatch.setenv("EASYNETWORK_HINT_FORCE_USE_ASYNCIO_TRANSPORTS", "1")
+    else:
+        monkeypatch.delenv("EASYNETWORK_HINT_FORCE_USE_ASYNCIO_TRANSPORTS", raising=False)
+
+    return use_asyncio_transport

--- a/tests/functional_test/test_communication/test_async/test_client/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_client/test_tcp.py
@@ -480,6 +480,7 @@ class TestAsyncTCPNetworkClientConnection:
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("use_asyncio_transport")
 class TestAsyncSSLOverTCPNetworkClient:
     @pytest_asyncio.fixture(autouse=True)
     @staticmethod

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -300,13 +300,6 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
 
     @pytest.fixture
     @staticmethod
-    def use_asyncio_transport(use_asyncio_transport: bool, use_ssl: bool) -> bool:
-        if use_ssl and not use_asyncio_transport:
-            pytest.skip("SSL/TLS not supported with transport=False")
-        return use_asyncio_transport
-
-    @pytest.fixture
-    @staticmethod
     def request_handler(request: Any) -> AsyncStreamRequestHandler[str, str]:
         request_handler_cls: type[AsyncStreamRequestHandler[str, str]] = getattr(request, "param", MyAsyncTCPRequestHandler)
         return request_handler_cls()
@@ -403,7 +396,6 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
 
     @pytest.mark.parametrize("host", [None, ""], ids=repr)
     @pytest.mark.parametrize("log_client_connection", [True, False], ids=lambda p: f"log_client_connection=={p}")
-    @pytest.mark.parametrize("use_ssl", ["NO_SSL"], indirect=True)
     @pytest.mark.usefixtures("use_asyncio_transport")
     async def test____dunder_init____bind_to_all_available_interfaces(
         self,


### PR DESCRIPTION
### What's changed
- By default, transport implementations with direct socket manipulations are used.
- `EASYNETWORK_HINT_FORCE_USE_ASYNCIO_TRANSPORTS` can be set to `1` to return to the old behavior (with `asyncio.Transport`)