### PR TITLE
`AsyncBackend.run_in_thread()`: Removed `**kwargs` and added `abandon_on_cancel`

### DIFF
--- a/src/easynetwork/lowlevel/api_async/backend/abc.py
+++ b/src/easynetwork/lowlevel/api_async/backend/abc.py
@@ -1085,7 +1085,13 @@ class AsyncBackend(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    async def run_in_thread(self, func: Callable[_P, _T], /, *args: _P.args, **kwargs: _P.kwargs) -> _T:
+    async def run_in_thread(
+        self,
+        func: Callable[[*_T_PosArgs], _T],
+        /,
+        *args: *_T_PosArgs,
+        abandon_on_cancel: bool = ...,
+    ) -> _T:
         """
         Executes a synchronous function in a worker thread.
 
@@ -1096,7 +1102,11 @@ class AsyncBackend(metaclass=ABCMeta):
 
         Cancellation handling:
             Because there is no way to "cancel" an arbitrary function call in an OS thread,
-            once the job is started, any cancellation requests will be discarded.
+            once the job is started:
+
+            * If `abandon_on_cancel` is False (the default), any cancellation requests will be discarded.
+
+            * If `abandon_on_cancel` is True, the task will notify the thread to stop (if possible) then will bail out.
 
         Warning:
             Due to the current coroutine implementation, `func` should not raise a :exc:`StopIteration`.
@@ -1104,14 +1114,15 @@ class AsyncBackend(metaclass=ABCMeta):
 
         Parameters:
             func: A synchronous function.
-            args: Positional arguments to be passed to `func`.
-            kwargs: Keyword arguments to be passed to `func`.
+            args: Positional arguments to be passed to `func`. If you need to pass keyword arguments,
+                  then use :func:`functools.partial`.
+            abandon_on_cancel: Whether or not to abort task on cancellation request.
 
         Raises:
-            Exception: Whatever ``func(*args, **kwargs)`` raises.
+            Exception: Whatever ``func(*args)`` raises.
 
         Returns:
-            Whatever ``func(*args, **kwargs)`` returns.
+            Whatever ``func(*args)`` returns.
         """
         raise NotImplementedError
 

--- a/src/easynetwork/lowlevel/futures.py
+++ b/src/easynetwork/lowlevel/futures.py
@@ -199,7 +199,8 @@ class AsyncExecutor(Generic[_T_Executor]):
                             has not started running. Any futures that are completed or running won't be cancelled,
                             regardless of the value of `cancel_futures`.
         """
-        await self.__backend.run_in_thread(self.__executor.shutdown, wait=True, cancel_futures=cancel_futures)
+        shutdown_callback = functools.partial(self.__executor.shutdown, wait=True, cancel_futures=cancel_futures)
+        await self.__backend.run_in_thread(shutdown_callback)
 
     def _setup_func(self, func: Callable[_P, _T]) -> Callable[_P, _T]:
         if self.__handle_contexts:

--- a/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
@@ -980,8 +980,10 @@ class TestAsyncIOBackend:
         mock_Condition.assert_called_once_with(mock_lock)
         assert condition is mocker.sentinel.condition_var
 
+    @pytest.mark.parametrize("abandon_on_cancel", [False, True], ids=lambda p: f"abandon_on_cancel=={p}")
     async def test____run_in_thread____use_loop_run_in_executor(
         self,
+        abandon_on_cancel: bool,
         backend: AsyncIOBackend,
         mocker: MockerFixture,
     ) -> None:
@@ -999,8 +1001,7 @@ class TestAsyncIOBackend:
             func_stub,
             mocker.sentinel.arg1,
             mocker.sentinel.arg2,
-            kw1=mocker.sentinel.kwargs1,
-            kw2=mocker.sentinel.kwargs2,
+            abandon_on_cancel=abandon_on_cancel,
         )
 
         # Assert
@@ -1012,8 +1013,6 @@ class TestAsyncIOBackend:
                 func_stub,
                 mocker.sentinel.arg1,
                 mocker.sentinel.arg2,
-                kw1=mocker.sentinel.kwargs1,
-                kw2=mocker.sentinel.kwargs2,
             ),
         )
         func_stub.assert_not_called()

--- a/tests/unit_test/test_async/test_lowlevel_api/test_backend/_fake_backends.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_backend/_fake_backends.py
@@ -79,13 +79,11 @@ class BaseFakeBackend(AsyncBackend):
     def create_condition_var(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError
 
+    @no_type_check
     async def run_in_thread(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError
 
     def create_threads_portal(self) -> Any:
-        raise NotImplementedError
-
-    async def wait_future(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError
 
 

--- a/tests/unit_test/test_async/test_lowlevel_api/test_futures.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_futures.py
@@ -238,7 +238,9 @@ class TestAsyncExecutor:
 
         # Assert
         mock_stdlib_executor.shutdown.assert_not_called()
-        mock_backend.run_in_thread.assert_awaited_once_with(mock_stdlib_executor.shutdown, wait=True, cancel_futures=False)
+        mock_backend.run_in_thread.assert_awaited_once_with(
+            partial_eq(mock_stdlib_executor.shutdown, wait=True, cancel_futures=False)
+        )
 
     @pytest.mark.parametrize("cancel_futures", [False, True])
     async def test____shutdown____shutdown_executor____cancel_futures(
@@ -257,9 +259,7 @@ class TestAsyncExecutor:
         # Assert
         mock_stdlib_executor.shutdown.assert_not_called()
         mock_backend.run_in_thread.assert_awaited_once_with(
-            mock_stdlib_executor.shutdown,
-            wait=True,
-            cancel_futures=cancel_futures,
+            partial_eq(mock_stdlib_executor.shutdown, wait=True, cancel_futures=cancel_futures)
         )
 
     async def test____context_manager____shutdown_executor_at_end(
@@ -280,4 +280,6 @@ class TestAsyncExecutor:
 
         # Assert
         mock_stdlib_executor.shutdown.assert_not_called()
-        mock_backend.run_in_thread.assert_awaited_once_with(mock_stdlib_executor.shutdown, wait=True, cancel_futures=False)
+        mock_backend.run_in_thread.assert_awaited_once_with(
+            partial_eq(mock_stdlib_executor.shutdown, wait=True, cancel_futures=False)
+        )


### PR DESCRIPTION
### What's changed
- It is no longer possible to call `run_in_thread()` with variadic keyword arguments
- Added keyword-only parameter `abandon_on_cancel` to permit task cancellation.