### PR TITLE
Removed `BufferedStreamReadTransport` class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,8 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+docs/source/_build/
+docs/build/
 
 # PyBuilder
 target/

--- a/benchmark_server/servers/easynetwork_tcp_echoserver.py
+++ b/benchmark_server/servers/easynetwork_tcp_echoserver.py
@@ -92,13 +92,16 @@ def create_tcp_server(
     if context_reuse:
         print("with context reuse")
 
+    serializer: BufferedIncrementalPacketSerializer[Any, Any, Any]
     protocol: StreamProtocol[Any, Any] | BufferedStreamProtocol[Any, Any, Any]
     if readline:
-        protocol = BufferedStreamProtocol(LineSerializer())
+        serializer = LineSerializer()
     else:
-        protocol = BufferedStreamProtocol(NoSerializer())
-    if not buffered:
-        protocol = protocol.into_data_protocol()
+        serializer = NoSerializer()
+    if buffered:
+        protocol = BufferedStreamProtocol(serializer)
+    else:
+        protocol = StreamProtocol(serializer)
     return StandaloneTCPNetworkServer(
         None,
         port,

--- a/docs/source/howto/advanced/buffered_serializers.rst
+++ b/docs/source/howto/advanced/buffered_serializers.rst
@@ -96,8 +96,6 @@ its :meth:`~.BufferedIncrementalPacketSerializer.create_deserializer_buffer` and
 .. note::
 
    You still need to implement :class:`.AbstractIncrementalPacketSerializer` methods.
-   Writing input directly to an external object that implements the :ref:`buffer protocol <bufferobjects>` is not supported by
-   all transport layer implementations.
 
 Let's see how we can use it for ``MyJSONSerializer`` (from :doc:`../serializers`):
 

--- a/src/easynetwork/lowlevel/api_async/transports/tls.py
+++ b/src/easynetwork/lowlevel/api_async/transports/tls.py
@@ -362,7 +362,7 @@ class _IncomingDataReader:
         self.buffer_view = memoryview(self.buffer)
 
     async def readinto(self, read_bio: MemoryBIO) -> int:
-        if nbytes := await self.transport.recv_into(buffer := self.buffer_view):
+        if (nbytes := await self.transport.recv_into(buffer := self.buffer_view)) > 0:
             return read_bio.write(buffer[:nbytes])
         read_bio.write_eof()
         return 0

--- a/src/easynetwork/lowlevel/api_async/transports/tls.py
+++ b/src/easynetwork/lowlevel/api_async/transports/tls.py
@@ -38,7 +38,7 @@ else:
 from ....exceptions import UnsupportedOperation
 from ... import _utils, constants, socket as socket_tools
 from ..backend.abc import AsyncBackend, TaskGroup
-from .abc import AsyncBufferedStreamReadTransport, AsyncListener, AsyncStreamReadTransport, AsyncStreamTransport
+from .abc import AsyncListener, AsyncStreamReadTransport, AsyncStreamTransport
 from .utils import aclose_forcefully
 
 if TYPE_CHECKING:
@@ -51,7 +51,7 @@ _T_Return = TypeVar("_T_Return")
 
 
 @dataclasses.dataclass(repr=False, eq=False, slots=True, kw_only=True)
-class AsyncTLSStreamTransport(AsyncStreamTransport, AsyncBufferedStreamReadTransport):
+class AsyncTLSStreamTransport(AsyncStreamTransport):
     """
     SSL/TLS wrapper for a continuous stream transport.
     """
@@ -66,10 +66,7 @@ class AsyncTLSStreamTransport(AsyncStreamTransport, AsyncBufferedStreamReadTrans
     __closing: bool = dataclasses.field(init=False, default=False)
 
     def __post_init__(self) -> None:
-        if isinstance(self._transport, AsyncBufferedStreamReadTransport):
-            self.__incoming_reader = _BufferedIncomingDataReader(transport=self._transport)
-        else:
-            self.__incoming_reader = _IncomingDataReader(transport=self._transport)
+        self.__incoming_reader = _IncomingDataReader(transport=self._transport)
 
     @classmethod
     async def wrap(
@@ -190,7 +187,7 @@ class AsyncTLSStreamTransport(AsyncStreamTransport, AsyncBufferedStreamReadTrans
                     return b""
             raise
 
-    @_utils.inherit_doc(AsyncBufferedStreamReadTransport)
+    @_utils.inherit_doc(AsyncStreamTransport)
     async def recv_into(self, buffer: WriteableBuffer) -> int:
         assert _ssl_module is not None, "stdlib ssl module not available"  # nosec assert_used
         nbytes = memoryview(buffer).nbytes or 1024
@@ -357,20 +354,6 @@ class _IncomingDataReader:
     transport: AsyncStreamReadTransport
     max_size: Final[int] = 256 * 1024  # 256KiB
 
-    async def readinto(self, read_bio: MemoryBIO) -> int:
-        data = await self.transport.recv(self.max_size)
-        if data:
-            return read_bio.write(data)
-        read_bio.write_eof()
-        return 0
-
-    def close(self) -> None:
-        pass
-
-
-@dataclasses.dataclass(kw_only=True, eq=False, slots=True)
-class _BufferedIncomingDataReader(_IncomingDataReader):
-    transport: AsyncBufferedStreamReadTransport
     buffer: bytearray | None = dataclasses.field(init=False)
     buffer_view: memoryview = dataclasses.field(init=False)
 
@@ -379,9 +362,7 @@ class _BufferedIncomingDataReader(_IncomingDataReader):
         self.buffer_view = memoryview(self.buffer)
 
     async def readinto(self, read_bio: MemoryBIO) -> int:
-        buffer = self.buffer_view
-        nbytes = await self.transport.recv_into(buffer)
-        if nbytes:
+        if nbytes := await self.transport.recv_into(buffer := self.buffer_view):
             return read_bio.write(buffer[:nbytes])
         read_bio.write_eof()
         return 0

--- a/src/easynetwork/lowlevel/api_sync/transports/socket.py
+++ b/src/easynetwork/lowlevel/api_sync/transports/socket.py
@@ -61,7 +61,7 @@ def _close_stream_socket(sock: socket.socket) -> None:
         sock.close()
 
 
-class SocketStreamTransport(base_selector.SelectorStreamTransport, base_selector.SelectorBufferedStreamReadTransport):
+class SocketStreamTransport(base_selector.SelectorStreamTransport):
     """
     A stream data transport implementation which wraps a stream :class:`~socket.socket`.
     """
@@ -114,7 +114,7 @@ class SocketStreamTransport(base_selector.SelectorStreamTransport, base_selector
         except (BlockingIOError, InterruptedError):
             raise base_selector.WouldBlockOnRead(self.__socket.fileno()) from None
 
-    @_utils.inherit_doc(base_selector.SelectorBufferedStreamReadTransport)
+    @_utils.inherit_doc(base_selector.SelectorStreamTransport)
     def recv_noblock_into(self, buffer: WriteableBuffer) -> int:
         try:
             return self.__socket.recv_into(buffer)
@@ -172,7 +172,7 @@ class SocketStreamTransport(base_selector.SelectorStreamTransport, base_selector
         return socket_tools._get_socket_extra(socket)
 
 
-class SSLStreamTransport(base_selector.SelectorStreamTransport, base_selector.SelectorBufferedStreamReadTransport):
+class SSLStreamTransport(base_selector.SelectorStreamTransport):
     """
     A stream data transport implementation which wraps a stream :class:`~socket.socket`.
     """
@@ -277,7 +277,7 @@ class SSLStreamTransport(base_selector.SelectorStreamTransport, base_selector.Se
         except _ssl_module.SSLZeroReturnError if _ssl_module else ():
             return b""
 
-    @_utils.inherit_doc(base_selector.SelectorBufferedStreamReadTransport)
+    @_utils.inherit_doc(base_selector.SelectorStreamTransport)
     def recv_noblock_into(self, buffer: WriteableBuffer) -> int:
         try:
             return self._try_ssl_method(self.__socket.recv_into, buffer)

--- a/src/easynetwork/lowlevel/std_asyncio/stream/socket.py
+++ b/src/easynetwork/lowlevel/std_asyncio/stream/socket.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any, final
 from ....exceptions import UnsupportedOperation
 from ... import _utils, socket as socket_tools
 from ...api_async.backend.abc import AsyncBackend
-from ...api_async.transports.abc import AsyncBufferedStreamReadTransport, AsyncStreamTransport
+from ...api_async.transports.abc import AsyncStreamTransport
 from .._asyncio_utils import add_flowcontrol_defaults
 from .._flow_control import WriteFlowControl
 
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 
 
 @final
-class AsyncioTransportStreamSocketAdapter(AsyncStreamTransport, AsyncBufferedStreamReadTransport):
+class AsyncioTransportStreamSocketAdapter(AsyncStreamTransport):
     __slots__ = (
         "__backend",
         "__transport",

--- a/src/easynetwork/protocol.py
+++ b/src/easynetwork/protocol.py
@@ -157,13 +157,6 @@ class BufferedStreamProtocol(Generic[_T_SentPacket, _T_ReceivedPacket, _T_Buffer
         self.__serializer: BufferedIncrementalPacketSerializer[Any, Any, _T_Buffer] = serializer
         self.__converter: AbstractPacketConverterComposite[_T_SentPacket, _T_ReceivedPacket, Any, Any] | None = converter
 
-    def into_data_protocol(self) -> StreamProtocol[_T_SentPacket, _T_ReceivedPacket]:
-        """
-        Returns:
-            a valid :class:`StreamProtocol` from this protocol object.
-        """
-        return StreamProtocol(self.__serializer, converter=self.__converter)
-
     def create_buffer(self, sizehint: int) -> _T_Buffer:
         """
         Called to allocate a new receive buffer.

--- a/tests/unit_test/_utils.py
+++ b/tests/unit_test/_utils.py
@@ -219,6 +219,15 @@ def make_recv_into_side_effect(to_write: bytes | list[bytes]) -> Callable[[bytea
     return recv_into_side_effect
 
 
+def make_recv_noblock_into_side_effect(to_write: bytes | list[bytes]) -> Callable[[bytearray | memoryview], int]:
+    write_in_buffer = __make_write_in_buffer_side_effect(to_write)
+
+    def recv_into_side_effect(buffer: bytearray | memoryview) -> int:
+        return write_in_buffer(buffer)
+
+    return recv_into_side_effect
+
+
 def make_async_recv_into_side_effect(to_write: bytes | list[bytes]) -> Callable[[bytearray | memoryview], Awaitable[int]]:
     write_in_buffer = __make_write_in_buffer_side_effect(to_write)
 

--- a/tests/unit_test/base.py
+++ b/tests/unit_test/base.py
@@ -164,8 +164,6 @@ class BaseTestWithStreamProtocol:
 
         mock_stream_protocol.generate_chunks.side_effect = generate_chunks_side_effect
         mock_stream_protocol.build_packet_from_chunks.side_effect = build_packet_from_chunks_side_effect
-        mock_buffered_stream_protocol.into_data_protocol.side_effect = None
-        mock_buffered_stream_protocol.into_data_protocol.return_value = mock_stream_protocol
 
         match stream_protocol_mode:
             case "data":

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -224,14 +224,12 @@ def mock_stream_protocol(mock_stream_protocol_factory: Callable[[], Any]) -> Any
 
 @pytest.fixture
 def mock_buffered_stream_protocol_factory(
-    mock_stream_protocol_factory: Callable[[], Any],
     mocker: MockerFixture,
 ) -> Callable[[], Any]:
     return lambda: mocker.NonCallableMagicMock(
         spec=BufferedStreamProtocol,
         **{
             "create_buffer.side_effect": lambda sizehint: memoryview(bytearray(sizehint)),
-            "into_data_protocol.side_effect": mock_buffered_stream_protocol_factory,
         },
     )
 

--- a/tests/unit_test/test_async/test_lowlevel_api/test_transports/test_abc.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_transports/test_abc.py
@@ -6,6 +6,8 @@ from easynetwork.lowlevel.api_async.transports.abc import AsyncStreamTransport
 
 import pytest
 
+from ...._utils import make_async_recv_into_side_effect as make_recv_into_side_effect
+
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
@@ -14,6 +16,66 @@ if TYPE_CHECKING:
 
 @pytest.mark.asyncio
 class TestAsyncStreamTransport:
+    async def test____recv____default(
+        self,
+        mock_stream_socket_adapter: MagicMock,
+        mocker: MockerFixture,
+    ) -> None:
+        # Arrange
+        mock_stream_socket_adapter.recv_into.side_effect = make_recv_into_side_effect(b"value")
+
+        # Act
+        data = await AsyncStreamTransport.recv(mock_stream_socket_adapter, 128)
+
+        # Assert
+        assert type(data) is bytes
+        assert data == b"value"
+        mock_stream_socket_adapter.recv_into.assert_awaited_once_with(mocker.ANY)
+
+    async def test____recv____null_bufsize(
+        self,
+        mock_stream_socket_adapter: MagicMock,
+    ) -> None:
+        # Arrange
+        mock_stream_socket_adapter.recv_into.side_effect = make_recv_into_side_effect(b"never")
+
+        # Act & Assert
+        data = await AsyncStreamTransport.recv(mock_stream_socket_adapter, 0)
+
+        # Assert
+        assert type(data) is bytes
+        assert len(data) == 0
+        mock_stream_socket_adapter.recv_into.assert_not_called()
+
+    async def test____recv____invalid_bufsize_value(
+        self,
+        mock_stream_socket_adapter: MagicMock,
+    ) -> None:
+        # Arrange
+        mock_stream_socket_adapter.recv_into.side_effect = make_recv_into_side_effect(b"never")
+
+        # Act & Assert
+        with pytest.raises(ValueError, match=r"^'bufsize' must be a positive or null integer$"):
+            await AsyncStreamTransport.recv(mock_stream_socket_adapter, -1)
+
+        # Assert
+        mock_stream_socket_adapter.recv_into.assert_not_called()
+
+    async def test____recv____invalid_recv_into_return_value(
+        self,
+        mock_stream_socket_adapter: MagicMock,
+        mocker: MockerFixture,
+    ) -> None:
+        # Arrange
+        mock_stream_socket_adapter.recv_into.side_effect = [-1]
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match=r"^transport\.recv_into\(\) returned a negative value$"):
+            await AsyncStreamTransport.recv(mock_stream_socket_adapter, 128)
+
+        # Assert
+        mock_stream_socket_adapter.recv_into.assert_awaited_once_with(mocker.ANY)
+
     async def test____send_all_from_iterable____concatenates_chunks_and_call_send_all(
         self,
         mock_stream_socket_adapter: MagicMock,

--- a/tests/unit_test/test_protocol.py
+++ b/tests/unit_test/test_protocol.py
@@ -486,31 +486,6 @@ class TestBufferedStreamProtocol(_BaseTestAnyStreamProtocol):
         with pytest.raises(TypeError, match=r"^Expected a converter instance, got .+$"):
             BufferedStreamProtocol(mock_incremental_serializer, mock_not_converter)
 
-    def test____into_data_protocol____create_a_new_StreamProtocol_object(
-        self,
-        protocol: BufferedStreamProtocol[Any, Any, memoryview],
-        protocol_with_converter: BufferedStreamProtocol[Any, Any, memoryview],
-        protocol_without_converter: BufferedStreamProtocol[Any, Any, memoryview],
-        mock_incremental_serializer: MagicMock,
-        mock_converter: MagicMock,
-        mocker: MockerFixture,
-    ) -> None:
-        # Arrange
-        mock_protocol_cls = mocker.patch(f"{StreamProtocol.__module__}.StreamProtocol", autospec=True, wraps=StreamProtocol)
-
-        # Act
-        new_protocol = protocol.into_data_protocol()
-
-        # Assert
-        if protocol is protocol_with_converter:
-            mock_protocol_cls.assert_called_once_with(mock_incremental_serializer, converter=mock_converter)
-        elif protocol is protocol_without_converter:
-            mock_protocol_cls.assert_called_once_with(mock_incremental_serializer, converter=None)
-        else:
-            pytest.fail(f"{protocol=!r} is ???")
-
-        assert isinstance(new_protocol, StreamProtocol)
-
     def test____create_buffer____create_deserializer_buffer(
         self,
         protocol: BufferedStreamProtocol[Any, Any, memoryview],

--- a/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/test_readonly.py
+++ b/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/test_readonly.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
-from easynetwork.exceptions import UnsupportedOperation
 from easynetwork.lowlevel.api_sync.endpoints.stream import StreamReceiverEndpoint
-from easynetwork.lowlevel.api_sync.transports.abc import BufferedStreamReadTransport, StreamReadTransport
+from easynetwork.lowlevel.api_sync.transports.abc import StreamReadTransport
 
 import pytest
 
@@ -19,16 +18,10 @@ if TYPE_CHECKING:
 
 
 class TestStreamReceiverEndpoint(BaseEndpointReceiveTests):
-    @pytest.fixture(params=["recv_data", "recv_buffer"])
+    @pytest.fixture
     @staticmethod
-    def mock_stream_transport(request: pytest.FixtureRequest, mocker: MockerFixture) -> MagicMock:
-        match request.param:
-            case "recv_data":
-                return make_transport_mock(mocker=mocker, spec=StreamReadTransport)
-            case "recv_buffer":
-                return make_transport_mock(mocker=mocker, spec=BufferedStreamReadTransport)
-            case _:
-                pytest.fail("Invalid stream transport parameter")
+    def mock_stream_transport(mocker: MockerFixture) -> MagicMock:
+        return make_transport_mock(mocker=mocker, spec=StreamReadTransport)
 
     @pytest.fixture
     @staticmethod
@@ -37,14 +30,11 @@ class TestStreamReceiverEndpoint(BaseEndpointReceiveTests):
         mock_stream_protocol: MagicMock,
         max_recv_size: int,
     ) -> Iterator[StreamReceiverEndpoint[Any]]:
-        try:
-            endpoint: StreamReceiverEndpoint[Any] = StreamReceiverEndpoint(
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-            )
-        except UnsupportedOperation:
-            pytest.skip("Skip unsupported combination")
+        endpoint: StreamReceiverEndpoint[Any] = StreamReceiverEndpoint(
+            mock_stream_transport,
+            mock_stream_protocol,
+            max_recv_size,
+        )
         with endpoint:
             yield endpoint
 
@@ -74,7 +64,6 @@ class TestStreamReceiverEndpoint(BaseEndpointReceiveTests):
         with pytest.raises(TypeError, match=r"^Expected a StreamProtocol or a BufferedStreamProtocol object, got .*$"):
             _ = StreamReceiverEndpoint(mock_stream_transport, mock_invalid_protocol, max_recv_size)
 
-    @pytest.mark.parametrize("mock_stream_transport", ["recv_buffer"], indirect=True)
     @pytest.mark.parametrize("max_recv_size", [1, 2**16], ids=lambda p: f"max_recv_size=={p}")
     def test____dunder_init____max_recv_size____valid_value(
         self,
@@ -105,7 +94,6 @@ class TestStreamReceiverEndpoint(BaseEndpointReceiveTests):
         with pytest.raises(ValueError, match=r"^'max_recv_size' must be a strictly positive integer$"):
             _ = StreamReceiverEndpoint(mock_stream_transport, mock_stream_protocol, max_recv_size)
 
-    @pytest.mark.parametrize("mock_stream_transport", ["recv_buffer"], indirect=True)
     def test____dunder_del____ResourceWarning(
         self,
         mock_stream_transport: MagicMock,
@@ -124,24 +112,3 @@ class TestStreamReceiverEndpoint(BaseEndpointReceiveTests):
             del endpoint
 
         mock_stream_transport.close.assert_called()
-
-    @pytest.mark.parametrize("mock_stream_transport", ["recv_data"], indirect=True)
-    @pytest.mark.parametrize("stream_protocol_mode", ["buffer"], indirect=True)
-    def test____manual_buffer_allocation____but_stream_transport_does_not_support_it(
-        self,
-        mock_stream_transport: MagicMock,
-        mock_stream_protocol: MagicMock,
-        max_recv_size: int,
-    ) -> None:
-        # Arrange
-
-        # Act & Assert
-        with pytest.raises(
-            UnsupportedOperation,
-            match=r"^The transport implementation .+ does not implement BufferedStreamReadTransport interface$",
-        ):
-            _ = StreamReceiverEndpoint(
-                mock_stream_transport,
-                mock_stream_protocol,
-                max_recv_size,
-            )


### PR DESCRIPTION
### What's changed
- Removed `easynetwork.lowlevel.api_async.transports.abc.AsyncBufferedStreamReadTransport`
  - `AsyncStreamReadTransport` now have `recv_into()` abstract method
  - `AsyncStreamReadTransport.recv()` now have a default implementation that uses `recv_into()`
- Removed `easynetwork.lowlevel.api_sync.transports.abc.BufferedStreamReadTransport`
  - `StreamReadTransport` now have `recv_into()` abstract method
  - `StreamReadTransport.recv()` now have a default implementation that uses `recv_into()`
- Removed `easynetwork.lowlevel.api_sync.transports.base_selector.SelectorBufferedStreamReadTransport`
  - `SelectorStreamReadTransport` now have `recv_noblock_into()` abstract method
  - `SelectorStreamReadTransport.recv_noblock()` now have a default implementation that uses `recv_noblock_into()`