### PR TITLE
TCP server: Fixed `socket.accept()` stopping the application for ignorable errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,12 @@ name: Test
 
 on:
   workflow_dispatch:
+    inputs:
+      verbose:
+        description: 'Increase level of test verbosity'
+        required: false
+        default: false
+        type: boolean
   pull_request:
     types:
       - opened
@@ -56,8 +62,10 @@ jobs:
             tox_py: py312
           - python_version: '3.13'
             tox_py: py313
+    env:
+      PYTEST_VERBOSE_FLAG: ${{ inputs.verbose && '-v' || '' }}
 
-    name: Tests (${{ matrix.os }}, ${{ matrix.python_version }})
+    name: test (${{ matrix.os }}, ${{ matrix.python_version }})
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,7 +76,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
       - name: Launch tests
         timeout-minutes: 20
-        run: tox run -f ${{ matrix.tox_py }} -- -v
+        run: tox run -f ${{ matrix.tox_py }} -- ${{ env.PYTEST_VERBOSE_FLAG }}
       - name: Generate coverage report
         if: hashFiles('.coverage.*') != ''  # Rudimentary `file.exists()`
         continue-on-error: true

--- a/src/easynetwork/lowlevel/api_async/backend/_asyncio/stream/listener.py
+++ b/src/easynetwork/lowlevel/api_async/backend/_asyncio/stream/listener.py
@@ -122,7 +122,7 @@ class ListenerSocketAdapter(AsyncListener[_T_Stream]):
                     # The remote host closed the connection before starting the task.
                     # See this test for details:
                     # test____serve_forever____accept_client____client_sent_RST_packet_right_after_accept
-                    logger.warning("A client connection was interrupted just after listener.accept()")
+                    pass
                 else:
                     self.__accepted_socket_factory.log_connection_error(logger, exc)
 
@@ -181,7 +181,7 @@ class ListenerSocketAdapter(AsyncListener[_T_Stream]):
                             raise _utils.error_from_errno(_errno.EBADF) from None
                     finally:
                         self.__accept_scope = None
-                else:
+                elif exc.errno not in constants.IGNORABLE_ACCEPT_ERRNOS:
                     raise
 
     def backend(self) -> AsyncBackend:

