### PR TITLE
Low-level API: transports' `send_all_from_iterable()` method are more efficient

### DIFF
--- a/src/easynetwork/lowlevel/api_async/transports/abc.py
+++ b/src/easynetwork/lowlevel/api_async/transports/abc.py
@@ -173,7 +173,7 @@ class AsyncStreamWriteTransport(AsyncBaseTransport):
         Parameters:
             iterable_of_data: An :term:`iterable` yielding the bytes to send.
         """
-        for data in iterable_of_data:
+        for data in list(iterable_of_data):
             await self.send_all(data)
 
 

--- a/src/easynetwork/lowlevel/api_sync/transports/abc.py
+++ b/src/easynetwork/lowlevel/api_sync/transports/abc.py
@@ -202,7 +202,7 @@ class StreamWriteTransport(BaseTransport):
             ValueError: Negative `timeout`.
             TimeoutError: Operation timed out.
         """
-        for data in iterable_of_data:
+        for data in list(iterable_of_data):
             with _utils.ElapsedTime() as elapsed:
                 self.send_all(data, timeout)
             timeout = elapsed.recompute_timeout(timeout)

--- a/src/easynetwork/lowlevel/api_sync/transports/socket.py
+++ b/src/easynetwork/lowlevel/api_sync/transports/socket.py
@@ -130,7 +130,12 @@ class SocketStreamTransport(base_selector.SelectorStreamTransport):
 
     @_utils.inherit_doc(base_selector.SelectorStreamTransport)
     def send_all_from_iterable(self, iterable_of_data: Iterable[bytes | bytearray | memoryview], timeout: float) -> None:
-        if constants.SC_IOV_MAX <= 0 or not _utils.supports_socket_sendmsg(self.__socket):
+        if constants.SC_IOV_MAX <= 0:
+            return super().send_all_from_iterable(iterable_of_data, timeout)
+
+        socket = self.__socket
+        socket_fileno = self.__socket.fileno
+        if not _utils.supports_socket_sendmsg(socket):
             return super().send_all_from_iterable(iterable_of_data, timeout)
 
         buffers: deque[memoryview] = deque(map(memoryview, iterable_of_data))
@@ -138,9 +143,9 @@ class SocketStreamTransport(base_selector.SelectorStreamTransport):
 
         def try_sendmsg() -> int:
             try:
-                return self.__socket.sendmsg(itertools.islice(buffers, constants.SC_IOV_MAX))
+                return socket.sendmsg(itertools.islice(buffers, constants.SC_IOV_MAX))
             except (BlockingIOError, InterruptedError):
-                raise base_selector.WouldBlockOnWrite(self.__socket.fileno()) from None
+                raise base_selector.WouldBlockOnWrite(socket_fileno()) from None
 
         while buffers:
             sent, timeout = self._retry(try_sendmsg, timeout)

--- a/tests/unit_test/base.py
+++ b/tests/unit_test/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from socket import AF_INET, AF_INET6, socket as Socket
+from socket import AF_INET, AF_INET6
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -101,14 +101,6 @@ class MixinTestSocketSendMSG:
             value = 1024
         monkeypatch.setattr("easynetwork.lowlevel.constants.SC_IOV_MAX", value)
         return value
-
-    @pytest.fixture(autouse=True)
-    @staticmethod
-    def supports_socket_sendmsg(mocker: MockerFixture) -> None:
-        def supports_socket_sendmsg(sock: Socket) -> bool:
-            return hasattr(sock, "sendmsg")
-
-        mocker.patch("easynetwork.lowlevel._utils.supports_socket_sendmsg", supports_socket_sendmsg)
 
 
 class BaseTestWithStreamProtocol:


### PR DESCRIPTION
### What's changed
#### Asynchronous API
- `AsyncStreamWriteTransport`: Default implementation of `send_all_from_iterable()` consumes the iterable before trying to call `send_all()`

#### Synchronous API
- `StreamWriteTransport`: Default implementation of `send_all_from_iterable()` consumes the iterable before trying to call `send_all()`
- `SocketStreamTransport.send_all_from_iterable()`: Code cleanup
- `SSLStreamTransport`: Override `send_all_from_iterable()` to concatenate the given data and call `send_all()` once.