### PR TITLE
The `TrioListenerSocketAdapter` now handles `accept()` capacity errors

### DIFF
--- a/tests/tools.py
+++ b/tests/tools.py
@@ -27,7 +27,7 @@ def _make_skipif_platform(platform: str, reason: str, *, skip_only_on_ci: bool) 
     if skip_only_on_ci:
         # CI=true is always set for Github Actions
         # c.f. https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-        condition = condition and os.environ.get("CI") == "true"
+        condition = condition and "CI" in os.environ
     return pytest.mark.skipif(condition, reason=reason)
 
 

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -25,9 +25,10 @@ _T_Args = TypeVarTuple("_T_Args")
 def _make_skipif_platform(platform: str, reason: str, *, skip_only_on_ci: bool) -> pytest.MarkDecorator:
     condition: bool = sys.platform.startswith(platform)
     if skip_only_on_ci:
+        # skip if 'CI' is set to a non-empty value
         # CI=true is always set for Github Actions
         # c.f. https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-        condition = condition and "CI" in os.environ
+        condition = condition and bool(os.environ.get("CI", ""))
     return pytest.mark.skipif(condition, reason=reason)
 
 

--- a/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
@@ -357,7 +357,7 @@ class TestListenerSocketAdapter(BaseTestTransportStreamSocket, BaseTestAsyncSock
                     exc,
                 )
 
-    @PlatformMarkers.skipif_platform_win32
+    @PlatformMarkers.skipif_platform_win32_because("test failures are all too frequent on CI", skip_only_on_ci=True)
     @pytest.mark.parametrize("errno_value", sorted(ACCEPT_CAPACITY_ERRNOS), ids=errno_errorcode.__getitem__)
     @pytest.mark.flaky(retries=3, delay=0.1)
     async def test____accept____accept_capacity_error(

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,8 @@ wheel_build_env = {package_env}
 setenv =
     PYTHONUNBUFFERED = 1
     PDM_CHECK_UPDATE = False
+passenv =
+    CI
 
 [docs]
 root_dir = {toxinidir}{/}docs
@@ -54,6 +56,8 @@ setenv =
     {[pytest-conf]setenv}
     PYTHONHASHSEED = 0
     PYTEST_ADDOPTS = {[pytest-conf]addopts} --no-cov
+passenv =
+    {[base]passenv}
 commands =
     tests: pytest -m "not unit and not functional" {posargs}
     docstrings: pytest --doctest-modules {posargs} {toxinidir}{/}src
@@ -81,6 +85,7 @@ setenv =
     unit: TESTS_ROOTDIR = {[pytest-conf]unit_tests_rootdir}
     functional: TESTS_ROOTDIR = {[pytest-conf]functional_tests_rootdir}
 passenv =
+    {[base]passenv}
     PYTEST_MAX_WORKERS
 commands =
     standard: pytest -n "{env:PYTEST_MAX_WORKERS:auto}" -m "not feature" {posargs} {env:TESTS_ROOTDIR}
@@ -109,6 +114,7 @@ setenv =
     asyncio_proactor: ASYNCIO_EVENTLOOP = asyncio-proactor
     uvloop: ASYNCIO_EVENTLOOP = uvloop
 passenv =
+    {[base]passenv}
     PYTEST_MAX_WORKERS
 commands =
     pytest -n "{env:PYTEST_MAX_WORKERS:auto}" --asyncio-event-loop="{env:ASYNCIO_EVENTLOOP}" -m "asyncio and not feature" {posargs} {env:TESTS_ROOTDIR}
@@ -128,6 +134,8 @@ setenv =
     unit: COVERAGE_FILE = .coverage.unit
     functional: COVERAGE_FILE = .coverage.functional
     full: COVERAGE_FILE = .coverage
+passenv =
+    {[base]passenv}
 commands =
     !full: coverage combine
     full: coverage combine --keep
@@ -143,6 +151,7 @@ groups =
 setenv =
     {[base]setenv}
 passenv =
+    {[base]passenv}
     SOURCE_DATE_EPOCH
 commands =
     python -m build --outdir {toxinidir}{/}dist
@@ -156,6 +165,8 @@ setenv =
     {[base]setenv}
     SOURCEDIR = source
     BUILDDIR = build
+passenv =
+    {[base]passenv}
 commands =
     sphinx-build -T -b html {env:SOURCEDIR} {env:BUILDDIR} {posargs}
 
@@ -179,6 +190,8 @@ setenv =
     {[base]setenv}
     MYPY_CACHE_DIR = {envtmpdir}{/}.mypy_cache
     MYPY_OPTS = --config-file {toxinidir}{/}pyproject.toml
+passenv =
+    {[base]passenv}
 commands =
     # package
     full: mypy {env:MYPY_OPTS} -p easynetwork
@@ -209,6 +222,7 @@ groups =
 setenv =
     {[base]setenv}
 passenv =
+    {[base]passenv}
     PRE_COMMIT_HOME
     XDG_CACHE_HOME
 commands =
@@ -226,6 +240,8 @@ setenv =
     {[pytest-conf]setenv}
     PYTHONHASHSEED = 0
     PYTEST_ADDOPTS = {[pytest-conf]addopts}
+passenv =
+    {[base]passenv}
 commands =
     pytest -c pytest-benchmark.ini {posargs:--benchmark-histogram=benchmark_reports{/}micro_benches{/}benchmark}
 
@@ -260,6 +276,7 @@ setenv =
     BENCHMARK_REPORT_JSON = {toxinidir}{/}benchmark_reports{/}server_benches{/}json{/}{envname}-{env:BENCHMARK_PYTHON_VERSION}-report.json
     BENCHMARK_REPORT_HTML = {toxinidir}{/}benchmark_reports{/}server_benches{/}html{/}{envname}-{env:BENCHMARK_PYTHON_VERSION}-report.html
 passenv =
+    {[base]passenv}
     BENCHMARK_PYTHON_VERSION
     DOCKER_HOST
     DOCKER_CERT_PATH


### PR DESCRIPTION
The docstring of `trio.SocketListener.accept()` explicitly says that these errors are *not* handled, but I have never seen this before.