--- a/src/easynetwork/servers/async_tcp.py
+++ b/src/easynetwork/servers/async_tcp.py
@@ -284,7 +284,6 @@ class AsyncTCPNetworkServer(
 
             client_address = lowlevel_client.extra(INETSocketAttribute.peername, None)
             if client_address is None:
-                self.__client_closed_before_starting_task(self.logger)
                 yield None
                 return
 
@@ -358,16 +357,9 @@ class AsyncTCPNetworkServer(
                 or _utils.is_ssl_eof_error(exc)
                 or exc.errno in constants.NOT_CONNECTED_SOCKET_ERRNOS
             ):
-                cls.__client_closed_before_starting_task(logger)
+                pass
             case _:  # pragma: no cover
                 logger.warning("Error in client task (during TLS handshake)", exc_info=exc)
-
-    @staticmethod
-    def __client_closed_before_starting_task(logger: logging.Logger) -> None:
-        # The remote host closed the connection before starting the task.
-        # See this test for details:
-        # test____serve_forever____accept_client____client_sent_RST_packet_right_after_accept
-        logger.warning("A client connection was interrupted just after listener.accept()")
 
     @_utils.inherit_doc(_base.BaseAsyncNetworkServerImpl)
     def get_addresses(self) -> Sequence[SocketAddress]:

--- a/tests/functional_test/test_communication/test_async/test_client/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_client/test_udp.py
@@ -87,9 +87,7 @@ class TestAsyncUDPNetworkClient:
         async with asyncio.timeout(3):
             assert await server.recvfrom() == (b"ABCDEF", client.get_local_address())
 
-    # Windows and MacOS do not raise error
-    @PlatformMarkers.skipif_platform_win32
-    @PlatformMarkers.skipif_platform_macOS
+    @PlatformMarkers.runs_only_on_platform("linux", "Windows and MacOS do not raise error")
     async def test____send_packet____connection_refused(
         self,
         client: AsyncUDPNetworkClient[str, str],
@@ -99,9 +97,7 @@ class TestAsyncUDPNetworkClient:
         with pytest.raises(ConnectionRefusedError):
             await client.send_packet("ABCDEF")
 
-    # Windows and MacOS do not raise error
-    @PlatformMarkers.skipif_platform_win32
-    @PlatformMarkers.skipif_platform_macOS
+    @PlatformMarkers.runs_only_on_platform("linux", "Windows and MacOS do not raise error")
     async def test____send_packet____connection_refused____after_previous_successful_try(
         self,
         client: AsyncUDPNetworkClient[str, str],

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -624,7 +624,6 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
         from socket import socket as SocketType
 
         caplog.set_level(logging.WARNING, LOGGER.name)
-        logger_crash_maximum_nb_lines[LOGGER.name] = 1
 
         socket = SocketType()
 
@@ -638,10 +637,8 @@ class TestAsyncTCPNetworkServer(BaseTestAsyncServer):
         # and will fail at client initialization when calling socket.getpeername() (errno.ENOTCONN will be raised)
         await asyncio.sleep(0.1)
 
-        # ENOTCONN error should not create a big Traceback error but only a warning (at least)
-        assert len(caplog.records) == 1
-        assert caplog.records[0].levelno == logging.WARNING
-        assert caplog.records[0].message == "A client connection was interrupted just after listener.accept()"
+        # On Linux: ENOTCONN error should not create a big Traceback error
+        assert len(caplog.records) == 0
 
     async def test____serve_forever____client_extra_attributes(
         self,

--- a/tests/functional_test/test_communication/test_sync/test_client/test_udp.py
+++ b/tests/functional_test/test_communication/test_sync/test_client/test_udp.py
@@ -58,17 +58,13 @@ class TestUDPNetworkClient:
         client.send_packet("ABCDEF")
         assert server.recvfrom(1024) == (b"ABCDEF", client.get_local_address())
 
-    # Windows and MacOS do not raise error
-    @PlatformMarkers.skipif_platform_win32
-    @PlatformMarkers.skipif_platform_macOS
+    @PlatformMarkers.runs_only_on_platform("linux", "Windows and MacOS do not raise error")
     def test____send_packet____connection_refused(self, client: UDPNetworkClient[str, str], server: Socket) -> None:
         server.close()
         with pytest.raises(ConnectionRefusedError):
             client.send_packet("ABCDEF")
 
-    # Windows and MacOS do not raise error
-    @PlatformMarkers.skipif_platform_win32
-    @PlatformMarkers.skipif_platform_macOS
+    @PlatformMarkers.runs_only_on_platform("linux", "Windows and MacOS do not raise error")
     def test____send_packet____connection_refused____after_previous_successful_try(
         self,
         client: UDPNetworkClient[str, str],

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -22,7 +22,7 @@ _V_co = TypeVar("_V_co", covariant=True)
 _T_Args = TypeVarTuple("_T_Args")
 
 
-def _make_skipif_platform(platform: str, reason: str, *, skip_only_on_ci: bool) -> pytest.MarkDecorator:
+def _make_skipif_platform(platform: str | tuple[str, ...], reason: str, *, skip_only_on_ci: bool) -> pytest.MarkDecorator:
     condition: bool = sys.platform.startswith(platform)
     if skip_only_on_ci:
         # skip if 'CI' is set to a non-empty value
@@ -32,8 +32,14 @@ def _make_skipif_platform(platform: str, reason: str, *, skip_only_on_ci: bool) 
     return pytest.mark.skipif(condition, reason=reason)
 
 
+def _make_skipif_not_on_platform(platform: str | tuple[str, ...], reason: str) -> pytest.MarkDecorator:
+    return pytest.mark.skipif(not sys.platform.startswith(platform), reason=reason)
+
+
 @final
 class PlatformMarkers:
+    ###### SKIP SOME PLATFORMS ######
+
     @staticmethod
     def skipif_platform_win32_because(reason: str, *, skip_only_on_ci: bool = False) -> pytest.MarkDecorator:
         return _make_skipif_platform("win32", reason, skip_only_on_ci=skip_only_on_ci)
@@ -49,6 +55,12 @@ class PlatformMarkers:
     skipif_platform_win32 = skipif_platform_win32_because("cannot run on Windows")
     skipif_platform_macOS = skipif_platform_macOS_because("cannot run on MacOS")
     skipif_platform_linux = skipif_platform_linux_because("cannot run on Linux")
+
+    ###### RESTRICT TESTS FOR PLATFORMS ######
+
+    @staticmethod
+    def runs_only_on_platform(platform: str | tuple[str, ...], reason: str) -> pytest.MarkDecorator:
+        return _make_skipif_not_on_platform(platform, reason)
 
 
 def send_return(gen: Generator[Any, _T_contra, _V_co], value: _T_contra, /) -> _V_co:


### PR DESCRIPTION
### What's changed
- Some `OSError`s raised by `socket.accept()` are simply ignored.
  - The same list is used between `asyncio` and `trio` for consistency.

### Miscellaneous
- Decreased log verbosity on CI by default