### PR TITLE
Servers: Common implementation for both TCP and UDP servers

### DIFF
--- a/docs/source/_extensions/sphinx_easynetwork.py
+++ b/docs/source/_extensions/sphinx_easynetwork.py
@@ -3,32 +3,40 @@ Changelog:
 
 v0.1.0: Initial
 v0.1.1: Fix base is not replaced if the class is generic.
-v0.2.0 (current): Log when an object does not have a docstring.
+v0.2.0: Log when an object does not have a docstring.
+v0.2.1 (current): Add base class to replace.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, get_origin
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, get_args, get_origin
 
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
-from easynetwork.servers._base import BaseStandaloneNetworkServerImpl
-from easynetwork.servers.abc import AbstractNetworkServer
+from easynetwork.servers._base import BaseAsyncNetworkServerImpl, BaseStandaloneNetworkServerImpl
+from easynetwork.servers.abc import AbstractAsyncNetworkServer, AbstractNetworkServer
 
 logger = logging.getLogger(__name__)
 
 
-def _replace_base_in_place(klass: type, bases: list[type], base_to_replace: type, base_to_set_instead: type) -> None:
+def _replace_base_in_place(
+    klass: type,
+    bases: list[type],
+    base_to_replace: type,
+    base_to_set_instead: Callable[[tuple[Any, ...]], Any],
+) -> None:
     if issubclass(klass, base_to_replace):
         for index, base in enumerate(bases):
-            if get_origin(base) is base_to_replace:
-                bases[index] = base_to_set_instead
+            if base is base_to_replace or get_origin(base) is base_to_replace:
+                bases[index] = base_to_set_instead(get_args(base))
 
 
 def autodoc_process_bases(app: Sphinx, name: str, obj: type, options: dict[str, Any], bases: list[type]) -> None:
-    _replace_base_in_place(obj, bases, BaseStandaloneNetworkServerImpl, AbstractNetworkServer)
+    _replace_base_in_place(obj, bases, BaseAsyncNetworkServerImpl, lambda _: AbstractAsyncNetworkServer)
+    _replace_base_in_place(obj, bases, BaseStandaloneNetworkServerImpl, lambda _: AbstractNetworkServer)
 
 
 def _is_magic_method(name: str) -> bool:
@@ -47,7 +55,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.connect("autodoc-process-docstring", autodoc_process_docstring)
 
     return {
-        "version": "0.2.0",
+        "version": "0.2.1",
         "parallel_read_safe": True,
         "parallel_write_safe": True,
     }

--- a/docs/source/_include/examples/howto/tcp_servers/background_server.py
+++ b/docs/source/_include/examples/howto/tcp_servers/background_server.py
@@ -63,6 +63,7 @@ async def main() -> None:
         await client(host, port, "Hello world 3")
 
         await server.shutdown()
+        await server_task
 
 
 if __name__ == "__main__":

--- a/docs/source/_include/examples/howto/tcp_servers/background_server_ssl.py
+++ b/docs/source/_include/examples/howto/tcp_servers/background_server_ssl.py
@@ -71,6 +71,7 @@ async def main() -> None:
         await client(host, port, "Hello world 3")
 
         await server.shutdown()
+        await server_task
 
 
 if __name__ == "__main__":

--- a/docs/source/_include/examples/howto/udp_servers/background_server.py
+++ b/docs/source/_include/examples/howto/udp_servers/background_server.py
@@ -60,6 +60,7 @@ async def main() -> None:
         await client(host, port, "Hello world 3")
 
         await server.shutdown()
+        await server_task
 
 
 if __name__ == "__main__":

--- a/src/easynetwork/lowlevel/_utils.py
+++ b/src/easynetwork/lowlevel/_utils.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 __all__ = [
     "ElapsedTime",
+    "Flag",
     "WarnCallback",
     "adjust_leftover_buffer",
     "check_real_socket_state",
@@ -393,6 +394,22 @@ class WarnCallback(Protocol):
         stacklevel: int = 1,
         source: Any | None = None,
     ) -> None: ...
