### PR TITLE
`MessagePackSerializer` can be used with `StreamProtocol` and `BufferedStreamProtocol`

### DIFF
--- a/docs/source/api/serializers/cbor.rst
+++ b/docs/source/api/serializers/cbor.rst
@@ -12,6 +12,8 @@ Configuration
 
 .. autoclass:: CBOREncoderConfig
    :members:
+   :undoc-members:
 
 .. autoclass:: CBORDecoderConfig
    :members:
+   :undoc-members:

--- a/docs/source/api/serializers/json.rst
+++ b/docs/source/api/serializers/json.rst
@@ -12,6 +12,8 @@ Configuration
 
 .. autoclass:: JSONEncoderConfig
    :members:
+   :undoc-members:
 
 .. autoclass:: JSONDecoderConfig
    :members:
+   :undoc-members:

--- a/docs/source/api/serializers/msgpack.rst
+++ b/docs/source/api/serializers/msgpack.rst
@@ -12,6 +12,8 @@ Configuration
 
 .. autoclass:: MessagePackerConfig
    :members:
+   :undoc-members:
 
 .. autoclass:: MessageUnpackerConfig
    :members:
+   :undoc-members:

--- a/docs/source/api/serializers/pickle.rst
+++ b/docs/source/api/serializers/pickle.rst
@@ -16,6 +16,8 @@ Configuration
 
 .. autoclass:: PicklerConfig
    :members:
+   :undoc-members:
 
 .. autoclass:: UnpicklerConfig
    :members:
+   :undoc-members:

--- a/micro_benchmarks/serializers/bench_cbor.py
+++ b/micro_benchmarks/serializers/bench_cbor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, assert_type
+from typing import TYPE_CHECKING, Any
 
 from easynetwork.serializers.cbor import CBORSerializer
 
