### PR TITLE
Added `BufferedStreamProtocol` object

### DIFF
--- a/docs/source/_include/examples/howto/protocols/usage/buffered_stream_protocol.py
+++ b/docs/source/_include/examples/howto/protocols/usage/buffered_stream_protocol.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from easynetwork.clients import TCPNetworkClient
+from easynetwork.protocol import BufferedStreamProtocol
+from easynetwork.serializers import StringLineSerializer
+
+
+def main() -> None:
+    serializer = StringLineSerializer()
+    protocol = BufferedStreamProtocol(serializer)
+
+    with TCPNetworkClient(("remote_address", 12345), protocol) as endpoint:
+        endpoint.send_packet("Hello, world!")

--- a/docs/source/howto/advanced/buffered_serializers.rst
+++ b/docs/source/howto/advanced/buffered_serializers.rst
@@ -76,6 +76,16 @@ to keep a server running with acceptable performance.
 
 ------
 
+Usage
+=====
+
+For the serializers that support this API, you must use :class:`.BufferedStreamProtocol` instead of :class:`.StreamProtocol`:
+
+.. literalinclude:: ../../_include/examples/howto/protocols/usage/buffered_stream_protocol.py
+   :pyobject: main
+   :linenos:
+   :emphasize-lines: 3
+
 Writing A Buffered Serializer
 =============================
 
@@ -172,7 +182,7 @@ At each :keyword:`yield` checkpoint, the endpoint implementation sends to the ge
       If you are relying only on the area that has already been written, you can skip this step (as in the example above).
 
    Growing buffers
-      It is not officially supported to increase/decrease the buffer size during deserialization.
+      It is not supported to increase/decrease the buffer size during deserialization.
 
 .. tip::
 

--- a/src/easynetwork/lowlevel/api_async/endpoints/stream.py
+++ b/src/easynetwork/lowlevel/api_async/endpoints/stream.py
@@ -26,12 +26,11 @@ import dataclasses
 import errno as _errno
 import warnings
 from collections.abc import Callable, Mapping
-from typing import Any, Generic, Literal, assert_never
+from typing import Any, Generic, assert_never
 
 from ...._typevars import _T_ReceivedPacket, _T_SentPacket
 from ....exceptions import UnsupportedOperation
