### PR TITLE
Upgrade `pdm` to version 2.14.0

### DIFF
--- a/.github/actions/setup-tox/action.yml
+++ b/.github/actions/setup-tox/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
     - uses: pdm-project/setup-pdm@v4
       with:
-        version: '2.13.2'
+        version: '2.14.0'
         python-version: ${{ inputs.python-version }}
         ### setup-pdm cache seems broken. See https://github.com/pdm-project/setup-pdm/issues/43
         # cache: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
         types: []  # Overwrite with empty in order to fallback to types_or
         types_or: [python, pyi]
   - repo: https://github.com/pdm-project/pdm
-    rev: '2.13.2'
+    rev: '2.14.0'
     hooks:
       - id: pdm-lock-check
       - id: pdm-export

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: "3.11"
   jobs:
     post_create_environment:
-      - pip install --no-cache-dir pdm==2.13.2
+      - pip install --no-cache-dir pdm==2.14.0
       - pdm config check_update false
       - pdm use -f $READTHEDOCS_VIRTUALENV_PATH
     post_install:


### PR DESCRIPTION
Sometimes the CI fails because of the new cache system introduced in `pdm` 2.13. This feature has been disabled by default in 2.14

Full release note: https://github.com/pdm-project/pdm/releases/tag/2.14.0