+
+
+class Flag:
+    __slots__ = ("__value", "__weakref__")
+
+    def __init__(self) -> None:
+        self.__value: bool = False
+
+    def is_set(self) -> bool:
+        return self.__value
+
+    def set(self) -> None:
+        self.__value = True
+
+    def clear(self) -> None:
+        self.__value = False
 
 
 class ElapsedTime:

--- a/src/easynetwork/servers/_base.py
+++ b/src/easynetwork/servers/_base.py
@@ -16,25 +16,42 @@
 
 from __future__ import annotations
 
-__all__ = ["BaseStandaloneNetworkServerImpl"]
+__all__ = ["BaseAsyncNetworkServerImpl", "BaseStandaloneNetworkServerImpl"]
 
 import concurrent.futures
 import contextlib
+import dataclasses
+import logging
 import threading as _threading
-from collections.abc import Callable, Mapping, Sequence
-from typing import Any, Generic, TypeVar
+from abc import abstractmethod
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from types import TracebackType
+from typing import Any, Generic, NoReturn, Protocol, Self, TypeVar
 
 from ..exceptions import ServerAlreadyRunning, ServerClosedError
 from ..lowlevel import _utils
 from ..lowlevel._lock import ForkSafeLock
-from ..lowlevel.api_async.backend.abc import AsyncBackend, ThreadsPortal
+from ..lowlevel.api_async.backend.abc import AsyncBackend, CancelScope, Task, TaskGroup, ThreadsPortal
 from ..lowlevel.api_async.backend.utils import BuiltinAsyncBackendLiteral, ensure_backend
-from ..lowlevel.socket import SocketAddress
 from .abc import AbstractAsyncNetworkServer, AbstractNetworkServer, SupportsEventSet
 
+
+class _SupportsAclose(Protocol):
+    def is_closing(self) -> bool: ...
+    def aclose(self) -> Awaitable[object]: ...
+
+
+_T_Address = TypeVar("_T_Address")
 _T_Return = TypeVar("_T_Return")
 _T_Default = TypeVar("_T_Default")
 _T_AsyncServer = TypeVar("_T_AsyncServer", bound=AbstractAsyncNetworkServer)
+
+
+##############################################################################################################
+#
+# BLOCKING SERVER
+#
+##############################################################################################################
 
 
 class BaseStandaloneNetworkServerImpl(AbstractNetworkServer, Generic[_T_AsyncServer]):