@@ -57,9 +57,8 @@ def bench_CBORSerializer_incremental_deserialize(
 
         def deserialize() -> Any:
             consumer = serializer.buffered_incremental_deserialize(buffer)
-            assert_type(next(consumer), None)
-            with buffer.cast("B") as view:
-                view[:nbytes] = cbor_data
+            next(consumer)
+            buffer[:nbytes] = cbor_data
             try:
                 consumer.send(nbytes)
             except StopIteration as exc:

--- a/micro_benchmarks/serializers/bench_msgpack.py
+++ b/micro_benchmarks/serializers/bench_msgpack.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any
 
 from easynetwork.serializers.msgpack import MessagePackSerializer
 
+import pytest
+
 if TYPE_CHECKING:
     from pytest_benchmark.fixture import BenchmarkFixture
 
@@ -27,5 +29,55 @@ def bench_MessagePackSerializer_deserialize(
     serializer = MessagePackSerializer()
 
     result = benchmark(serializer.deserialize, msgpack_data)
+
+    assert result == json_object
+
+
+def bench_MessagePackSerializer_incremental_serialize(
+    benchmark: BenchmarkFixture,
+    json_object: Any,
+) -> None:
+    serializer = MessagePackSerializer()
+
+    benchmark(lambda: b"".join(serializer.incremental_serialize(json_object)))
+
+
+@pytest.mark.parametrize("buffered", [False, True], ids=lambda p: f"buffered=={p}")
+def bench_MessagePackSerializer_incremental_deserialize(
+    buffered: bool,
+    benchmark: BenchmarkFixture,
+    msgpack_data: bytes,
+    json_object: Any,
+) -> None:
+    serializer = MessagePackSerializer()
+
+    if buffered:
+        nbytes = len(msgpack_data)
+        buffer: memoryview = serializer.create_deserializer_buffer(nbytes)
+
+        def deserialize() -> Any:
+            consumer = serializer.buffered_incremental_deserialize(buffer)
+            next(consumer)
+            buffer[:nbytes] = msgpack_data
+            try:
+                consumer.send(nbytes)
+            except StopIteration as exc:
+                return exc.value
+            else:
+                raise RuntimeError("consumer yielded")
+
+    else:
+
+        def deserialize() -> Any:
+            consumer = serializer.incremental_deserialize()
+            next(consumer)
+            try:
+                consumer.send(msgpack_data)
+            except StopIteration as exc:
+                return exc.value
+            else:
+                raise RuntimeError("consumer yielded")
+
+    result, _ = benchmark(deserialize)
 
     assert result == json_object

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "bandit", "benchmark-servers", "benchmark-servers-deps", "build", "cbor", "coverage", "dev", "doc", "flake8", "format", "micro-benchmark", "msgpack", "mypy", "pre-commit", "test", "test-trio", "tox", "trio", "types-msgpack", "uvloop"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:1b80719e2b5aeccbd3fc7688f2139ec1335e93b13057431aa7e47cd0c1a66ab2"
+content_hash = "sha256:696499065d91cf2d7c26ecdd12eb68179cb0e0972ba0a3847690fbefc8e1d9d5"
 
 [[metadata.targets]]
 requires_python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ cbor = [
     "cbor2>=5.5,<6",
 ]
 msgpack = [
-    "msgpack>=1.0.7,<2",
+    "msgpack>=1.0.8,<2",
 ]
 trio = [
     "trio>=0.26,<1",

--- a/src/easynetwork/exceptions.py
+++ b/src/easynetwork/exceptions.py
@@ -115,7 +115,7 @@ class LimitOverrunError(IncrementalDeserializeError):
                 while remaining_data.nbytes and remaining_data[:seplen] != separator[: remaining_data.nbytes]:
                     remaining_data = remaining_data[1:]
 
-        super().__init__(message, remaining_data, error_info=None)
+        super().__init__(message, bytes(remaining_data), error_info=None)
 
         self.consumed: int = consumed
         """Total number of to be consumed bytes."""

--- a/src/easynetwork/serializers/cbor.py
+++ b/src/easynetwork/serializers/cbor.py
@@ -36,6 +36,7 @@ from functools import partial
 from typing import IO, TYPE_CHECKING, Any, final
 
 from ..lowlevel import _utils
+from ..lowlevel.constants import DEFAULT_SERIALIZER_LIMIT
 from .base_stream import FileBasedPacketSerializer
 
 if TYPE_CHECKING:
@@ -86,12 +87,14 @@ class CBORSerializer(FileBasedPacketSerializer[Any, Any]):
         encoder_config: CBOREncoderConfig | None = None,
         decoder_config: CBORDecoderConfig | None = None,
         *,
+        limit: int = DEFAULT_SERIALIZER_LIMIT,
         debug: bool = False,
     ) -> None:
         """
         Parameters:
             encoder_config: Parameter object to configure the :class:`~cbor.encoder.CBOREncoder`.
             decoder_config: Parameter object to configure the :class:`~cbor.decoder.CBORDecoder`.
+            limit: Maximum buffer size. Used in incremental serialization context.
             debug: If :data:`True`, add information to :exc:`.DeserializeError` via the ``error_info`` attribute.
         """
         try:
@@ -99,7 +102,7 @@ class CBORSerializer(FileBasedPacketSerializer[Any, Any]):
         except ModuleNotFoundError as exc:
             raise _utils.missing_extra_deps("cbor") from exc
 
-        super().__init__(expected_load_error=(cbor2.CBORDecodeError, UnicodeError), debug=debug)
+        super().__init__(expected_load_error=(cbor2.CBORDecodeError, UnicodeError), limit=limit, debug=debug)
         self.__encoder_cls: Callable[[IO[bytes]], cbor2.CBOREncoder]
         self.__decoder_cls: Callable[[IO[bytes]], cbor2.CBORDecoder]
 

--- a/tests/functional_test/test_serializers/test_cbor.py
+++ b/tests/functional_test/test_serializers/test_cbor.py
@@ -18,12 +18,15 @@ from .samples.json import SAMPLES
 class TestCBORSerializer(BaseTestBufferedIncrementalSerializer, BaseTestSerializerExtraData):
     #### Serializers
 
-    ENCODER_CONFIG = CBOREncoderConfig()
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def encoder_config() -> CBOREncoderConfig:
+        return CBOREncoderConfig()
 
     @pytest.fixture(scope="class")
-    @classmethod
-    def serializer_for_serialization(cls) -> CBORSerializer:
-        return CBORSerializer(encoder_config=cls.ENCODER_CONFIG)
+    @staticmethod
+    def serializer_for_serialization(encoder_config: CBOREncoderConfig) -> CBORSerializer:
+        return CBORSerializer(encoder_config=encoder_config)
 
     @pytest.fixture(scope="class")
     @staticmethod
@@ -41,10 +44,10 @@ class TestCBORSerializer(BaseTestBufferedIncrementalSerializer, BaseTestSerializ
 
     @pytest.fixture(scope="class")
     @classmethod
-    def expected_complete_data(cls, packet_to_serialize: Any) -> bytes:
+    def expected_complete_data(cls, packet_to_serialize: Any, encoder_config: CBOREncoderConfig) -> bytes:
         import cbor2
 
-        return cbor2.dumps(packet_to_serialize, **dataclasses.asdict(cls.ENCODER_CONFIG))
+        return cbor2.dumps(packet_to_serialize, **dataclasses.asdict(encoder_config))
 
     #### Incremental Serialize
 

--- a/tests/functional_test/test_serializers/test_json.py
+++ b/tests/functional_test/test_serializers/test_json.py
@@ -23,11 +23,14 @@ TOO_BIG_JSON_SERIALIZED = json.dumps(TOO_BIG_JSON, ensure_ascii=False).encode("u
 class TestJSONSerializer(BaseTestIncrementalSerializer, BaseTestSerializerExtraData):
     #### Serializers
 
-    ENCODER_CONFIG = JSONEncoderConfig(ensure_ascii=False)
-
     BUFFER_LIMIT = 14 * 1024  # 14KiB
 
     assert len(TOO_BIG_JSON_SERIALIZED) > BUFFER_LIMIT
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def encoder_config() -> JSONEncoderConfig:
+        return JSONEncoderConfig(ensure_ascii=False)
 
     @pytest.fixture(scope="class", params=[False, True], ids=lambda p: f"use_lines=={p}")
     @staticmethod
@@ -36,8 +39,8 @@ class TestJSONSerializer(BaseTestIncrementalSerializer, BaseTestSerializerExtraD
 
     @pytest.fixture(scope="class")
     @classmethod
-    def serializer_for_serialization(cls, use_lines: bool) -> JSONSerializer:
-        return JSONSerializer(encoder_config=cls.ENCODER_CONFIG, use_lines=use_lines, limit=cls.BUFFER_LIMIT)
+    def serializer_for_serialization(cls, encoder_config: JSONEncoderConfig, use_lines: bool) -> JSONSerializer:
+        return JSONSerializer(encoder_config=encoder_config, use_lines=use_lines, limit=cls.BUFFER_LIMIT)
 
     @pytest.fixture(scope="class")
     @classmethod
@@ -55,8 +58,8 @@ class TestJSONSerializer(BaseTestIncrementalSerializer, BaseTestSerializerExtraD
 
     @pytest.fixture(scope="class")
     @classmethod
-    def expected_complete_data(cls, packet_to_serialize: Any) -> bytes:
-        return json.dumps(packet_to_serialize, **dataclasses.asdict(cls.ENCODER_CONFIG), separators=(",", ":")).encode("utf-8")
+    def expected_complete_data(cls, packet_to_serialize: Any, encoder_config: JSONEncoderConfig) -> bytes:
+        return json.dumps(packet_to_serialize, **dataclasses.asdict(encoder_config), separators=(",", ":")).encode("utf-8")
 
     #### Incremental Serialize
 

--- a/tests/functional_test/test_serializers/test_msgpack.py
+++ b/tests/functional_test/test_serializers/test_msgpack.py
@@ -9,13 +9,13 @@ from easynetwork.serializers.msgpack import MessagePackerConfig, MessagePackSeri
 
 import pytest
 
-from .base import BaseTestSerializerExtraData
+from .base import BaseTestBufferedIncrementalSerializer, BaseTestSerializerExtraData
 from .samples.json import SAMPLES
 
 
 @final
 @pytest.mark.feature_msgpack
-class TestMessagePackSerializer(BaseTestSerializerExtraData):
+class TestMessagePackSerializer(BaseTestBufferedIncrementalSerializer, BaseTestSerializerExtraData):
     #### Serializers
 
     @pytest.fixture(scope="class")
@@ -49,6 +49,13 @@ class TestMessagePackSerializer(BaseTestSerializerExtraData):
 
         return msgpack.packb(packet_to_serialize, **dataclasses.asdict(packer_config), autoreset=True)
 
+    #### Incremental Serialize
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def expected_joined_data(expected_complete_data: bytes) -> bytes:
+        return expected_complete_data
+
     #### One-shot Deserialize
 
     @pytest.fixture(scope="class")
@@ -58,9 +65,21 @@ class TestMessagePackSerializer(BaseTestSerializerExtraData):
 
         return msgpack.packb(packet_to_serialize)
 
+    #### Incremental Deserialize
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def complete_data_for_incremental_deserialize(complete_data: bytes) -> bytes:
+        return complete_data
+
     #### Invalid data
 
     @pytest.fixture(scope="class")
     @staticmethod
     def invalid_complete_data(complete_data: bytes) -> bytes:
-        return complete_data[:-1]  # Missing data error
+        return complete_data[:-1]  # Extra data error
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def invalid_partial_data_extra_data() -> tuple[bytes, bytes]:
+        return (b"remaining_data", b"")

--- a/tests/unit_test/test_serializers/test_compressor.py
+++ b/tests/unit_test/test_serializers/test_compressor.py
@@ -457,7 +457,17 @@ class TestAbstractCompressorSerializer:
 
 
 class BaseTestCompressorSerializerImplementation:
-    @pytest.mark.parametrize("method", ["serialize", "incremental_serialize", "deserialize", "incremental_deserialize"])
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "serialize",
+            "incremental_serialize",
+            "deserialize",
+            "incremental_deserialize",
+            "create_deserializer_buffer",
+            "buffered_incremental_deserialize",
+        ],
+    )
     def test____base_class____implements_default_methods(
         self,
         serializer_cls: type[AbstractCompressorSerializer[Any, Any]],

--- a/tests/unit_test/test_serializers/test_struct.py
+++ b/tests/unit_test/test_serializers/test_struct.py
@@ -56,7 +56,15 @@ class TestAbstractStructSerializer(BaseTestStructBasedSerializer):
     def mock_serializer_from_tuple(mocker: MockerFixture) -> MagicMock:
         return mocker.patch.object(_StructSerializerForTest, "from_tuple")
 
-    @pytest.mark.parametrize("method", ["incremental_serialize", "incremental_deserialize"])
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "incremental_serialize",
+            "incremental_deserialize",
+            "create_deserializer_buffer",
+            "buffered_incremental_deserialize",
+        ],
+    )
     def test____base_class____implements_default_methods(self, method: str) -> None:
         # Arrange
         from easynetwork.serializers.base_stream import FixedSizePacketSerializer
@@ -157,7 +165,17 @@ class TestAbstractStructSerializer(BaseTestStructBasedSerializer):
 
 
 class TestNamedTupleStructSerializer(BaseTestStructBasedSerializer):
-    @pytest.mark.parametrize("method", ["serialize", "incremental_serialize", "deserialize", "incremental_deserialize"])
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "serialize",
+            "incremental_serialize",
+            "deserialize",
+            "incremental_deserialize",
+            "create_deserializer_buffer",
+            "buffered_incremental_deserialize",
+        ],
+    )
     def test____base_class____implements_default_methods(self, method: str) -> None:
         # Arrange
 
@@ -471,7 +489,17 @@ class TestNamedTupleStructSerializer(BaseTestStructBasedSerializer):
 
 
 class TestStructSerializer(BaseTestStructBasedSerializer):
-    @pytest.mark.parametrize("method", ["serialize", "incremental_serialize", "deserialize", "incremental_deserialize"])
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "serialize",
+            "incremental_serialize",
+            "deserialize",
+            "incremental_deserialize",
+            "create_deserializer_buffer",
+            "buffered_incremental_deserialize",
+        ],
+    )
     def test____base_class____implements_default_methods(self, method: str) -> None:
         # Arrange
 


### PR DESCRIPTION
### What's changed
- `MessagePackSerializer` implements `BufferedIncrementalPacketSerializer` class.
- Added `limit` parameter to `FileBasedPacketSerializer`
- Added `limit` parameter to `CBORSerializer`
- Fixed an invalid (and useless) `try/except` in `MessagePackSerializer.deserialize()`
- Fixed documentation not showing dataclasses attributes