### PR TITLE
Several fixes in documentation

### DIFF
--- a/docs/source/_include/examples/howto/tcp_servers/request_handler_explanation.py
+++ b/docs/source/_include/examples/howto/tcp_servers/request_handler_explanation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import traceback
 from collections.abc import AsyncGenerator
 
 from easynetwork.exceptions import StreamProtocolParseError
@@ -111,6 +112,9 @@ class ErrorHandlingInRequestHandler(AsyncStreamRequestHandler[Request, Response]
                 await client.aclose()
                 raise
         except Exception:
+            # Most likely a bug in EasyNetwork code. Log the error.
+            traceback.print_exc()
+
             await client.send_packet(InternalError())
         else:
             await client.send_packet(Response())

--- a/docs/source/_include/examples/howto/udp_servers/request_handler_explanation.py
+++ b/docs/source/_include/examples/howto/udp_servers/request_handler_explanation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import traceback
 from collections.abc import AsyncGenerator
 
 from easynetwork.exceptions import DatagramProtocolParseError
@@ -79,6 +80,9 @@ class ErrorHandlingInRequestHandler(AsyncDatagramRequestHandler[Request, Respons
         except DatagramProtocolParseError:
             await client.send_packet(BadRequest())
         except Exception:
+            # Most likely a bug in EasyNetwork code. Log the error.
+            traceback.print_exc()
+
             await client.send_packet(InternalError())
         else:
             await client.send_packet(Response())

--- a/docs/source/howto/advanced/buffered_serializers.rst
+++ b/docs/source/howto/advanced/buffered_serializers.rst
@@ -74,6 +74,10 @@ that exchange large amounts of data with their clients. In such a situation, the
 the whole thing crashing down. Under "normal" conditions, the basic implementation is more than enough
 to keep a server running with acceptable performance.
 
+.. important::
+
+   I want to point out that it's not about speed, it's about improving global performance by minimizing memory footprint over time.
+
 ------
 
 Writing A Buffered Serializer

--- a/docs/source/howto/tcp_clients.rst
+++ b/docs/source/howto/tcp_clients.rst
@@ -401,7 +401,7 @@ Concurrency And Multithreading
 
       * :meth:`~.AsyncTCPNetworkClient.send_packet` and :meth:`~.AsyncTCPNetworkClient.recv_packet` do not share the same lock instance.
 
-      * :meth:`~.AsyncTCPNetworkClient.close` will not wait for :meth:`~.AsyncTCPNetworkClient.recv_packet`.
+      * :meth:`~.AsyncTCPNetworkClient.aclose` will not wait for :meth:`~.AsyncTCPNetworkClient.recv_packet`.
 
       This allows you to do something like this:
 

--- a/docs/source/howto/tcp_servers.rst
+++ b/docs/source/howto/tcp_servers.rst
@@ -109,12 +109,23 @@ Error Handling
    :pyobject: ErrorHandlingInRequestHandler.handle
    :dedent:
    :linenos:
-   :emphasize-lines: 8
 
 .. note::
 
    ``handle()`` will never get a :exc:`ConnectionError` subclass. In case of an unexpected disconnect, the generator is closed,
    so you should handle :exc:`GeneratorExit` instead.
+
+.. warning::
+
+   You should always log or re-raise a bare :exc:`Exception` thrown in your generator.
+
+   .. literalinclude:: ../_include/examples/howto/tcp_servers/request_handler_explanation.py
+      :pyobject: ErrorHandlingInRequestHandler.handle
+      :dedent:
+      :linenos:
+      :start-at: except Exception
+      :end-at: InternalError()
+      :emphasize-lines: 2-3
 
 
 Having Multiple ``yield`` Statements
@@ -152,7 +163,7 @@ Cancellation And Timeouts
          :pyobject: TimeoutYieldedRequestHandler.handle
          :dedent:
          :linenos:
-         :emphasize-lines: 4,7
+         :emphasize-lines: 4,7-9
 
    .. tab:: Using ``with``
 

--- a/docs/source/howto/udp_clients.rst
+++ b/docs/source/howto/udp_clients.rst
@@ -296,4 +296,4 @@ Concurrency And Multithreading
 
       * :meth:`~.AsyncUDPNetworkClient.send_packet` and :meth:`~.AsyncUDPNetworkClient.recv_packet` do not share the same lock instance.
 
-      * :meth:`~.AsyncUDPNetworkClient.close` will not wait for :meth:`~.AsyncUDPNetworkClient.recv_packet`.
+      * :meth:`~.AsyncUDPNetworkClient.aclose` will not wait for :meth:`~.AsyncUDPNetworkClient.recv_packet`.

--- a/docs/source/howto/udp_servers.rst
+++ b/docs/source/howto/udp_servers.rst
@@ -74,7 +74,18 @@ Error Handling
    :pyobject: ErrorHandlingInRequestHandler.handle
    :dedent:
    :linenos:
-   :emphasize-lines: 8
+
+.. warning::
+
+   You should always log or re-raise a bare :exc:`Exception` thrown in your generator.
+
+   .. literalinclude:: ../_include/examples/howto/udp_servers/request_handler_explanation.py
+      :pyobject: ErrorHandlingInRequestHandler.handle
+      :dedent:
+      :linenos:
+      :start-at: except Exception
+      :end-at: InternalError()
+      :emphasize-lines: 2-3
 
 
 Having Multiple ``yield`` Statements
@@ -111,7 +122,7 @@ Cancellation And Timeouts
          :pyobject: TimeoutYieldedRequestHandler.handle
          :dedent:
          :linenos:
-         :emphasize-lines: 4,15
+         :emphasize-lines: 4,15-17
 
    .. tab:: Using ``with``
 
@@ -136,8 +147,8 @@ Cancellation And Timeouts
 Service Initialization
 ----------------------
 
-The server will call :meth:`~.AsyncStreamRequestHandler.service_init` and pass it an :class:`~contextlib.AsyncExitStack`
-at the beginning of the :meth:`~.AsyncTCPNetworkServer.serve_forever` task to set up the global service.
+The server will call :meth:`~.AsyncDatagramRequestHandler.service_init` and pass it an :class:`~contextlib.AsyncExitStack`
+at the beginning of the :meth:`~.AsyncUDPNetworkServer.serve_forever` task to set up the global service.
 
 This allows you to do something like this:
 

--- a/src/easynetwork/lowlevel/api_async/backend/abc.py
+++ b/src/easynetwork/lowlevel/api_async/backend/abc.py
@@ -363,7 +363,7 @@ class CancelScope(metaclass=ABCMeta):
         Returns the scope cancellation state.
 
         Returns:
-            :data:`True` if the scope has been is *cancelled*.
+            :data:`True` if the scope has been *cancelled*.
         """
         raise NotImplementedError
 

--- a/src/easynetwork/protocol.py
+++ b/src/easynetwork/protocol.py
@@ -123,8 +123,9 @@ class DatagramProtocol(Generic[_T_SentPacket, _T_ReceivedPacket]):
 class BufferedStreamReceiver(Generic[_T_ReceivedPacket, _T_Buffer]):
     """A specialization of :class:`StreamProtocol` in order to use a buffered :term:`incremental serializer`.
 
-    It is not recommended to instantiate `BufferedStreamReceiver` objects directly;
-    use :meth:`StreamProtocol.buffered_receiver` instead.
+    Warning:
+        It is not recommended to instantiate `BufferedStreamReceiver` objects directly;
+        use :meth:`StreamProtocol.buffered_receiver` instead.
     """
 
     __slots__ = ("__serializer", "__converter", "__weakref__")

--- a/src/easynetwork/serializers/cbor.py
+++ b/src/easynetwork/serializers/cbor.py
@@ -39,7 +39,7 @@ class CBOREncoderConfig:
     """
     A dataclass with the CBOR encoder options.
 
-    See :class:`cbor2.encoder.CBOREncoder` for details.
+    See :class:`cbor2.CBOREncoder` for details.
     """
 
     datetime_as_timestamp: bool = False
@@ -56,7 +56,7 @@ class CBORDecoderConfig:
     """
     A dataclass with the CBOR decoder options.
 
-    See :class:`cbor2.decoder.CBORDecoder` for details.
+    See :class:`cbor2.CBORDecoder` for details.
     """
 
     object_hook: Callable[..., Any] | None = None

--- a/src/easynetwork/servers/handlers.py
+++ b/src/easynetwork/servers/handlers.py
@@ -171,6 +171,9 @@ class AsyncStreamRequestHandler(Generic[_T_Request, _T_Response], metaclass=ABCM
 
         Parameters:
             client: An interface to communicate with the remote endpoint.
+
+        Yields:
+            :data:`None` or a number interpreted as the timeout delay.
         """
         raise NotImplementedError
 
@@ -205,6 +208,9 @@ class AsyncStreamRequestHandler(Generic[_T_Request, _T_Response], metaclass=ABCM
 
         Parameters:
             client: An interface to communicate with the remote endpoint.
+
+        Yields:
+            If it is an :term:`asynchronous generator`, :data:`None` or a number interpreted as the timeout delay.
         """
 
         async def _pass() -> None:
@@ -290,5 +296,8 @@ class AsyncDatagramRequestHandler(Generic[_T_Request, _T_Response], metaclass=AB
 
         Parameters:
             client: An interface to communicate with the remote endpoint.
+
+        Yields:
+            :data:`None` or a number interpreted as the timeout delay.
         """
         raise NotImplementedError


### PR DESCRIPTION
- [x] https://easynetwork.readthedocs.io/en/latest/api/lowlevel/async/backend.html#easynetwork.lowlevel.api_async.backend.abc.CancelScope.cancelled_caught => "the scope has been is cancelled"
- [x] Request handlers: Say to always re-raise or log errors thrown at `yield` in order not to hide the potential bugs
- [x] BufferedIncrementalSerializer: Add a note about performances mostly acquired for memory consumption rather than read speed.
- [x] The recommendation in `BufferedStreamReceiver` should be in a `Warning` aggregation
- [x] Request handlers (docstrings): Add a note about yielding a value (the timeout)
- [x] Request handers (how-to guide): Highlight the `except TimeoutError` clause in the `yield <timeout>` example
- [x] https://easynetwork.readthedocs.io/en/latest/howto/udp_servers.html#service-initialization => `service_init()` points to `AsyncStreamRequestHandler` instead of `AsyncDatagramRequestHandler`
- [x] https://easynetwork.readthedocs.io/en/latest/howto/tcp_clients.html#concurrency-and-multithreading => In `Asynchronous` tab, replace `close()` by `aclose()`
  - Same for UDP client page
- [x] https://easynetwork.readthedocs.io/en/latest/api/serializers/cbor.html => Change reference to cbor2 classes