@@ -188,6 +205,250 @@ class BaseStandaloneNetworkServerImpl(AbstractNetworkServer, Generic[_T_AsyncSer
 
             backend.bootstrap(serve_forever, runner_options=runner_options)
 
-    @_utils.inherit_doc(AbstractNetworkServer)
-    def get_addresses(self) -> Sequence[SocketAddress]:
-        return self._run_sync_or(lambda portal, server: portal.run_sync(server.get_addresses), ())
+
+_T_LowLevelServer = TypeVar("_T_LowLevelServer", bound=_SupportsAclose)
+
+
+##############################################################################################################
+#
+# ASYNCHRONOUS SERVER
+#
+##############################################################################################################
+
+
+@dataclasses.dataclass(repr=False, eq=False, frozen=True, slots=True)
+class _BindServer(contextlib.AbstractContextManager[None]):
+    attach: Callable[[], None]
+    detach: Callable[[], None]
+
+    def __enter__(self) -> None:
+        self.attach()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.detach()
+
+
+class BaseAsyncNetworkServerImpl(AbstractAsyncNetworkServer, Generic[_T_LowLevelServer, _T_Address]):
+    """
+    An asynchronous network server for TCP connections.
+    """
+
+    __slots__ = (
+        "__backend",
+        "__servers",
+        "__servers_factory_cb",
+        "__servers_factory_scope",
+        "__initialize_service_cb",
+        "__lowlevel_serve_cb",
+        "__server_activation_lock",
+        "__server_close_lock",
+        "__server_close_guard",
+        "__is_shutdown",
+        "__server_tasks",
+        "__server_run_scope",
+        "__active_tasks",
+        "__logger",
+    )
+
+    def __init__(
+        self,
+        *,
+        backend: AsyncBackend | BuiltinAsyncBackendLiteral | None,
+        servers_factory: Callable[[Self], Awaitable[Sequence[_T_LowLevelServer]]],
+        initialize_service: Callable[[Self, contextlib.AsyncExitStack], Awaitable[None]],
+        lowlevel_serve: Callable[[Self, _T_LowLevelServer, TaskGroup], Awaitable[NoReturn]],
+        logger: logging.Logger,
+    ) -> None:
+        """
+        Parameters:
+            backend: The :term:`asynchronous backend interface` to use.
+        """
+        super().__init__()
+
+        backend = ensure_backend(backend)
+
+        self.__backend: AsyncBackend = backend
+        self.__servers_factory_cb: Callable[[Self], Awaitable[Sequence[_T_LowLevelServer]]] | None = servers_factory
+        self.__initialize_service_cb: Callable[[Self, contextlib.AsyncExitStack], Awaitable[None]] = initialize_service
+        self.__lowlevel_serve_cb: Callable[[Self, _T_LowLevelServer, TaskGroup], Awaitable[NoReturn]] = lowlevel_serve
+
+        self.__servers_factory_scope: CancelScope | None = None
+        self.__server_run_scope: CancelScope | None = None
+        self.__server_activation_lock = backend.create_lock()
+        self.__server_close_lock = backend.create_lock()
+        self.__server_close_guard = _utils.ResourceGuard("Cannot close server during serve_forever() setup.")
+
+        self.__servers: list[_T_LowLevelServer] = []
+        self.__is_shutdown = backend.create_event()
+        self.__is_shutdown.set()
+        self.__server_tasks: list[Task[NoReturn]] = []
+        self.__logger: logging.Logger = logger
+        self.__active_tasks: int = 0
+
+    @_utils.inherit_doc(AbstractAsyncNetworkServer)
+    def is_serving(self) -> bool:
+        return bool(self.__server_tasks) and all(not t.done() for t in self.__server_tasks) and self.is_listening()
+
+    @_utils.inherit_doc(AbstractAsyncNetworkServer)
+    def is_listening(self) -> bool:
+        return bool(self.__servers) and all(not server.is_closing() for server in self.__servers)
+
+    @_utils.inherit_doc(AbstractAsyncNetworkServer)
+    async def server_activate(self) -> None:
+        async with self.__server_activation_lock:
+            assert self.__servers_factory_scope is None  # nosec assert_used
+            if (servers_factory := self.__servers_factory_cb) is None:
+                raise ServerClosedError("Closed server")
+            if self.__servers:
+                return
+            listeners: list[_T_LowLevelServer] = []
+            try:
+                with self.__backend.open_cancel_scope() as self.__servers_factory_scope:
+                    await self.__backend.coro_yield()
+                    listeners.extend(await servers_factory(self))  # type: ignore[arg-type]
+                if self.__servers_factory_scope.cancelled_caught():
+                    raise ServerClosedError("Server has been closed")
+            finally:
+                self.__servers_factory_scope = None
+            if not listeners:
+                raise OSError("empty listeners list")
+            self.__servers[:] = listeners
+
+    @_utils.inherit_doc(AbstractAsyncNetworkServer)
+    async def server_close(self) -> None:
+        async with contextlib.AsyncExitStack() as exit_stack:
+            await exit_stack.enter_async_context(self.__server_close_lock)
+            exit_stack.enter_context(self.__server_close_guard)
+
+            if self.__servers_factory_scope is not None:
+                self.__servers_factory_scope.cancel()
+            self.__servers_factory_cb = None
+
+            exit_stack.callback(self.__servers.clear)
+            exit_stack.push_async_callback(self.__close_all_servers, self.__backend, self.__servers[:])
+
+            async with self.__backend.create_task_group() as group:
+                for task in self.__server_tasks:
+                    task.cancel()
+                    group.start_soon(task.wait)
+
+    @classmethod
+    async def __close_all_servers(cls, backend: AsyncBackend, servers: Sequence[_T_LowLevelServer]) -> None:
+        async with backend.create_task_group() as group:
+            for server in servers:
+                group.start_soon(cls.__close_server, server)
+
+    @classmethod
+    async def __close_server(cls, server: _T_LowLevelServer) -> None:
+        await server.aclose()
+
+    @_utils.inherit_doc(AbstractAsyncNetworkServer)
+    async def shutdown(self) -> None:
+        if self.__server_run_scope is not None:
+            self.__server_run_scope.cancel()
+        await self.__is_shutdown.wait()
+
+    @_utils.inherit_doc(AbstractAsyncNetworkServer)
+    async def serve_forever(self, *, is_up_event: SupportsEventSet | None = None) -> None:
+        async with contextlib.AsyncExitStack() as server_exit_stack:
+            # Wake up server
+            if not self.__is_shutdown.is_set():
+                raise ServerAlreadyRunning("Server is already running")
+            self.__is_shutdown = is_shutdown = self.__backend.create_event()
+            server_exit_stack.callback(is_shutdown.set)
+            self.__server_run_scope = server_exit_stack.enter_context(self.__backend.open_cancel_scope())
+
+            def reset_scope() -> None:
+                self.__server_run_scope = None
+
+            server_exit_stack.callback(reset_scope)
+            ################
+
+            # Bind and activate
+            await self.server_activate()
+            assert len(self.__servers) > 0  # nosec assert_used
+            ###################
+
+            with self.__server_close_guard:
+
+                # Final teardown
+                server_exit_stack.callback(self.__logger.info, "Server stopped")
+                ################
+
+                # Initialize service
+                initialize_service = self.__initialize_service_cb
+                await initialize_service(self, server_exit_stack)  # type: ignore[arg-type]
+                ############################
+
+                # Setup task group
+                self.__active_tasks = 0
+                server_exit_stack.callback(self.__server_tasks.clear)
+                task_group = await server_exit_stack.enter_async_context(self.__backend.create_task_group())
+                server_exit_stack.callback(self.__logger.info, "Server loop break, waiting for remaining tasks...")
+                ##################
+
+                # Enable listener
+                self.__server_tasks[:] = [await task_group.start(self.__serve, server, task_group) for server in self.__servers]
+                self.__logger.info("Start serving at %s", ", ".join(map(str, self.get_addresses())))
+                #################
+
+            # Server is up
+            if is_up_event is not None:
+                is_up_event.set()
+            ##############
+
+            # Main loop
+            try:
+                await self.__backend.sleep_forever()
+            finally:
+                reset_scope()
+
+    @abstractmethod
+    def get_addresses(self) -> Sequence[_T_Address]:
+        """
+        Returns all interfaces to which the server is bound.
+
+        Returns:
+            A sequence of network socket address.
+            If the server is not serving (:meth:`is_serving` returns :data:`False`), an empty sequence is returned.
+        """
+        raise NotImplementedError
+
+    def _bind_server(self) -> _BindServer:
+        return _BindServer(self.__attach_server, self.__detach_server)
+
+    async def __serve(
+        self,
+        server: _T_LowLevelServer,
+        task_group: TaskGroup,
+    ) -> NoReturn:
+        lowlevel_serve = self.__lowlevel_serve_cb
+        with _BindServer(self.__attach_server, self.__detach_server):
+            await lowlevel_serve(self, server, task_group)  # type: ignore[arg-type]
+
+    def __attach_server(self) -> None:
+        self.__active_tasks += 1
+
+    def __detach_server(self) -> None:
+        self.__active_tasks -= 1
+        if self.__active_tasks < 0:
+            raise AssertionError("self.__active_tasks < 0")
+        if not self.__active_tasks and self.__server_run_scope is not None:
+            self.__server_run_scope.cancel()
+
+    def _with_lowlevel_servers(self, f: Callable[[Sequence[_T_LowLevelServer]], _T_Return]) -> _T_Return:
+        servers = tuple(self.__servers)
+        return f(servers)
+
+    @_utils.inherit_doc(AbstractAsyncNetworkServer)
+    def backend(self) -> AsyncBackend:
+        return self.__backend
+
+    @property
+    def logger(self) -> logging.Logger:
+        return self.__logger

--- a/src/easynetwork/servers/abc.py
+++ b/src/easynetwork/servers/abc.py
@@ -148,7 +148,6 @@ class AbstractAsyncNetworkServer(metaclass=ABCMeta):
         Raises:
             ServerClosedError: The server is closed.
             ServerAlreadyRunning: Another task already called :meth:`serve_forever`.
-            ServerNotActivated: :meth:`server_activate` must be used before calling :meth:`serve_forever`.
         """
         raise NotImplementedError
 
@@ -165,8 +164,6 @@ class AbstractAsyncNetworkServer(metaclass=ABCMeta):
         Opens all listeners.
 
         This method MUST be idempotent. Further calls to :meth:`is_listening` will return :data:`True`.
-
-        To stop and close the listeners, you can use :meth:`stop_listening`.
 
         Raises:
             ServerClosedError: The server is closed.

--- a/src/easynetwork/servers/abc.py
+++ b/src/easynetwork/servers/abc.py
@@ -23,12 +23,10 @@ __all__ = [
 ]
 
 from abc import ABCMeta, abstractmethod
-from collections.abc import Sequence
 from types import TracebackType
 from typing import Protocol, Self
 
 from ..lowlevel.api_async.backend.abc import AsyncBackend
-from ..lowlevel.socket import SocketAddress
 
 
 class SupportsEventSet(Protocol):
@@ -108,17 +106,6 @@ class AbstractNetworkServer(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    @abstractmethod
-    def get_addresses(self) -> Sequence[SocketAddress]:
-        """
-        Returns all interfaces to which the server is bound. Thread-safe.
-
-        Returns:
-            A sequence of network socket address.
-            If the server is not serving (:meth:`is_serving` returns :data:`False`), an empty sequence is returned.
-        """
-        raise NotImplementedError
-
 
 class AbstractAsyncNetworkServer(metaclass=ABCMeta):
     """
@@ -128,6 +115,8 @@ class AbstractAsyncNetworkServer(metaclass=ABCMeta):
     __slots__ = ("__weakref__",)
 
     async def __aenter__(self) -> Self:
+        """Calls :meth:`server_activate`."""
+        await self.server_activate()
         return self
 
     async def __aexit__(
@@ -142,7 +131,7 @@ class AbstractAsyncNetworkServer(metaclass=ABCMeta):
     @abstractmethod
     def is_serving(self) -> bool:
         """
-        Checks whether the server is up and accepting new clients.
+        Checks whether the server is up (:meth:`is_listening` returns :data:`True`) and accepting new clients.
         """
         raise NotImplementedError
 
@@ -151,12 +140,36 @@ class AbstractAsyncNetworkServer(metaclass=ABCMeta):
         """
         Starts the server's main loop.
 
+        Further calls to :meth:`is_serving` will return :data:`True` until the loop is stopped.
+
         Parameters:
             is_up_event: If given, will be triggered when the server is ready to accept new clients.
 
         Raises:
             ServerClosedError: The server is closed.
             ServerAlreadyRunning: Another task already called :meth:`serve_forever`.
+            ServerNotActivated: :meth:`server_activate` must be used before calling :meth:`serve_forever`.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_listening(self) -> bool:
+        """
+        Checks whether the server is up.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def server_activate(self) -> None:
+        """
+        Opens all listeners.
+
+        This method MUST be idempotent. Further calls to :meth:`is_listening` will return :data:`True`.
+
+        To stop and close the listeners, you can use :meth:`stop_listening`.
+
+        Raises:
+            ServerClosedError: The server is closed.
         """
         raise NotImplementedError
 
@@ -178,16 +191,6 @@ class AbstractAsyncNetworkServer(metaclass=ABCMeta):
             Do not call this method in the :meth:`serve_forever` task; it will cause a deadlock.
         """
         raise NotImplementedError
-
-    @abstractmethod
-    def get_addresses(self) -> Sequence[SocketAddress]:
-        """
-        Returns all interfaces to which the server is bound.
-
-        Returns:
-            A sequence of network socket address.
-            If the server is not serving (:meth:`is_serving` returns :data:`False`), an empty sequence is returned.
-        """
 
     @abstractmethod
     def backend(self) -> AsyncBackend:

--- a/src/easynetwork/servers/standalone_tcp.py
+++ b/src/easynetwork/servers/standalone_tcp.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any, Generic
 from .._typevars import _T_Request, _T_Response
 from ..lowlevel.api_async.backend.abc import AsyncBackend
 from ..lowlevel.api_async.backend.utils import BuiltinAsyncBackendLiteral
-from ..lowlevel.socket import SocketProxy
+from ..lowlevel.socket import SocketAddress, SocketProxy
 from ..protocol import AnyStreamProtocolType
 from . import _base
 from .async_tcp import AsyncTCPNetworkServer
@@ -98,16 +98,15 @@ class StandaloneTCPNetworkServer(
             runner_options=runner_options,
         )
 
-    def stop_listening(self) -> None:
+    def get_addresses(self) -> Sequence[SocketAddress]:
         """
-        Schedules the shutdown of all listener sockets. Thread-safe.
+        Returns all interfaces to which the server is bound. Thread-safe.
 
-        After that, all new connections will be refused, but the server will continue to run and handle
-        previously accepted connections.
-
-        Further calls to :meth:`is_serving` will return :data:`False`.
+        Returns:
+            A sequence of network socket address.
+            If the server is not serving (:meth:`is_serving` returns :data:`False`), an empty sequence is returned.
         """
-        self._run_sync_or(lambda portal, server: portal.run_sync(server.stop_listening), None)
+        return self._run_sync_or(lambda portal, server: portal.run_sync(server.get_addresses), ())
 
     def get_sockets(self) -> Sequence[SocketProxy]:
         """Gets the listeners sockets. Thread-safe.

--- a/src/easynetwork/servers/standalone_udp.py
+++ b/src/easynetwork/servers/standalone_udp.py
@@ -27,7 +27,7 @@ from typing import Any, Generic
 from .._typevars import _T_Request, _T_Response
 from ..lowlevel.api_async.backend.abc import AsyncBackend
 from ..lowlevel.api_async.backend.utils import BuiltinAsyncBackendLiteral
-from ..lowlevel.socket import SocketProxy
+from ..lowlevel.socket import SocketAddress, SocketProxy
 from ..protocol import DatagramProtocol
 from . import _base
 from .async_udp import AsyncUDPNetworkServer
@@ -80,6 +80,16 @@ class StandaloneUDPNetworkServer(
             ),
             runner_options=runner_options,
         )
+
+    def get_addresses(self) -> Sequence[SocketAddress]:
+        """
+        Returns all interfaces to which the server is bound. Thread-safe.
+
+        Returns:
+            A sequence of network socket address.
+            If the server is not serving (:meth:`is_serving` returns :data:`False`), an empty sequence is returned.
+        """
+        return self._run_sync_or(lambda portal, server: portal.run_sync(server.get_addresses), ())
 
     def get_sockets(self) -> Sequence[SocketProxy]:
         """Gets the listeners sockets. Thread-safe.

--- a/tests/functional_test/test_communication/test_async/test_server/base.py
+++ b/tests/functional_test/test_communication/test_async/test_server/base.py
@@ -101,17 +101,17 @@ class BaseTestAsyncServer:
 
     async def test____serve_forever____shutdown_during_setup(
         self,
-        server: AbstractAsyncNetworkServer,
+        server_not_activated: AbstractAsyncNetworkServer,
         enable_eager_tasks: bool,
     ) -> None:
         event = asyncio.Event()
         async with asyncio.TaskGroup() as tg:
-            _ = tg.create_task(server.serve_forever(is_up_event=event))
+            _ = tg.create_task(server_not_activated.serve_forever(is_up_event=event))
             if not enable_eager_tasks:
                 await asyncio.sleep(0)
             assert not event.is_set()
             async with asyncio.timeout(1):
-                await server.shutdown()
+                await server_not_activated.shutdown()
             assert not event.is_set()
 
     async def test____serve_forever____without_is_up_event(

--- a/tests/functional_test/test_communication/test_async/test_server/base.py
+++ b/tests/functional_test/test_communication/test_async/test_server/base.py
@@ -89,14 +89,6 @@ class BaseTestAsyncServer:
         await server.server_close()
         await server.server_close()
 
-    async def test____server_close____while_server_is_running(
-        self,
-        server: AbstractAsyncNetworkServer,
-        run_server: asyncio.Event,
-    ) -> None:
-        await run_server.wait()
-        await server.server_close()
-
     @pytest.mark.usefixtures("run_server")
     async def test____serve_forever____error_already_running(self, server: AbstractAsyncNetworkServer) -> None:
         with pytest.raises(ServerAlreadyRunning):
@@ -120,26 +112,6 @@ class BaseTestAsyncServer:
             assert not event.is_set()
             async with asyncio.timeout(1):
                 await server.shutdown()
-            assert not event.is_set()
-
-    async def test____serve_forever____server_close_during_setup(
-        self,
-        server: AbstractAsyncNetworkServer,
-        enable_eager_tasks: bool,
-    ) -> None:
-        event = asyncio.Event()
-
-        async def serve() -> None:
-            with pytest.raises(ServerClosedError):
-                await server.serve_forever(is_up_event=event)
-
-        async with asyncio.TaskGroup() as tg:
-            _ = tg.create_task(serve())
-            if not enable_eager_tasks:
-                await asyncio.sleep(0)
-            assert not event.is_set()
-            async with asyncio.timeout(1):
-                await server.server_close()
             assert not event.is_set()
 
     async def test____serve_forever____without_is_up_event(
@@ -166,3 +138,21 @@ class BaseTestAsyncServer:
             await run_server.wait()
 
         await asyncio.gather(*[server.shutdown() for _ in range(10)])
+
+    async def test____server_activate____server_close_during_activation(
+        self,
+        server_not_activated: AbstractAsyncNetworkServer,
+        enable_eager_tasks: bool,
+    ) -> None:
+        async def serve() -> None:
+            with pytest.raises(ServerClosedError):
+                await server_not_activated.server_activate()
+
+        async with asyncio.TaskGroup() as tg:
+            _ = tg.create_task(serve())
+            if not enable_eager_tasks:
+                await asyncio.sleep(0)
+            assert not server_not_activated.is_listening()
+            async with asyncio.timeout(1):
+                await server_not_activated.server_close()
+            assert not server_not_activated.is_listening()

--- a/tests/functional_test/test_communication/test_async/test_server/base.py
+++ b/tests/functional_test/test_communication/test_async/test_server/base.py
@@ -89,6 +89,19 @@ class BaseTestAsyncServer:
         await server.server_close()
         await server.server_close()
 
+    async def test____server_close____while_server_is_running(
+        self,
+        server: AbstractAsyncNetworkServer,
+        run_server: asyncio.Event,
+    ) -> None:
+        await run_server.wait()
+        await server.server_close()
+        await asyncio.sleep(0.5)
+
+        # There is no client so the server loop should stop by itself
+        assert not server.is_serving()
+        assert not server.is_listening()
+
     @pytest.mark.usefixtures("run_server")
     async def test____serve_forever____error_already_running(self, server: AbstractAsyncNetworkServer) -> None:
         with pytest.raises(ServerAlreadyRunning):

--- a/tests/functional_test/test_communication/test_sync/test_server/test_standalone.py
+++ b/tests/functional_test/test_communication/test_sync/test_server/test_standalone.py
@@ -46,6 +46,14 @@ class BaseTestStandaloneNetworkServer:
             server.shutdown()
 
     @pytest.mark.usefixtures("start_server")
+    def test____server_close____while_server_is_running(self, server: AbstractNetworkServer) -> None:
+        server.server_close()
+        time.sleep(0.5)
+
+        # There is no client so the server loop should stop by itself
+        assert not server.is_serving()
+
+    @pytest.mark.usefixtures("start_server")
     def test____shutdown____while_server_is_running(self, server: AbstractNetworkServer) -> None:
         assert server.is_serving()
 

--- a/tests/functional_test/test_concurrency/conftest.py
+++ b/tests/functional_test/test_concurrency/conftest.py
@@ -49,6 +49,7 @@ def _run_server(server: AbstractNetworkServer) -> None:
 
 
 def _retrieve_server_address(server: AbstractNetworkServer) -> tuple[str, int]:
+    assert isinstance(server, (StandaloneTCPNetworkServer, StandaloneUDPNetworkServer))
     address = server.get_addresses()[0]
     if isinstance(address, IPv4SocketAddress):
         return "127.0.0.1", address.port

--- a/tests/scripts/async_server_test.py
+++ b/tests/scripts/async_server_test.py
@@ -22,8 +22,6 @@ class MyAsyncRequestHandler(AsyncStreamRequestHandler[str, str], AsyncDatagramRe
         self.server = server
 
     async def handle(self, client: AsyncBaseClientInterface[str]) -> AsyncGenerator[None, str]:
-        from easynetwork.servers.async_tcp import AsyncTCPNetworkServer
-
         request: str = yield
         logger.debug(f"Received {request!r} from {client!r}")
         match request:
@@ -31,8 +29,8 @@ class MyAsyncRequestHandler(AsyncStreamRequestHandler[str, str], AsyncDatagramRe
                 raise RuntimeError("requested error")
             case "wait:":
                 request = (yield) + " after wait"
-            case "self_kill:" if isinstance(self.server, AsyncTCPNetworkServer):
-                self.server.stop_listening()
+            case "self_kill:":
+                await self.server.server_close()
                 await client.send_packet("stop_listening() done")
                 return
         await client.send_packet(request.upper())

--- a/tests/unit_test/test_tools/test_utils.py
+++ b/tests/unit_test/test_tools/test_utils.py
@@ -17,6 +17,7 @@ from easynetwork.exceptions import BusyResourceError
 from easynetwork.lowlevel._final import runtime_final_class
 from easynetwork.lowlevel._utils import (
     ElapsedTime,
+    Flag,
     ResourceGuard,
     adjust_leftover_buffer,
     check_real_socket_state,
@@ -806,6 +807,22 @@ def test____iterate_exceptions____recursive_yield_exceptions_in_group() -> None:
 
     # Assert
     assert all_exceptions == list(itertools.chain(sub_excgrp1.exceptions, sub_excgrp2.exceptions))
+
+
+def test____Flag___set_and_reset() -> None:
+    # Arrange
+    flag = Flag()
+    assert not flag.is_set()
+
+    # Act & Assert
+    flag.set()
+    assert flag.is_set()
+    flag.set()
+    assert flag.is_set()
+    flag.clear()
+    assert not flag.is_set()
+    flag.clear()
+    assert not flag.is_set()
 
 
 def test____ElapsedTime____catch_elapsed_time(mocker: MockerFixture) -> None:


### PR DESCRIPTION
### Backward-incompatible changes
- Removed `get_addresses()` from `AbstractNetworkServer` and `AbstractAsyncNetworkServer`
- Removed `stop_listening()` from `StandaloneTCPNetworkServer` and `AsyncTCPNetworkServer`
  - `server_close()` must be used from now on
- `server_close()` no longer shut down the `serve_forever()` loop directly like `shutdown()`

### New feature
- Asynchronous servers ONLY :
  - Added `server_activate()` method to add the possibility to bind and activate listeners before calling `serve_forever()`
  - Added `is_listening()` to check if `server_activate()` has already been called
