### PR TITLE
Updated github-actions dependencies

### DIFF
--- a/.github/actions/setup-tox/action.yml
+++ b/.github/actions/setup-tox/action.yml
@@ -28,7 +28,7 @@ runs:
       run: cat ${{ env.WORKFLOW_CACHE_KEY_FILE }}
       shell: bash
     - name: Install PDM
-      uses: pdm-project/setup-pdm@v4.2
+      uses: pdm-project/setup-pdm@v4.4
       id: pdm
       with:
         version: ${{ env.PDM_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     env:
       SOURCE_DATE_EPOCH: ${{ inputs.SOURCE_DATE_EPOCH }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup tox
@@ -86,7 +86,7 @@ jobs:
       - name: Build packages
         run: tox run -e build
       - name: Upload packages as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: easynetwork-dist
           path: dist

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,7 +58,7 @@ jobs:
         os: [ubuntu-24.04, windows-2022, macos-14]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup tox
@@ -76,7 +76,7 @@ jobs:
 
     name: type-hinting (freebsd-14.3)
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Launch checks
@@ -97,7 +97,7 @@ jobs:
 
     name: type-hinting (openbsd-7.6)
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Launch checks
@@ -126,7 +126,7 @@ jobs:
 
     name: type-hinting (netbsd-10.1)
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Launch checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     name: Distribute packages
     steps:
       - name: Retrieve packages
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: easynetwork-dist
           path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
 
     name: test (${{ matrix.os }}, ${{ matrix.python_version }})
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup tox (python ${{ matrix.python_version }})
@@ -131,7 +131,7 @@ jobs:
 
     name: test (freebsd-14.3, ${{ matrix.python_version }})
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Launch tests
@@ -196,7 +196,7 @@ jobs:
 
     name: test (openbsd-${{ matrix.os_version }}, ${{ matrix.python_version }})
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Launch tests
@@ -276,7 +276,7 @@ jobs:
 
     name: test (netbsd-10.1, ${{ matrix.python_version }})
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Launch tests


### PR DESCRIPTION
### Changes
- Bump actions/checkout from 5 to 6 (#435)
- Bump actions/download-artifact from 5 to 7 (#436)
- Bump actions/upload-artifact from 4 to 6 (#437)
- Bump pdm-project/setup-pdm from 4.2 to 4.4