-from ....protocol import StreamProtocol
-from ....warnings import ManualBufferAllocationWarning
+from ....protocol import AnyStreamProtocolType
 from ... import _stream, _utils
 from ..backend.abc import AsyncBackend
 from ..transports.abc import (
@@ -57,43 +56,24 @@ class AsyncStreamReceiverEndpoint(AsyncBaseTransport, Generic[_T_ReceivedPacket]
     def __init__(
         self,
         transport: AsyncStreamReadTransport,
-        protocol: StreamProtocol[Any, _T_ReceivedPacket],
+        protocol: AnyStreamProtocolType[Any, _T_ReceivedPacket],
         max_recv_size: int,
-        *,
-        manual_buffer_allocation: Literal["try", "no", "force"] = "try",
-        manual_buffer_allocation_warning_stacklevel: int = 2,
     ) -> None:
         """
         Parameters:
             transport: The data transport to use.
             protocol: The :term:`protocol object` to use.
             max_recv_size: Read buffer size.
-            manual_buffer_allocation: Select whether or not to enable the manual buffer allocation system:
-
-                                      * ``"try"``: (the default) will use the buffer API if the transport and protocol support it,
-                                        and fall back to the default implementation otherwise.
-                                        Emits a :exc:`.ManualBufferAllocationWarning` if only the transport does not support it.
-
-                                      * ``"no"``: does not use the buffer API, even if they both support it.
-
-                                      * ``"force"``: requires the buffer API. Raises :exc:`.UnsupportedOperation` if it fails and
-                                        no warnings are emitted.
-            manual_buffer_allocation_warning_stacklevel: ``stacklevel`` parameter of :func:`warnings.warn` when emitting
-                                                         :exc:`.ManualBufferAllocationWarning`.
         """
 
         if not isinstance(transport, AsyncStreamReadTransport):
             raise TypeError(f"Expected an AsyncStreamReadTransport object, got {transport!r}")
         _check_max_recv_size_value(max_recv_size)
-        _check_manual_buffer_allocation_value(manual_buffer_allocation)
-        manual_buffer_allocation_warning_stacklevel = max(manual_buffer_allocation_warning_stacklevel, 2)
 
         self.__receiver: _DataReceiverImpl[_T_ReceivedPacket] | _BufferedReceiverImpl[_T_ReceivedPacket] = _get_receiver(
             transport=transport,
             protocol=protocol,
             max_recv_size=max_recv_size,
-            manual_buffer_allocation=manual_buffer_allocation,
-            manual_buffer_allocation_warning_stacklevel=manual_buffer_allocation_warning_stacklevel,
         )
 
         self.__transport: AsyncStreamReadTransport = transport
@@ -169,7 +149,7 @@ class AsyncStreamSenderEndpoint(AsyncBaseTransport, Generic[_T_SentPacket]):
     def __init__(
         self,
         transport: AsyncStreamWriteTransport,
-        protocol: StreamProtocol[_T_SentPacket, Any],
+        protocol: AnyStreamProtocolType[_T_SentPacket, Any],
     ) -> None:
         """
         Parameters:
@@ -252,44 +232,25 @@ class AsyncStreamEndpoint(AsyncBaseTransport, Generic[_T_SentPacket, _T_Received
     def __init__(
         self,
         transport: AsyncStreamTransport,
-        protocol: StreamProtocol[_T_SentPacket, _T_ReceivedPacket],
+        protocol: AnyStreamProtocolType[_T_SentPacket, _T_ReceivedPacket],
         max_recv_size: int,
-        *,
-        manual_buffer_allocation: Literal["try", "no", "force"] = "try",
-        manual_buffer_allocation_warning_stacklevel: int = 2,
     ) -> None:
         """
         Parameters:
             transport: The data transport to use.
             protocol: The :term:`protocol object` to use.
             max_recv_size: Read buffer size.
-            manual_buffer_allocation: Select whether or not to enable the manual buffer allocation system:
-
-                                      * ``"try"``: (the default) will use the buffer API if the transport and protocol support it,
-                                        and fall back to the default implementation otherwise.
-                                        Emits a :exc:`.ManualBufferAllocationWarning` if only the transport does not support it.
-
-                                      * ``"no"``: does not use the buffer API, even if they both support it.
-
-                                      * ``"force"``: requires the buffer API. Raises :exc:`.UnsupportedOperation` if it fails and
-                                        no warnings are emitted.
-            manual_buffer_allocation_warning_stacklevel: ``stacklevel`` parameter of :func:`warnings.warn` when emitting
-                                                         :exc:`.ManualBufferAllocationWarning`.
         """
 
         if not isinstance(transport, AsyncStreamTransport):
             raise TypeError(f"Expected an AsyncStreamTransport object, got {transport!r}")
         _check_max_recv_size_value(max_recv_size)
-        _check_manual_buffer_allocation_value(manual_buffer_allocation)
-        manual_buffer_allocation_warning_stacklevel = max(manual_buffer_allocation_warning_stacklevel, 2)
 
         self.__sender: _DataSenderImpl[_T_SentPacket] = _DataSenderImpl(transport, _stream.StreamDataProducer(protocol))
         self.__receiver: _DataReceiverImpl[_T_ReceivedPacket] | _BufferedReceiverImpl[_T_ReceivedPacket] = _get_receiver(
             transport=transport,
             protocol=protocol,
             max_recv_size=max_recv_size,
-            manual_buffer_allocation=manual_buffer_allocation,
-            manual_buffer_allocation_warning_stacklevel=manual_buffer_allocation_warning_stacklevel,
         )
 
         self.__transport: AsyncStreamTransport = transport
@@ -475,45 +436,27 @@ class _BufferedReceiverImpl(Generic[_T_ReceivedPacket]):
 
 def _get_receiver(
     transport: AsyncStreamReadTransport,
-    protocol: StreamProtocol[Any, _T_ReceivedPacket],
+    protocol: AnyStreamProtocolType[Any, _T_ReceivedPacket],
     *,
     max_recv_size: int,
-    manual_buffer_allocation: Literal["try", "no", "force"],
-    manual_buffer_allocation_warning_stacklevel: int,
 ) -> _DataReceiverImpl[_T_ReceivedPacket] | _BufferedReceiverImpl[_T_ReceivedPacket]:
-    # Always exclude this function frame.
-    manual_buffer_allocation_warning_stacklevel += 1
+    from ....protocol import BufferedStreamProtocol, StreamProtocol
 
-    match manual_buffer_allocation:
-        case "try" | "force":
-            try:
-                buffered_consumer = _stream.BufferedStreamDataConsumer(protocol, max_recv_size)
-                if not isinstance(transport, AsyncBufferedStreamReadTransport):
-                    msg = f"The transport implementation {transport!r} does not implement AsyncBufferedStreamReadTransport interface"
-                    if manual_buffer_allocation == "try":
-                        warnings.warn(
-                            f'{msg}. Consider explicitly setting the "manual_buffer_allocation" strategy to "no".',
-                            category=ManualBufferAllocationWarning,
-                            stacklevel=manual_buffer_allocation_warning_stacklevel,
-                        )
-                    raise UnsupportedOperation(msg)
-                return _BufferedReceiverImpl(transport, buffered_consumer)
-            except UnsupportedOperation as exc:
-                if manual_buffer_allocation == "force":
-                    exc.add_note('Consider setting the "manual_buffer_allocation" strategy to "no"')
-                    raise
-                return _DataReceiverImpl(transport, _stream.StreamDataConsumer(protocol), max_recv_size)
-        case "no":
+    _stream._check_any_protocol(protocol)
+
+    match protocol:
+        case BufferedStreamProtocol():
+            buffered_consumer = _stream.BufferedStreamDataConsumer(protocol, max_recv_size)
+            if not isinstance(transport, AsyncBufferedStreamReadTransport):
+                msg = f"The transport implementation {transport!r} does not implement AsyncBufferedStreamReadTransport interface"
+                raise UnsupportedOperation(msg)
+            return _BufferedReceiverImpl(transport, buffered_consumer)
+        case StreamProtocol():
             return _DataReceiverImpl(transport, _stream.StreamDataConsumer(protocol), max_recv_size)
         case _:  # pragma: no cover
-            assert_never(manual_buffer_allocation)
+            assert_never(protocol)
 
 
 def _check_max_recv_size_value(max_recv_size: int) -> None:
     if not isinstance(max_recv_size, int) or max_recv_size <= 0:
         raise ValueError("'max_recv_size' must be a strictly positive integer")
-
-
-def _check_manual_buffer_allocation_value(manual_buffer_allocation: Literal["try", "no", "force"]) -> None:
-    if manual_buffer_allocation not in ("try", "no", "force"):
-        raise ValueError('"manual_buffer_allocation" must be "try", "no" or "force"')

--- a/src/easynetwork/servers/standalone_tcp.py
+++ b/src/easynetwork/servers/standalone_tcp.py
@@ -22,13 +22,13 @@ __all__ = [
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Generic, Literal
+from typing import TYPE_CHECKING, Any, Generic
 
 from .._typevars import _T_Request, _T_Response
 from ..lowlevel.api_async.backend.abc import AsyncBackend
 from ..lowlevel.api_async.backend.utils import BuiltinAsyncBackendToken
 from ..lowlevel.socket import SocketProxy
-from ..protocol import StreamProtocol
+from ..protocol import AnyStreamProtocolType
 from . import _base
 from .async_tcp import AsyncTCPNetworkServer
 from .handlers import AsyncStreamRequestHandler
@@ -53,7 +53,7 @@ class StandaloneTCPNetworkServer(
         self,
         host: str | None | Sequence[str],
         port: int,
-        protocol: StreamProtocol[_T_Response, _T_Request],
+        protocol: AnyStreamProtocolType[_T_Response, _T_Request],
         request_handler: AsyncStreamRequestHandler[_T_Request, _T_Response],
         backend: AsyncBackend | BuiltinAsyncBackendToken | None = None,
         *,
@@ -65,7 +65,6 @@ class StandaloneTCPNetworkServer(
         backlog: int | None = None,
         reuse_port: bool = False,
         max_recv_size: int | None = None,
-        manual_buffer_allocation: Literal["try", "no", "force"] = "try",
         log_client_connection: bool | None = None,
         logger: logging.Logger | None = None,
         **kwargs: Any,
@@ -92,7 +91,6 @@ class StandaloneTCPNetworkServer(
                 backlog=backlog,
                 reuse_port=reuse_port,
                 max_recv_size=max_recv_size,
-                manual_buffer_allocation=manual_buffer_allocation,
                 log_client_connection=log_client_connection,
                 logger=logger,
                 **kwargs,

--- a/tests/functional_test/test_communication/test_async/test_client/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_client/test_udp.py
@@ -149,7 +149,7 @@ class TestAsyncUDPNetworkClient:
         with pytest.raises(ClientClosedError):
             await client.send_packet("ABCDEF")
 
-    @pytest.mark.parametrize("one_shot_serializer", [pytest.param("bad_serialize", id="serializer_crash")], indirect=True)
+    @pytest.mark.parametrize("datagram_protocol", [pytest.param("bad_serialize", id="serializer_crash")], indirect=True)
     async def test____send_packet____protocol_crashed(
         self,
         client: AsyncUDPNetworkClient[str, str],
@@ -185,7 +185,7 @@ class TestAsyncUDPNetworkClient:
             async with asyncio.timeout(3):
                 await client.recv_packet()
 
-    @pytest.mark.parametrize("one_shot_serializer", [pytest.param("invalid", id="serializer_crash")], indirect=True)
+    @pytest.mark.parametrize("datagram_protocol", [pytest.param("invalid", id="serializer_crash")], indirect=True)
     async def test____recv_packet____protocol_crashed(
         self,
         client: AsyncUDPNetworkClient[str, str],

--- a/tests/functional_test/test_communication/test_async/test_server/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_udp.py
@@ -400,7 +400,7 @@ class TestAsyncUDPNetworkServer(BaseTestAsyncServer):
 
     @pytest.mark.parametrize("mute_thrown_exception", [False, True])
     @pytest.mark.parametrize("request_handler", [ErrorInRequestHandler], indirect=True)
-    @pytest.mark.parametrize("one_shot_serializer", [pytest.param("invalid", id="serializer_crash")], indirect=True)
+    @pytest.mark.parametrize("datagram_protocol", [pytest.param("invalid", id="serializer_crash")], indirect=True)
     async def test____serve_forever____internal_error(
         self,
         mute_thrown_exception: bool,
@@ -457,7 +457,7 @@ class TestAsyncUDPNetworkServer(BaseTestAsyncServer):
         else:
             assert type(caplog.records[1].exc_info[1]) is RandomError
 
-    @pytest.mark.parametrize("one_shot_serializer", [pytest.param("bad_serialize", id="serializer_crash")], indirect=True)
+    @pytest.mark.parametrize("datagram_protocol", [pytest.param("bad_serialize", id="serializer_crash")], indirect=True)
     async def test____serve_forever____unexpected_error_during_response_serialization(
         self,
         client_factory: Callable[[], Awaitable[DatagramEndpoint]],

--- a/tests/functional_test/test_communication/test_sync/test_client/test_tcp.py
+++ b/tests/functional_test/test_communication/test_sync/test_client/test_tcp.py
@@ -11,7 +11,7 @@ from typing import Any
 from easynetwork.clients.tcp import TCPNetworkClient
 from easynetwork.exceptions import ClientClosedError, StreamProtocolParseError
 from easynetwork.lowlevel.socket import IPv4SocketAddress, IPv6SocketAddress
-from easynetwork.protocol import StreamProtocol
+from easynetwork.protocol import AnyStreamProtocolType
 
 import pytest
 
@@ -44,7 +44,7 @@ class TestTCPNetworkClient:
     @staticmethod
     def client(
         socket_pair: tuple[Socket, Socket],
-        stream_protocol: StreamProtocol[str, str],
+        stream_protocol: AnyStreamProtocolType[str, str],
     ) -> Iterator[TCPNetworkClient[str, str]]:
         with TCPNetworkClient(socket_pair[1], stream_protocol) as client:
             client.socket.setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
@@ -303,7 +303,7 @@ class TestTCPNetworkClientConnection:
         self,
         localhost_ip: str,
         remote_address: tuple[str, int],
-        stream_protocol: StreamProtocol[str, str],
+        stream_protocol: AnyStreamProtocolType[str, str],
     ) -> None:
         # Arrange
 
@@ -339,7 +339,7 @@ class TestSSLOverTCPNetworkClient:
     def test____dunder_init____handshake_and_shutdown(
         self,
         remote_address: tuple[str, int],
-        stream_protocol: StreamProtocol[str, str],
+        stream_protocol: AnyStreamProtocolType[str, str],
         client_ssl_context: ssl.SSLContext,
     ) -> None:
         # Arrange
@@ -357,7 +357,7 @@ class TestSSLOverTCPNetworkClient:
     def test____dunder_init____use_default_context(
         self,
         remote_address: tuple[str, int],
-        stream_protocol: StreamProtocol[str, str],
+        stream_protocol: AnyStreamProtocolType[str, str],
         client_ssl_context: ssl.SSLContext,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -377,7 +377,7 @@ class TestSSLOverTCPNetworkClient:
     def test____dunder_init____use_default_context____disable_hostname_check(
         self,
         remote_address: tuple[str, int],
-        stream_protocol: StreamProtocol[str, str],
+        stream_protocol: AnyStreamProtocolType[str, str],
         client_ssl_context: ssl.SSLContext,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -401,7 +401,7 @@ class TestSSLOverTCPNetworkClient:
     def test____dunder_init____no_ssl_module(
         self,
         remote_address: tuple[str, int],
-        stream_protocol: StreamProtocol[str, str],
+        stream_protocol: AnyStreamProtocolType[str, str],
         client_ssl_context: ssl.SSLContext,
     ) -> None:
         # Arrange
@@ -418,7 +418,7 @@ class TestSSLOverTCPNetworkClient:
     def test____send_eof____not_supported(
         self,
         remote_address: tuple[str, int],
-        stream_protocol: StreamProtocol[str, str],
+        stream_protocol: AnyStreamProtocolType[str, str],
         client_ssl_context: ssl.SSLContext,
     ) -> None:
         # Arrange

--- a/tests/functional_test/test_communication/test_sync/test_server/test_standalone.py
+++ b/tests/functional_test/test_communication/test_sync/test_server/test_standalone.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncGenerator, Iterator
 
 from easynetwork.exceptions import ServerAlreadyRunning, ServerClosedError
 from easynetwork.lowlevel.std_asyncio import AsyncIOBackend
-from easynetwork.protocol import DatagramProtocol, StreamProtocol
+from easynetwork.protocol import AnyStreamProtocolType, DatagramProtocol
 from easynetwork.servers.abc import AbstractNetworkServer
 from easynetwork.servers.handlers import AsyncBaseClientInterface, AsyncDatagramRequestHandler, AsyncStreamRequestHandler
 from easynetwork.servers.standalone_tcp import StandaloneTCPNetworkServer
@@ -114,7 +114,7 @@ class BaseTestStandaloneNetworkServer:
 class TestStandaloneTCPNetworkServer(BaseTestStandaloneNetworkServer):
     @pytest.fixture
     @staticmethod
-    def server(stream_protocol: StreamProtocol[str, str]) -> StandaloneTCPNetworkServer[str, str]:
+    def server(stream_protocol: AnyStreamProtocolType[str, str]) -> StandaloneTCPNetworkServer[str, str]:
         return StandaloneTCPNetworkServer(None, 0, stream_protocol, EchoRequestHandler(), AsyncIOBackend())
 
     @pytest.fixture

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -6,8 +6,7 @@ from ssl import SSLContext, SSLObject, SSLSocket
 from typing import TYPE_CHECKING, Any
 
 from easynetwork.converter import AbstractPacketConverterComposite
-from easynetwork.exceptions import UnsupportedOperation
-from easynetwork.protocol import BufferedStreamReceiver, DatagramProtocol, StreamProtocol
+from easynetwork.protocol import BufferedStreamProtocol, DatagramProtocol, StreamProtocol
 from easynetwork.serializers.abc import (
     AbstractIncrementalPacketSerializer,
     AbstractPacketSerializer,
@@ -168,25 +167,29 @@ def mock_serializer(mock_serializer_factory: Callable[[], Any]) -> Any:
     return mock_serializer_factory()
 
 
-@pytest.fixture(params=[None, "buffered"], ids=lambda p: f"incremental_serializer_factory=={p}")
-def mock_incremental_serializer_factory(request: pytest.FixtureRequest, mocker: MockerFixture) -> Callable[[], Any]:
-    match getattr(request, "param", None):
-        case "buffered":
-            return lambda: mocker.NonCallableMagicMock(
-                spec=BufferedIncrementalPacketSerializer,
-                **{
-                    "create_deserializer_buffer.side_effect": lambda sizehint: memoryview(bytearray(sizehint)),
-                },
-            )
-        case None:
-            return lambda: mocker.NonCallableMagicMock(spec=AbstractIncrementalPacketSerializer)
-        case _:
-            pytest.fail("mock_incremental_serializer_factory: Invalid parameter")
+@pytest.fixture
+def mock_incremental_serializer_factory(mocker: MockerFixture) -> Callable[[], Any]:
+    return lambda: mocker.NonCallableMagicMock(spec=AbstractIncrementalPacketSerializer)
 
 
 @pytest.fixture
 def mock_incremental_serializer(mock_incremental_serializer_factory: Callable[[], Any]) -> Any:
     return mock_incremental_serializer_factory()
+
+
+@pytest.fixture
+def mock_buffered_incremental_serializer_factory(mocker: MockerFixture) -> Callable[[], Any]:
+    return lambda: mocker.NonCallableMagicMock(
+        spec=BufferedIncrementalPacketSerializer,
+        **{
+            "create_deserializer_buffer.side_effect": lambda sizehint: memoryview(bytearray(sizehint)),
+        },
+    )
+
+
+@pytest.fixture
+def mock_buffered_incremental_serializer(mock_buffered_incremental_serializer_factory: Callable[[], Any]) -> Any:
+    return mock_buffered_incremental_serializer_factory()
 
 
 @pytest.fixture
@@ -211,7 +214,7 @@ def mock_datagram_protocol(mock_datagram_protocol_factory: Callable[[], Any]) ->
 
 @pytest.fixture
 def mock_stream_protocol_factory(mocker: MockerFixture) -> Callable[[], Any]:
-    return lambda: mocker.NonCallableMagicMock(spec=StreamProtocol, **{"buffered_receiver.side_effect": UnsupportedOperation})
+    return lambda: mocker.NonCallableMagicMock(spec=StreamProtocol)
 
 
 @pytest.fixture
@@ -220,15 +223,19 @@ def mock_stream_protocol(mock_stream_protocol_factory: Callable[[], Any]) -> Any
 
 
 @pytest.fixture
-def mock_buffered_stream_receiver_factory(mocker: MockerFixture) -> Callable[[], Any]:
+def mock_buffered_stream_protocol_factory(
+    mock_stream_protocol_factory: Callable[[], Any],
+    mocker: MockerFixture,
+) -> Callable[[], Any]:
     return lambda: mocker.NonCallableMagicMock(
-        spec=BufferedStreamReceiver,
+        spec=BufferedStreamProtocol,
         **{
             "create_buffer.side_effect": lambda sizehint: memoryview(bytearray(sizehint)),
+            "into_data_protocol.side_effect": mock_buffered_stream_protocol_factory,
         },
     )
 
 
 @pytest.fixture
-def mock_buffered_stream_receiver(mock_buffered_stream_receiver_factory: Callable[[], Any]) -> Any:
-    return mock_buffered_stream_receiver_factory()
+def mock_buffered_stream_protocol(mock_buffered_stream_protocol_factory: Callable[[], Any]) -> Any:
+    return mock_buffered_stream_protocol_factory()

--- a/tests/unit_test/test_async/conftest.py
+++ b/tests/unit_test/test_async/conftest.py
@@ -29,9 +29,14 @@ class FakeCancellation(BaseException):
 
 @pytest.fixture(scope="module", autouse=True)
 def __mute_socket_getaddrinfo(module_mocker: MockerFixture) -> None:
-    from socket import EAI_NONAME, gaierror
+    from socket import EAI_NONAME, gaierror, getaddrinfo
 
-    module_mocker.patch("socket.getaddrinfo", autospec=True, side_effect=gaierror(EAI_NONAME, "Name or service not known"))
+    module_mocker.patch(
+        "socket.getaddrinfo",
+        autospec=True,
+        wraps=getaddrinfo,
+        side_effect=gaierror(EAI_NONAME, "Name or service not known"),
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit_test/test_async/test_api/test_server/test_tcp.py
+++ b/tests/unit_test/test_async/test_api/test_server/test_tcp.py
@@ -32,7 +32,7 @@ class TestAsyncTCPNetworkServer:
         # Arrange
 
         # Act & Assert
-        with pytest.raises(TypeError, match=r"^Expected a StreamProtocol object, got .*$"):
+        with pytest.raises(TypeError, match=r"^Expected a StreamProtocol or a BufferedStreamProtocol object, got .*$"):
             _ = AsyncTCPNetworkServer(None, 0, mock_datagram_protocol, mock_stream_request_handler, mock_backend)
 
     async def test____dunder_init____request_handler____invalid_value(
@@ -46,27 +46,6 @@ class TestAsyncTCPNetworkServer:
         # Act & Assert
         with pytest.raises(TypeError, match=r"^Expected an AsyncStreamRequestHandler object, got .*$"):
             _ = AsyncTCPNetworkServer(None, 0, mock_stream_protocol, mock_datagram_request_handler, mock_backend)
-
-    @pytest.mark.parametrize("manual_buffer_allocation", ["unknown", ""], ids=lambda p: f"manual_buffer_allocation=={p!r}")
-    async def test____dunder_init____manual_buffer_allocation____invalid_value(
-        self,
-        manual_buffer_allocation: Any,
-        mock_stream_protocol: MagicMock,
-        mock_stream_request_handler: MagicMock,
-        mock_backend: MagicMock,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        with pytest.raises(ValueError, match=r'^"manual_buffer_allocation" must be "try", "no" or "force"$'):
-            _ = AsyncTCPNetworkServer(
-                None,
-                0,
-                mock_stream_protocol,
-                mock_stream_request_handler,
-                mock_backend,
-                manual_buffer_allocation=manual_buffer_allocation,
-            )
 
     async def test____dunder_init____backend____invalid_value(
         self,

--- a/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream/base.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream/base.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Literal
 from easynetwork.exceptions import IncrementalDeserializeError, StreamProtocolParseError
 from easynetwork.lowlevel.api_async.transports.abc import AsyncBufferedStreamReadTransport
 from easynetwork.lowlevel.typed_attr import TypedAttributeProvider
-from easynetwork.warnings import ManualBufferAllocationWarning
 
 import pytest
 
@@ -18,10 +17,6 @@ if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
     from pytest_mock import MockerFixture
-
-pytest_mark_ignore_manual_buffer_allocation_warning = pytest.mark.filterwarnings(
-    f"ignore::{ManualBufferAllocationWarning.__module__}.{ManualBufferAllocationWarning.__qualname__}",
-)
 
 
 @pytest.mark.asyncio
@@ -304,7 +299,7 @@ class BaseAsyncEndpointReceiveTests(BaseAsyncEndpointTests):
         self,
         endpoint: SupportsReceiving,
         mock_stream_transport: MagicMock,
-        mock_buffered_stream_receiver: MagicMock,
+        mock_stream_protocol: MagicMock,
     ) -> None:
         # Arrange
         mock_stream_transport.recv_into.side_effect = make_recv_into_side_effect([b"packet\n"])
@@ -314,7 +309,7 @@ class BaseAsyncEndpointReceiveTests(BaseAsyncEndpointTests):
             yield
             raise expected_error
 
-        mock_buffered_stream_receiver.build_packet_from_buffer.side_effect = side_effect
+        mock_stream_protocol.build_packet_from_buffer.side_effect = side_effect
 
         # Act
         with pytest.raises(StreamProtocolParseError) as exc_info:
@@ -360,7 +355,7 @@ class BaseAsyncEndpointReceiveTests(BaseAsyncEndpointTests):
         before_transport_reading: bool,
         endpoint: SupportsReceiving,
         mock_stream_transport: MagicMock,
-        mock_buffered_stream_receiver: MagicMock,
+        mock_stream_protocol: MagicMock,
     ) -> None:
         # Arrange
         mock_stream_transport.recv_into.side_effect = make_recv_into_side_effect([b"packet_1\n", b"packet_2\n"])
@@ -373,7 +368,7 @@ class BaseAsyncEndpointReceiveTests(BaseAsyncEndpointTests):
             yield
             raise expected_error
 
-        mock_buffered_stream_receiver.build_packet_from_buffer.side_effect = side_effect
+        mock_stream_protocol.build_packet_from_buffer.side_effect = side_effect
 
         # Act
         with pytest.raises(RuntimeError, match=r"^protocol\.build_packet_from_buffer\(\) crashed$") as exc_info:

--- a/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream/test_readonly.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream/test_readonly.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
@@ -8,13 +7,12 @@ from easynetwork.exceptions import UnsupportedOperation
 from easynetwork.lowlevel.api_async.endpoints.stream import AsyncStreamReceiverEndpoint
 from easynetwork.lowlevel.api_async.transports.abc import AsyncBufferedStreamReadTransport, AsyncStreamReadTransport
 from easynetwork.lowlevel.std_asyncio.backend import AsyncIOBackend
-from easynetwork.warnings import ManualBufferAllocationWarning
 
 import pytest
 import pytest_asyncio
 
 from ....mock_tools import make_transport_mock
-from .base import BaseAsyncEndpointReceiveTests, pytest_mark_ignore_manual_buffer_allocation_warning
+from .base import BaseAsyncEndpointReceiveTests
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
@@ -25,12 +23,7 @@ if TYPE_CHECKING:
 
 
 class TestAsyncStreamReceiverEndpoint(BaseAsyncEndpointReceiveTests):
-    @pytest.fixture(
-        params=[
-            pytest.param("recv_data", marks=pytest_mark_ignore_manual_buffer_allocation_warning),
-            pytest.param("recv_buffer"),
-        ]
-    )
+    @pytest.fixture(params=["recv_data", "recv_buffer"])
     @staticmethod
     def mock_stream_transport(
         asyncio_backend: AsyncIOBackend,
@@ -53,9 +46,10 @@ class TestAsyncStreamReceiverEndpoint(BaseAsyncEndpointReceiveTests):
         max_recv_size: int,
     ) -> AsyncIterator[AsyncStreamReceiverEndpoint[Any]]:
         endpoint: AsyncStreamReceiverEndpoint[Any]
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", ManualBufferAllocationWarning)
+        try:
             endpoint = AsyncStreamReceiverEndpoint(mock_stream_transport, mock_stream_protocol, max_recv_size)
+        except UnsupportedOperation:
+            pytest.skip("Skip unsupported combination")
         async with endpoint:
             yield endpoint
 
@@ -82,9 +76,10 @@ class TestAsyncStreamReceiverEndpoint(BaseAsyncEndpointReceiveTests):
         mock_invalid_protocol = mocker.NonCallableMagicMock(spec=object)
 
         # Act & Assert
-        with pytest.raises(TypeError, match=r"^Expected a StreamProtocol object, got .*$"):
+        with pytest.raises(TypeError, match=r"^Expected a StreamProtocol or a BufferedStreamProtocol object, got .*$"):
             _ = AsyncStreamReceiverEndpoint(mock_stream_transport, mock_invalid_protocol, max_recv_size)
 
+    @pytest.mark.parametrize("mock_stream_transport", ["recv_buffer"], indirect=True)
     @pytest.mark.parametrize("max_recv_size", [1, 2**16], ids=lambda p: f"max_recv_size=={p}")
     async def test____dunder_init____max_recv_size____valid_value(
         self,
@@ -117,25 +112,7 @@ class TestAsyncStreamReceiverEndpoint(BaseAsyncEndpointReceiveTests):
         with pytest.raises(ValueError, match=r"^'max_recv_size' must be a strictly positive integer$"):
             _ = AsyncStreamReceiverEndpoint(mock_stream_transport, mock_stream_protocol, max_recv_size)
 
-    @pytest.mark.parametrize("manual_buffer_allocation", ["unknown", ""], ids=lambda p: f"manual_buffer_allocation=={p!r}")
-    async def test____dunder_init____manual_buffer_allocation____invalid_value(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-        manual_buffer_allocation: Any,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        with pytest.raises(ValueError, match=r'^"manual_buffer_allocation" must be "try", "no" or "force"$'):
-            _ = AsyncStreamReceiverEndpoint(
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-                manual_buffer_allocation=manual_buffer_allocation,
-            )
-
+    @pytest.mark.parametrize("mock_stream_transport", ["recv_buffer"], indirect=True)
     async def test____dunder_del____ResourceWarning(
         self,
         mock_stream_transport: MagicMock,
@@ -147,7 +124,6 @@ class TestAsyncStreamReceiverEndpoint(BaseAsyncEndpointReceiveTests):
             mock_stream_transport,
             mock_stream_protocol,
             max_recv_size,
-            manual_buffer_allocation="no",
         )
 
         # Act & Assert
@@ -159,34 +135,9 @@ class TestAsyncStreamReceiverEndpoint(BaseAsyncEndpointReceiveTests):
 
         mock_stream_transport.aclose.assert_not_called()
 
-    # NOTE: The cases where recv_packet() uses transport.recv() or transport.recv_into() when manual_buffer_allocation == "try"
-    #       are implicitly tested above, because this is the default behavior.
-
-    @pytest.mark.parametrize("stream_protocol_mode", ["data"], indirect=True)
-    async def test____manual_buffer_allocation____try____but_stream_protocol_does_not_support_it(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        endpoint: AsyncStreamReceiverEndpoint[Any]
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", ManualBufferAllocationWarning)
-            endpoint = AsyncStreamReceiverEndpoint(
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-                manual_buffer_allocation="try",
-            )
-
-        await endpoint.aclose()
-
     @pytest.mark.parametrize("mock_stream_transport", ["recv_data"], indirect=True)
     @pytest.mark.parametrize("stream_protocol_mode", ["buffer"], indirect=True)
-    async def test____manual_buffer_allocation____try____but_stream_transport_does_not_support_it(
+    async def test____manual_buffer_allocation____but_stream_transport_does_not_support_it(
         self,
         mock_stream_transport: MagicMock,
         mock_stream_protocol: MagicMock,
@@ -195,101 +146,12 @@ class TestAsyncStreamReceiverEndpoint(BaseAsyncEndpointReceiveTests):
         # Arrange
 
         # Act & Assert
-        endpoint: AsyncStreamReceiverEndpoint[Any]
-        with pytest.warns(
-            ManualBufferAllocationWarning,
-            match=r'^The transport implementation .+ does not implement AsyncBufferedStreamReadTransport interface\. Consider explicitly setting the "manual_buffer_allocation" strategy to "no"\.$',
+        with pytest.raises(
+            UnsupportedOperation,
+            match=r"^The transport implementation .+ does not implement AsyncBufferedStreamReadTransport interface$",
         ):
-            endpoint = AsyncStreamReceiverEndpoint(
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-                manual_buffer_allocation="try",
-            )
-
-        await endpoint.aclose()
-
-    async def test____manual_buffer_allocation____disabled(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-        mocker: MockerFixture,
-    ) -> None:
-        # Arrange
-        mock_stream_transport.recv.side_effect = [b"packet\n"]
-
-        # Act
-        endpoint: AsyncStreamReceiverEndpoint[Any]
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", ManualBufferAllocationWarning)
-            endpoint = AsyncStreamReceiverEndpoint(
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-                manual_buffer_allocation="no",
-            )
-        packet = await endpoint.recv_packet()
-        await endpoint.aclose()
-
-        # Assert
-        mock_stream_transport.recv.assert_awaited_once_with(max_recv_size)
-        if hasattr(mock_stream_transport, "recv_into"):
-            mock_stream_transport.recv_into.assert_not_called()
-        assert packet is mocker.sentinel.packet
-
-    @pytest.mark.parametrize("stream_protocol_mode", ["data"], indirect=True)
-    async def test____manual_buffer_allocation____force____but_stream_protocol_does_not_support_it(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        with (
-            pytest.raises(UnsupportedOperation, match=r"^This protocol does not support the buffer API$") as exc_info,
-            warnings.catch_warnings(),
-        ):
-            warnings.simplefilter("error", ManualBufferAllocationWarning)
             _ = AsyncStreamReceiverEndpoint(
                 mock_stream_transport,
                 mock_stream_protocol,
                 max_recv_size,
-                manual_buffer_allocation="force",
             )
-
-        assert exc_info.value.__notes__ == [
-            'Consider setting the "manual_buffer_allocation" strategy to "no"',
-        ]
-
-    @pytest.mark.parametrize("mock_stream_transport", ["recv_data"], indirect=True)
-    @pytest.mark.parametrize("stream_protocol_mode", ["buffer"], indirect=True)
-    async def test____manual_buffer_allocation____force____but_stream_transport_does_not_support_it(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        with (
-            pytest.raises(
-                UnsupportedOperation,
-                match=r"^The transport implementation .+ does not implement AsyncBufferedStreamReadTransport interface$",
-            ) as exc_info,
-            warnings.catch_warnings(),
-        ):
-            warnings.simplefilter("error", ManualBufferAllocationWarning)
-            _ = AsyncStreamReceiverEndpoint(
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-                manual_buffer_allocation="force",
-            )
-
-        assert exc_info.value.__notes__ == [
-            'Consider setting the "manual_buffer_allocation" strategy to "no"',
-        ]

--- a/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream/test_writeonly.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream/test_writeonly.py
@@ -59,7 +59,7 @@ class TestAsyncStreamSenderEndpoint(BaseAsyncEndpointSendTests):
         mock_invalid_protocol = mocker.NonCallableMagicMock(spec=object)
 
         # Act & Assert
-        with pytest.raises(TypeError, match=r"^Expected a StreamProtocol object, got .*$"):
+        with pytest.raises(TypeError, match=r"^Expected a StreamProtocol or a BufferedStreamProtocol object, got .*$"):
             _ = AsyncStreamSenderEndpoint(mock_stream_transport, mock_invalid_protocol)
 
     async def test____dunder_del____ResourceWarning(

--- a/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/base.py
+++ b/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/base.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Literal
 from easynetwork.exceptions import IncrementalDeserializeError, StreamProtocolParseError
 from easynetwork.lowlevel.api_sync.transports.abc import BufferedStreamReadTransport
 from easynetwork.lowlevel.typed_attr import TypedAttributeProvider
-from easynetwork.warnings import ManualBufferAllocationWarning
 
 import pytest
 
@@ -19,11 +18,6 @@ if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
     from pytest_mock import MockerFixture
-
-
-pytest_mark_ignore_manual_buffer_allocation_warning = pytest.mark.filterwarnings(
-    f"ignore::{ManualBufferAllocationWarning.__module__}.{ManualBufferAllocationWarning.__qualname__}",
-)
 
 
 class BaseEndpointTests(BaseTestWithStreamProtocol):
@@ -431,7 +425,7 @@ class BaseEndpointReceiveTests(BaseEndpointTests):
         endpoint: SupportsReceiving,
         recv_timeout: float | None,
         mock_stream_transport: MagicMock,
-        mock_buffered_stream_receiver: MagicMock,
+        mock_stream_protocol: MagicMock,
     ) -> None:
         # Arrange
         mock_stream_transport.recv_into.side_effect = make_recv_into_side_effect([b"packet\n"])
@@ -441,7 +435,7 @@ class BaseEndpointReceiveTests(BaseEndpointTests):
             yield
             raise expected_error
 
-        mock_buffered_stream_receiver.build_packet_from_buffer.side_effect = side_effect
+        mock_stream_protocol.build_packet_from_buffer.side_effect = side_effect
 
         # Act
         with pytest.raises(StreamProtocolParseError) as exc_info:
@@ -489,7 +483,7 @@ class BaseEndpointReceiveTests(BaseEndpointTests):
         endpoint: SupportsReceiving,
         recv_timeout: float | None,
         mock_stream_transport: MagicMock,
-        mock_buffered_stream_receiver: MagicMock,
+        mock_stream_protocol: MagicMock,
     ) -> None:
         # Arrange
         mock_stream_transport.recv_into.side_effect = make_recv_into_side_effect([b"packet_1\n", b"packet_2\n"])
@@ -502,7 +496,7 @@ class BaseEndpointReceiveTests(BaseEndpointTests):
             yield
             raise expected_error
 
-        mock_buffered_stream_receiver.build_packet_from_buffer.side_effect = side_effect
+        mock_stream_protocol.build_packet_from_buffer.side_effect = side_effect
 
         # Act
         with pytest.raises(RuntimeError, match=r"^protocol\.build_packet_from_buffer\(\) crashed$") as exc_info:

--- a/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/test_fullduplex.py
+++ b/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/test_fullduplex.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 
-import math
-import warnings
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
 from easynetwork.exceptions import UnsupportedOperation
 from easynetwork.lowlevel.api_sync.endpoints.stream import StreamEndpoint
 from easynetwork.lowlevel.api_sync.transports.abc import BufferedStreamReadTransport, StreamTransport
-from easynetwork.warnings import ManualBufferAllocationWarning
 
 import pytest
 
 from ....mock_tools import make_transport_mock
-from .base import BaseEndpointReceiveTests, BaseEndpointSendTests, pytest_mark_ignore_manual_buffer_allocation_warning
+from .base import BaseEndpointReceiveTests, BaseEndpointSendTests
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
@@ -26,12 +23,7 @@ class BufferedStreamTransport(StreamTransport, BufferedStreamReadTransport):
 
 
 class TestStreamEndpoint(BaseEndpointSendTests, BaseEndpointReceiveTests):
-    @pytest.fixture(
-        params=[
-            pytest.param("recv_data", marks=pytest_mark_ignore_manual_buffer_allocation_warning),
-            pytest.param("recv_buffer"),
-        ]
-    )
+    @pytest.fixture(params=["recv_data", "recv_buffer"])
     @staticmethod
     def mock_stream_transport(request: pytest.FixtureRequest, mocker: MockerFixture) -> MagicMock:
         match request.param:
@@ -49,9 +41,10 @@ class TestStreamEndpoint(BaseEndpointSendTests, BaseEndpointReceiveTests):
         mock_stream_protocol: MagicMock,
         max_recv_size: int,
     ) -> Iterator[StreamEndpoint[Any, Any]]:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", ManualBufferAllocationWarning)
+        try:
             endpoint: StreamEndpoint[Any, Any] = StreamEndpoint(mock_stream_transport, mock_stream_protocol, max_recv_size)
+        except UnsupportedOperation:
+            pytest.skip("Skip unsupported combination")
         with endpoint:
             yield endpoint
 
@@ -78,9 +71,10 @@ class TestStreamEndpoint(BaseEndpointSendTests, BaseEndpointReceiveTests):
         mock_invalid_protocol = mocker.NonCallableMagicMock(spec=object)
 
         # Act & Assert
-        with pytest.raises(TypeError, match=r"^Expected a StreamProtocol object, got .*$"):
+        with pytest.raises(TypeError, match=r"^Expected a StreamProtocol or a BufferedStreamProtocol object, got .*$"):
             _ = StreamEndpoint(mock_stream_transport, mock_invalid_protocol, max_recv_size)
 
+    @pytest.mark.parametrize("mock_stream_transport", ["recv_buffer"], indirect=True)
     @pytest.mark.parametrize("max_recv_size", [1, 2**16], ids=lambda p: f"max_recv_size=={p}")
     def test____dunder_init____max_recv_size____valid_value(
         self,
@@ -111,25 +105,7 @@ class TestStreamEndpoint(BaseEndpointSendTests, BaseEndpointReceiveTests):
         with pytest.raises(ValueError, match=r"^'max_recv_size' must be a strictly positive integer$"):
             _ = StreamEndpoint(mock_stream_transport, mock_stream_protocol, max_recv_size)
 
-    @pytest.mark.parametrize("manual_buffer_allocation", ["unknown", ""], ids=lambda p: f"manual_buffer_allocation=={p!r}")
-    def test____dunder_init____manual_buffer_allocation____invalid_value(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-        manual_buffer_allocation: Any,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        with pytest.raises(ValueError, match=r'^"manual_buffer_allocation" must be "try", "no" or "force"$'):
-            _ = StreamEndpoint(
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-                manual_buffer_allocation=manual_buffer_allocation,
-            )
-
+    @pytest.mark.parametrize("mock_stream_transport", ["recv_buffer"], indirect=True)
     def test____dunder_del____ResourceWarning(
         self,
         mock_stream_transport: MagicMock,
@@ -141,7 +117,6 @@ class TestStreamEndpoint(BaseEndpointSendTests, BaseEndpointReceiveTests):
             mock_stream_transport,
             mock_stream_protocol,
             max_recv_size,
-            manual_buffer_allocation="no",
         )
 
         # Act & Assert
@@ -192,33 +167,9 @@ class TestStreamEndpoint(BaseEndpointSendTests, BaseEndpointReceiveTests):
         with pytest.raises(RuntimeError, match=r"^send_eof\(\) has been called earlier$"):
             endpoint.send_packet(mocker.sentinel.packet)
 
-    # NOTE: The cases where recv_packet() uses transport.recv() or transport.recv_into() when manual_buffer_allocation == "try"
-    #       are implicitly tested above, because this is the default behavior.
-
-    @pytest.mark.parametrize("stream_protocol_mode", ["data"], indirect=True)
-    def test____manual_buffer_allocation____try____but_stream_protocol_does_not_support_it(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", ManualBufferAllocationWarning)
-            endpoint = StreamEndpoint[Any, Any](
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-                manual_buffer_allocation="try",
-            )
-
-        endpoint.close()
-
     @pytest.mark.parametrize("mock_stream_transport", ["recv_data"], indirect=True)
     @pytest.mark.parametrize("stream_protocol_mode", ["buffer"], indirect=True)
-    def test____manual_buffer_allocation____try____but_stream_transport_does_not_support_it(
+    def test____manual_buffer_allocation____but_stream_transport_does_not_support_it(
         self,
         mock_stream_transport: MagicMock,
         mock_stream_protocol: MagicMock,
@@ -227,85 +178,8 @@ class TestStreamEndpoint(BaseEndpointSendTests, BaseEndpointReceiveTests):
         # Arrange
 
         # Act & Assert
-        with pytest.warns(
-            ManualBufferAllocationWarning,
-            match=r'^The transport implementation .+ does not implement BufferedStreamReadTransport interface\. Consider explicitly setting the "manual_buffer_allocation" strategy to "no"\.$',
+        with pytest.raises(
+            UnsupportedOperation,
+            match=r"^The transport implementation .+ does not implement BufferedStreamReadTransport interface$",
         ):
-            endpoint = StreamEndpoint[Any, Any](
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-                manual_buffer_allocation="try",
-            )
-
-        endpoint.close()
-
-    def test____manual_buffer_allocation____disabled(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-        mocker: MockerFixture,
-    ) -> None:
-        # Arrange
-        mock_stream_transport.recv.side_effect = [b"packet\n"]
-
-        # Act
-        endpoint: StreamEndpoint[Any, Any]
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", ManualBufferAllocationWarning)
-            endpoint = StreamEndpoint(mock_stream_transport, mock_stream_protocol, max_recv_size, manual_buffer_allocation="no")
-        packet = endpoint.recv_packet()
-        endpoint.close()
-
-        # Assert
-        mock_stream_transport.recv.assert_called_once_with(max_recv_size, math.inf)
-        if hasattr(mock_stream_transport, "recv_into"):
-            mock_stream_transport.recv_into.assert_not_called()
-        assert packet is mocker.sentinel.packet
-
-    @pytest.mark.parametrize("stream_protocol_mode", ["data"], indirect=True)
-    def test____manual_buffer_allocation____force____but_stream_protocol_does_not_support_it(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        with (
-            pytest.raises(UnsupportedOperation, match=r"^This protocol does not support the buffer API$") as exc_info,
-            warnings.catch_warnings(),
-        ):
-            warnings.simplefilter("error", ManualBufferAllocationWarning)
-            _ = StreamEndpoint(mock_stream_transport, mock_stream_protocol, max_recv_size, manual_buffer_allocation="force")
-
-        assert exc_info.value.__notes__ == [
-            'Consider setting the "manual_buffer_allocation" strategy to "no"',
-        ]
-
-    @pytest.mark.parametrize("mock_stream_transport", ["recv_data"], indirect=True)
-    @pytest.mark.parametrize("stream_protocol_mode", ["buffer"], indirect=True)
-    def test____manual_buffer_allocation____force____but_stream_transport_does_not_support_it(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        with (
-            pytest.raises(
-                UnsupportedOperation,
-                match=r"^The transport implementation .+ does not implement BufferedStreamReadTransport interface$",
-            ) as exc_info,
-            warnings.catch_warnings(),
-        ):
-            warnings.simplefilter("error", ManualBufferAllocationWarning)
-            _ = StreamEndpoint(mock_stream_transport, mock_stream_protocol, max_recv_size, manual_buffer_allocation="force")
-
-        assert exc_info.value.__notes__ == [
-            'Consider setting the "manual_buffer_allocation" strategy to "no"',
-        ]
+            _ = StreamEndpoint(mock_stream_transport, mock_stream_protocol, max_recv_size)

--- a/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/test_readonly.py
+++ b/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/test_readonly.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 
-import math
-import warnings
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
 from easynetwork.exceptions import UnsupportedOperation
 from easynetwork.lowlevel.api_sync.endpoints.stream import StreamReceiverEndpoint
 from easynetwork.lowlevel.api_sync.transports.abc import BufferedStreamReadTransport, StreamReadTransport
-from easynetwork.warnings import ManualBufferAllocationWarning
 
 import pytest
 
 from ....mock_tools import make_transport_mock
-from .base import BaseEndpointReceiveTests, pytest_mark_ignore_manual_buffer_allocation_warning
+from .base import BaseEndpointReceiveTests
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
@@ -22,12 +19,7 @@ if TYPE_CHECKING:
 
 
 class TestStreamReceiverEndpoint(BaseEndpointReceiveTests):
-    @pytest.fixture(
-        params=[
-            pytest.param("recv_data", marks=pytest_mark_ignore_manual_buffer_allocation_warning),
-            pytest.param("recv_buffer"),
-        ]
-    )
+    @pytest.fixture(params=["recv_data", "recv_buffer"])
     @staticmethod
     def mock_stream_transport(request: pytest.FixtureRequest, mocker: MockerFixture) -> MagicMock:
         match request.param:
@@ -45,13 +37,14 @@ class TestStreamReceiverEndpoint(BaseEndpointReceiveTests):
         mock_stream_protocol: MagicMock,
         max_recv_size: int,
     ) -> Iterator[StreamReceiverEndpoint[Any]]:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", ManualBufferAllocationWarning)
+        try:
             endpoint: StreamReceiverEndpoint[Any] = StreamReceiverEndpoint(
                 mock_stream_transport,
                 mock_stream_protocol,
                 max_recv_size,
             )
+        except UnsupportedOperation:
+            pytest.skip("Skip unsupported combination")
         with endpoint:
             yield endpoint
 
@@ -78,9 +71,10 @@ class TestStreamReceiverEndpoint(BaseEndpointReceiveTests):
         mock_invalid_protocol = mocker.NonCallableMagicMock(spec=object)
 
         # Act & Assert
-        with pytest.raises(TypeError, match=r"^Expected a StreamProtocol object, got .*$"):
+        with pytest.raises(TypeError, match=r"^Expected a StreamProtocol or a BufferedStreamProtocol object, got .*$"):
             _ = StreamReceiverEndpoint(mock_stream_transport, mock_invalid_protocol, max_recv_size)
 
+    @pytest.mark.parametrize("mock_stream_transport", ["recv_buffer"], indirect=True)
     @pytest.mark.parametrize("max_recv_size", [1, 2**16], ids=lambda p: f"max_recv_size=={p}")
     def test____dunder_init____max_recv_size____valid_value(
         self,
@@ -111,25 +105,7 @@ class TestStreamReceiverEndpoint(BaseEndpointReceiveTests):
         with pytest.raises(ValueError, match=r"^'max_recv_size' must be a strictly positive integer$"):
             _ = StreamReceiverEndpoint(mock_stream_transport, mock_stream_protocol, max_recv_size)
 
-    @pytest.mark.parametrize("manual_buffer_allocation", ["unknown", ""], ids=lambda p: f"manual_buffer_allocation=={p!r}")
-    def test____dunder_init____manual_buffer_allocation____invalid_value(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-        manual_buffer_allocation: Any,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        with pytest.raises(ValueError, match=r'^"manual_buffer_allocation" must be "try", "no" or "force"$'):
-            _ = StreamReceiverEndpoint(
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-                manual_buffer_allocation=manual_buffer_allocation,
-            )
-
+    @pytest.mark.parametrize("mock_stream_transport", ["recv_buffer"], indirect=True)
     def test____dunder_del____ResourceWarning(
         self,
         mock_stream_transport: MagicMock,
@@ -141,7 +117,6 @@ class TestStreamReceiverEndpoint(BaseEndpointReceiveTests):
             mock_stream_transport,
             mock_stream_protocol,
             max_recv_size,
-            manual_buffer_allocation="no",
         )
 
         # Act & Assert
@@ -150,33 +125,9 @@ class TestStreamReceiverEndpoint(BaseEndpointReceiveTests):
 
         mock_stream_transport.close.assert_called()
 
-    # NOTE: The cases where recv_packet() uses transport.recv() or transport.recv_into() when manual_buffer_allocation == "try"
-    #       are implicitly tested above, because this is the default behavior.
-
-    @pytest.mark.parametrize("stream_protocol_mode", ["data"], indirect=True)
-    def test____manual_buffer_allocation____try____but_stream_protocol_does_not_support_it(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", ManualBufferAllocationWarning)
-            endpoint = StreamReceiverEndpoint[Any](
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-                manual_buffer_allocation="try",
-            )
-
-        endpoint.close()
-
     @pytest.mark.parametrize("mock_stream_transport", ["recv_data"], indirect=True)
     @pytest.mark.parametrize("stream_protocol_mode", ["buffer"], indirect=True)
-    def test____manual_buffer_allocation____try____but_stream_transport_does_not_support_it(
+    def test____manual_buffer_allocation____but_stream_transport_does_not_support_it(
         self,
         mock_stream_transport: MagicMock,
         mock_stream_protocol: MagicMock,
@@ -185,100 +136,12 @@ class TestStreamReceiverEndpoint(BaseEndpointReceiveTests):
         # Arrange
 
         # Act & Assert
-        with pytest.warns(
-            ManualBufferAllocationWarning,
-            match=r'^The transport implementation .+ does not implement BufferedStreamReadTransport interface\. Consider explicitly setting the "manual_buffer_allocation" strategy to "no"\.$',
+        with pytest.raises(
+            UnsupportedOperation,
+            match=r"^The transport implementation .+ does not implement BufferedStreamReadTransport interface$",
         ):
-            endpoint = StreamReceiverEndpoint[Any](
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-                manual_buffer_allocation="try",
-            )
-
-        endpoint.close()
-
-    def test____manual_buffer_allocation____disabled(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-        mocker: MockerFixture,
-    ) -> None:
-        # Arrange
-        mock_stream_transport.recv.side_effect = [b"packet\n"]
-
-        # Act
-        endpoint: StreamReceiverEndpoint[Any]
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", ManualBufferAllocationWarning)
-            endpoint = StreamReceiverEndpoint(
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-                manual_buffer_allocation="no",
-            )
-        packet = endpoint.recv_packet()
-        endpoint.close()
-
-        # Assert
-        mock_stream_transport.recv.assert_called_once_with(max_recv_size, math.inf)
-        if hasattr(mock_stream_transport, "recv_into"):
-            mock_stream_transport.recv_into.assert_not_called()
-        assert packet is mocker.sentinel.packet
-
-    @pytest.mark.parametrize("stream_protocol_mode", ["data"], indirect=True)
-    def test____manual_buffer_allocation____force____but_stream_protocol_does_not_support_it(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        with (
-            pytest.raises(UnsupportedOperation, match=r"^This protocol does not support the buffer API$") as exc_info,
-            warnings.catch_warnings(),
-        ):
-            warnings.simplefilter("error", ManualBufferAllocationWarning)
             _ = StreamReceiverEndpoint(
                 mock_stream_transport,
                 mock_stream_protocol,
                 max_recv_size,
-                manual_buffer_allocation="force",
             )
-
-        assert exc_info.value.__notes__ == [
-            'Consider setting the "manual_buffer_allocation" strategy to "no"',
-        ]
-
-    @pytest.mark.parametrize("mock_stream_transport", ["recv_data"], indirect=True)
-    @pytest.mark.parametrize("stream_protocol_mode", ["buffer"], indirect=True)
-    def test____manual_buffer_allocation____force____but_stream_transport_does_not_support_it(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        with (
-            pytest.raises(
-                UnsupportedOperation,
-                match=r"^The transport implementation .+ does not implement BufferedStreamReadTransport interface$",
-            ) as exc_info,
-            warnings.catch_warnings(),
-        ):
-            warnings.simplefilter("error", ManualBufferAllocationWarning)
-            _ = StreamReceiverEndpoint(
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-                manual_buffer_allocation="force",
-            )
-
-        assert exc_info.value.__notes__ == [
-            'Consider setting the "manual_buffer_allocation" strategy to "no"',
-        ]

--- a/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/test_writeonly.py
+++ b/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/test_writeonly.py
@@ -53,7 +53,7 @@ class TestStreamSenderEndpoint(BaseEndpointSendTests):
         mock_invalid_protocol = mocker.NonCallableMagicMock(spec=object)
 
         # Act & Assert
-        with pytest.raises(TypeError, match=r"^Expected a StreamProtocol object, got .*$"):
+        with pytest.raises(TypeError, match=r"^Expected a StreamProtocol or a BufferedStreamProtocol object, got .*$"):
             _ = StreamSenderEndpoint(mock_stream_transport, mock_invalid_protocol)
 
     def test____dunder_del____ResourceWarning(


### PR DESCRIPTION
### What's changed
`BufferedStreamProtocol` must be used to explictly exploit `BufferedIncrementalPacketSerializer` interface

### Backward incompatible changes
- Removed `manual_buffer_allocation` parameter from existing API
- Removed `BufferedStreamReceiver` class.
- Removed `StreamProtocol.buffered_receiver()` method.