### PR TITLE
TLS transport: Fixed SSL object consistency errors when sending data and closing the object

### DIFF
--- a/src/easynetwork/lowlevel/api_async/endpoints/stream.py
+++ b/src/easynetwork/lowlevel/api_async/endpoints/stream.py
@@ -273,8 +273,9 @@ class AsyncStreamEndpoint(AsyncBaseTransport, Generic[_T_SentPacket, _T_Received
         """
         Closes the endpoint.
         """
-        await self.__transport.aclose()
-        self.__receiver.clear()
+        with self.__send_guard:
+            await self.__transport.aclose()
+            self.__receiver.clear()
 
     async def send_packet(self, packet: _T_SentPacket) -> None:
         """

--- a/src/easynetwork/lowlevel/api_async/servers/stream.py
+++ b/src/easynetwork/lowlevel/api_async/servers/stream.py
@@ -78,8 +78,9 @@ class Client(AsyncBaseTransport, Generic[_T_Response]):
         """
         Closes the endpoint.
         """
-        await self.__transport.aclose()
-        await self.__exit_stack.aclose()
+        with self.__send_guard:
+            await self.__transport.aclose()
+            await self.__exit_stack.aclose()
 
     async def send_packet(self, packet: _T_Response) -> None:
         """

--- a/src/easynetwork/lowlevel/api_async/transports/tls.py
+++ b/src/easynetwork/lowlevel/api_async/transports/tls.py
@@ -24,7 +24,8 @@ import errno
 import functools
 import logging
 import warnings
-from collections.abc import Callable, Coroutine, Mapping
+from collections import deque
+from collections.abc import Callable, Coroutine, Iterable, Mapping
 from typing import TYPE_CHECKING, Any, Final, NoReturn, Self, TypeVar, TypeVarTuple
 
 try:
@@ -64,6 +65,7 @@ class AsyncTLSStreamTransport(AsyncStreamTransport):
     _write_bio: MemoryBIO
     __incoming_reader: _IncomingDataReader = dataclasses.field(init=False)
     __closing: bool = dataclasses.field(init=False, default=False)
+    __data_to_send: deque[memoryview] = dataclasses.field(init=False, default_factory=deque)
 
     def __post_init__(self) -> None:
         self.__incoming_reader = _IncomingDataReader(transport=self._transport)
@@ -203,11 +205,34 @@ class AsyncTLSStreamTransport(AsyncStreamTransport):
 
     @_utils.inherit_doc(AsyncStreamTransport)
     async def send_all(self, data: bytes | bytearray | memoryview) -> None:
+        self.__data_to_send.append(memoryview(data))
+        del data
+        return await self.__flush_data_to_send()
+
+    @_utils.inherit_doc(AsyncStreamTransport)
+    async def send_all_from_iterable(self, iterable_of_data: Iterable[bytes | bytearray | memoryview]) -> None:
+        self.__data_to_send.extend(map(memoryview, iterable_of_data))
+        del iterable_of_data
+        return await self.__flush_data_to_send()
+
+    async def __flush_data_to_send(self) -> None:
         assert _ssl_module is not None, "stdlib ssl module not available"  # nosec assert_used
         try:
-            await self._retry_ssl_method(self._ssl_object.write, data)
+            await self._retry_ssl_method(self.__write_all_to_ssl_object, self._ssl_object, self.__data_to_send)
         except _ssl_module.SSLZeroReturnError as exc:
             raise _utils.error_from_errno(errno.ECONNRESET) from exc
+
+    @staticmethod
+    def __write_all_to_ssl_object(ssl_object: SSLObject, write_backlog: deque[memoryview]) -> None:
+        while write_backlog:
+            data = write_backlog[0]
+            if data.itemsize != 1:
+                write_backlog[0] = data = data.cast("B")
+            sent = ssl_object.write(data)
+            if sent < len(data):
+                write_backlog[0] = data[sent:]
+            else:
+                del write_backlog[0]
 
     @_utils.inherit_doc(AsyncStreamTransport)
     async def send_eof(self) -> None:

--- a/src/easynetwork/lowlevel/api_async/transports/tls.py
+++ b/src/easynetwork/lowlevel/api_async/transports/tls.py
@@ -156,6 +156,7 @@ class AsyncTLSStreamTransport(AsyncStreamTransport):
     async def aclose(self) -> None:
         with contextlib.ExitStack() as stack:
             stack.callback(self.__incoming_reader.close)
+            stack.callback(self.__data_to_send.clear)
 
             self.__closing = True
             if self._standard_compatible:

--- a/src/easynetwork/servers/async_tcp.py
+++ b/src/easynetwork/servers/async_tcp.py
@@ -38,6 +38,7 @@ from ..lowlevel.socket import (
     ISocket,
     SocketAddress,
     SocketProxy,
+    TLSAttribute,
     enable_socket_linger,
     new_socket_address,
     set_tcp_keepalive,
@@ -405,7 +406,12 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_T_Request, _T_R
             client_exit_stack.enter_context(self.__suppress_and_log_remaining_exception(client_address=client_address))
             # If the socket was not closed gracefully, (i.e. client.aclose() failed )
             # tell the OS to immediately abort the connection when calling socket.socket.close()
-            client_exit_stack.callback(self.__set_socket_linger_if_not_closed, lowlevel_client.extra(INETSocketAttribute.socket))
+            # NOTE: Do not set this option if SSL/TLS is enabled
+            if lowlevel_client.extra(TLSAttribute.sslcontext, None) is None:
+                client_exit_stack.callback(
+                    self.__set_socket_linger_if_not_closed,
+                    lowlevel_client.extra(INETSocketAttribute.socket),
+                )
 
             logger: logging.Logger = self.__logger
             client = _ConnectedClientAPI(client_address, lowlevel_client)

--- a/src/easynetwork/servers/async_tcp.py
+++ b/src/easynetwork/servers/async_tcp.py
@@ -412,6 +412,9 @@ class AsyncTCPNetworkServer(AbstractAsyncNetworkServer, Generic[_T_Request, _T_R
                     self.__set_socket_linger_if_not_closed,
                     lowlevel_client.extra(INETSocketAttribute.socket),
                 )
+            elif lowlevel_client.extra(TLSAttribute.standard_compatible, False):
+                # We expect a TLS close handshake, so we must (try to) properly close the transport before
+                await client_exit_stack.enter_async_context(contextlib.aclosing(lowlevel_client))
 
             logger: logging.Logger = self.__logger
             client = _ConnectedClientAPI(client_address, lowlevel_client)

--- a/tests/unit_test/test_async/test_lowlevel_api/test_transports/test_tls.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_transports/test_tls.py
@@ -740,7 +740,7 @@ class TestAsyncTLSStreamTransport:
 
         mock_ssl_object.write.assert_not_called()
         mock_tls_transport_retry.assert_not_awaited()
-        assert tls_transport._test__data_queue() == []
+        assert len(tls_transport._data_deque) == 0
 
     @pytest.mark.usefixtures("mock_tls_transport_retry")
     async def test____send_all_from_iterable____default(
@@ -801,7 +801,7 @@ class TestAsyncTLSStreamTransport:
 
         mock_ssl_object.write.assert_not_called()
         mock_tls_transport_retry.assert_not_awaited()
-        assert tls_transport._test__data_queue() == []
+        assert len(tls_transport._data_deque) == 0
 
     async def test____send_eof____default(
         self,

--- a/tests/unit_test/test_async/test_lowlevel_api/test_transports/test_tls.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_transports/test_tls.py
@@ -102,8 +102,12 @@ class TestAsyncTLSStreamTransport:
     @pytest.fixture
     @staticmethod
     def mock_tls_transport_retry(mocker: MockerFixture) -> AsyncMock:
-        side_effect: Callable[..., Any] = lambda ssl_object_method, *args: ssl_object_method(*args)
-        return mocker.patch.object(AsyncTLSStreamTransport, "_retry_ssl_method", side_effect=side_effect)
+        return mocker.patch.object(
+            AsyncTLSStreamTransport,
+            "_retry_ssl_method",
+            autospec=True,
+            wraps=AsyncTLSStreamTransport._retry_ssl_method,
+        )
 
     async def test____wrap____default(
         self,
@@ -135,7 +139,7 @@ class TestAsyncTLSStreamTransport:
             server_hostname="server_hostname",
             session=None,
         )
-        mock_tls_transport_retry.assert_awaited_once_with(mock_ssl_object.do_handshake)
+        mock_tls_transport_retry.assert_awaited_once_with(tls_transport, mock_ssl_object.do_handshake)
         assert mock_ssl_object.mock_calls == [mocker.call.do_handshake(), mocker.call.getpeercert()]
         ## Attributes
         assert tls_transport._shutdown_timeout == DEFAULT_SSL_SHUTDOWN_TIMEOUT
@@ -199,7 +203,7 @@ class TestAsyncTLSStreamTransport:
             server_hostname=server_hostname,
             session=session,
         )
-        mock_tls_transport_retry.assert_awaited_once_with(mock_ssl_object.do_handshake)
+        mock_tls_transport_retry.assert_awaited_once_with(tls_transport, mock_ssl_object.do_handshake)
         assert mock_ssl_object.mock_calls == [mocker.call.do_handshake(), mocker.call.getpeercert()]
         assert mock_wrapped_transport.mock_calls == [mocker.call.backend()]
         ## Attributes
@@ -257,7 +261,7 @@ class TestAsyncTLSStreamTransport:
         mock_ssl_object: MagicMock,
     ) -> None:
         # Arrange
-        async def retry_side_effect(ssl_object_method: Callable[..., Any], *args: Any) -> Any:
+        async def retry_side_effect(self: AsyncTLSStreamTransport, ssl_object_method: Callable[..., Any], *args: Any) -> Any:
             await asyncio.sleep(5)
             return ssl_object_method(*args)
 
@@ -325,7 +329,6 @@ class TestAsyncTLSStreamTransport:
     async def test____aclose____close_transport(
         self,
         tls_transport: AsyncTLSStreamTransport,
-        mock_tls_transport_retry: AsyncMock,
         mock_wrapped_transport: MagicMock,
         mock_ssl_object: MagicMock,
         standard_compatible: bool,
@@ -341,22 +344,19 @@ class TestAsyncTLSStreamTransport:
         # Assert
         assert tls_transport.is_closing()
         if standard_compatible:
-            mock_tls_transport_retry.assert_awaited_once_with(mock_ssl_object.unwrap)
             mock_ssl_object.unwrap.assert_called_once_with()
             assert read_bio.eof
             assert write_bio.eof
         else:
-            mock_tls_transport_retry.assert_not_called()
             mock_ssl_object.unwrap.assert_not_called()
             assert not read_bio.eof
             assert not write_bio.eof
         mock_wrapped_transport.aclose.assert_awaited_once_with()
 
     @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
-    async def test____aclose____indempotent(
+    async def test____aclose____idempotent(
         self,
         tls_transport: AsyncTLSStreamTransport,
-        mock_tls_transport_retry: AsyncMock,
         mock_wrapped_transport: MagicMock,
         mock_ssl_object: MagicMock,
         standard_compatible: bool,
@@ -373,12 +373,10 @@ class TestAsyncTLSStreamTransport:
 
         # Assert
         if standard_compatible:
-            mock_tls_transport_retry.assert_awaited_once_with(mock_ssl_object.unwrap)
             mock_ssl_object.unwrap.assert_called_once_with()
             assert read_bio.eof
             assert write_bio.eof
         else:
-            mock_tls_transport_retry.assert_not_called()
             mock_ssl_object.unwrap.assert_not_called()
             assert not read_bio.eof
             assert not write_bio.eof
@@ -396,7 +394,7 @@ class TestAsyncTLSStreamTransport:
         write_bio: ssl.MemoryBIO,
     ) -> None:
         # Arrange
-        async def retry_side_effect(ssl_object_method: Callable[..., Any], *args: Any) -> Any:
+        async def retry_side_effect(self: AsyncTLSStreamTransport, ssl_object_method: Callable[..., Any], *args: Any) -> Any:
             await asyncio.sleep(5)
             return ssl_object_method(*args)
 
@@ -406,7 +404,7 @@ class TestAsyncTLSStreamTransport:
         await tls_transport.aclose()
 
         # Assert
-        mock_tls_transport_retry.assert_awaited_once_with(mock_ssl_object.unwrap)
+        mock_tls_transport_retry.assert_awaited_once_with(tls_transport, mock_ssl_object.unwrap)
         assert not read_bio.eof
         assert not write_bio.eof
         mock_wrapped_transport.aclose.assert_awaited_once_with()
@@ -422,7 +420,7 @@ class TestAsyncTLSStreamTransport:
         write_bio: ssl.MemoryBIO,
     ) -> None:
         # Arrange
-        async def retry_side_effect(ssl_object_method: Callable[..., Any], *args: Any) -> Any:
+        async def retry_side_effect(self: AsyncTLSStreamTransport, ssl_object_method: Callable[..., Any], *args: Any) -> Any:
             try:
                 return ssl_object_method(*args)
             except ssl.SSLError:
@@ -437,7 +435,7 @@ class TestAsyncTLSStreamTransport:
         await tls_transport.aclose()
 
         # Assert
-        mock_tls_transport_retry.assert_awaited_once_with(mock_ssl_object.unwrap)
+        mock_tls_transport_retry.assert_awaited_once_with(tls_transport, mock_ssl_object.unwrap)
         assert read_bio.eof
         assert write_bio.eof
         mock_wrapped_transport.aclose.assert_awaited_once_with()
@@ -456,7 +454,7 @@ class TestAsyncTLSStreamTransport:
 
         # Assert
         assert data == b"decrypted-data"
-        mock_tls_transport_retry.assert_awaited_once_with(mock_ssl_object.read, 123456)
+        mock_tls_transport_retry.assert_awaited_once_with(tls_transport, mock_ssl_object.read, 123456)
         mock_ssl_object.read.assert_called_once_with(123456)
 
     async def test____recv____null_buffer(
@@ -473,7 +471,7 @@ class TestAsyncTLSStreamTransport:
 
         # Assert
         assert data == b""
-        mock_tls_transport_retry.assert_awaited_once_with(mock_ssl_object.read, 0)
+        mock_tls_transport_retry.assert_awaited_once_with(tls_transport, mock_ssl_object.read, 0)
         mock_ssl_object.read.assert_called_once_with(0)
 
     @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
@@ -540,7 +538,7 @@ class TestAsyncTLSStreamTransport:
 
         # Assert
         assert nbytes == 42
-        mock_tls_transport_retry.assert_awaited_once_with(mock_ssl_object.read, 1234, buffer)
+        mock_tls_transport_retry.assert_awaited_once_with(tls_transport, mock_ssl_object.read, 1234, buffer)
         mock_ssl_object.read.assert_called_once_with(1234, buffer)
 
     async def test____recv_into____null_buffer(
@@ -558,7 +556,7 @@ class TestAsyncTLSStreamTransport:
 
         # Assert
         assert nbytes == 0
-        mock_tls_transport_retry.assert_awaited_once_with(mock_ssl_object.read, 1024, buffer)
+        mock_tls_transport_retry.assert_awaited_once_with(tls_transport, mock_ssl_object.read, 1024, buffer)
         mock_ssl_object.read.assert_called_once_with(1024, buffer)
 
     @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
@@ -728,17 +726,20 @@ class TestAsyncTLSStreamTransport:
     async def test____send_all____closed_transport(
         self,
         tls_transport: AsyncTLSStreamTransport,
+        mock_tls_transport_retry: AsyncMock,
         mock_ssl_object: MagicMock,
     ) -> None:
         # Arrange
         mock_ssl_object.unwrap.return_value = None
         await tls_transport.aclose()
+        mock_tls_transport_retry.reset_mock()
 
         # Act & Assert
         with pytest.raises(ConnectionAbortedError):
             await tls_transport.send_all(b"decrypted-data")
 
         mock_ssl_object.write.assert_not_called()
+        mock_tls_transport_retry.assert_not_awaited()
         assert tls_transport._test__data_queue() == []
 
     @pytest.mark.usefixtures("mock_tls_transport_retry")
@@ -786,17 +787,20 @@ class TestAsyncTLSStreamTransport:
     async def test____send_all_from_iterable____closed_transport(
         self,
         tls_transport: AsyncTLSStreamTransport,
+        mock_tls_transport_retry: AsyncMock,
         mock_ssl_object: MagicMock,
     ) -> None:
         # Arrange
         mock_ssl_object.unwrap.return_value = None
         await tls_transport.aclose()
+        mock_tls_transport_retry.reset_mock()
 
         # Act & Assert
         with pytest.raises(ConnectionAbortedError):
             await tls_transport.send_all_from_iterable([b"decrypted-data-1", b"decrypted-data-2"])
 
         mock_ssl_object.write.assert_not_called()
+        mock_tls_transport_retry.assert_not_awaited()
         assert tls_transport._test__data_queue() == []
 
     async def test____send_eof____default(
@@ -991,24 +995,6 @@ class TestAsyncTLSStreamTransport:
         assert ssl_object_method.call_count == 1
         assert read_bio.eof
         assert write_bio.eof
-
-    @pytest.mark.parametrize("standard_compatible", [False], ids=lambda p: f"standard_compatible=={p}")
-    async def test____retry____closed_transport(
-        self,
-        tls_transport: AsyncTLSStreamTransport,
-        mock_wrapped_transport: MagicMock,
-        mocker: MockerFixture,
-    ) -> None:
-        # Arrange
-        mock_wrapped_transport.send_all.return_value = None
-        ssl_object_method = mocker.stub()
-        await tls_transport.aclose()
-
-        # Act & Assert
-        with pytest.raises(ConnectionAbortedError):
-            await tls_transport._retry_ssl_method(ssl_object_method)
-
-        ssl_object_method.assert_not_called()
 
     async def test____get_backend____returns_inner_transport_backend(
         self,


### PR DESCRIPTION
- Fixed `send_all()` ignoring number of data written to SSL object
- Erase SSL errors raised by `ssl_object.shutdown()`
- Fix double-close issue