### PR TITLE
Selector transports now have methods to get file descriptors

### DIFF
--- a/changelog.d/462.added.1.rst
+++ b/changelog.d/462.added.1.rst
@@ -1,0 +1,1 @@
+Added ``SelectorStreamReadTransport.read_fileno()`` and ``SelectorStreamWriteTransport.write_fileno()`` **abstract** methods.

--- a/changelog.d/462.added.2.rst
+++ b/changelog.d/462.added.2.rst
@@ -1,0 +1,1 @@
+Added ``SelectorDatagramReadTransport.read_fileno()`` and ``SelectorDatagramWriteTransport.write_fileno()`` **abstract** methods.

--- a/changelog.d/462.added.rst
+++ b/changelog.d/462.added.rst
@@ -1,0 +1,1 @@
+Added ``SelectorBaseTransport.read_fileno()`` and ``SelectorBaseTransport.write_fileno()`` methods.

--- a/changelog.d/462.removed.rst
+++ b/changelog.d/462.removed.rst
@@ -1,0 +1,1 @@
+Removed ``fileno`` attribute from ``WouldBlockOnRead`` and ``WouldBlockOnWrite`` exceptions.

--- a/src/easynetwork/lowlevel/api_sync/transports/base_selector.py
+++ b/src/easynetwork/lowlevel/api_sync/transports/base_selector.py
@@ -50,21 +50,9 @@ from . import abc as transports
 class WouldBlockOnRead(Exception):
     """The operation would block when reading the pipe."""
 
-    def __init__(self, fileno: int) -> None:
-        super().__init__(fileno)
-
-        self.fileno: int = fileno
-        """The file descriptor to wait for."""
-
 
 class WouldBlockOnWrite(Exception):
     """The operation would block when writing on the pipe."""
-
-    def __init__(self, fileno: int) -> None:
-        super().__init__(fileno)
-
-        self.fileno: int = fileno
-        """The file descriptor to wait for."""
 
 
 class SelectorBaseTransport(transports.BaseTransport):
@@ -73,8 +61,8 @@ class SelectorBaseTransport(transports.BaseTransport):
     """
 
     __slots__ = (
-        "_retry_interval",
-        "_selector_factory",
+        "__retry_interval",
+        "__selector_factory",
     )
 
     def __init__(self, retry_interval: float, selector_factory: Callable[[], selectors.BaseSelector] | None = None) -> None:
@@ -93,25 +81,44 @@ class SelectorBaseTransport(transports.BaseTransport):
 
         if selector_factory is None:
             selector_factory = getattr(selectors, "PollSelector", selectors.SelectSelector)
-        self._selector_factory: Callable[[], selectors.BaseSelector] = selector_factory
+        self.__selector_factory: Callable[[], selectors.BaseSelector] = selector_factory
 
-        self._retry_interval: float = _utils.validate_timeout_delay(retry_interval, positive_check=False)
-        if self._retry_interval <= 0:
+        self.__retry_interval: float = _utils.validate_timeout_delay(retry_interval, positive_check=False)
+        if self.__retry_interval <= 0:
             raise ValueError("retry_interval must be a strictly positive float")
+
+    def read_fileno(self) -> int:  # pragma: no cover
+        """
+        .. versionadded:: NEXT_VERSION
+
+        Returns:
+            The file descriptor used for I/O reading. May return a negative value if the transport is closed.
+        """
+        raise NotImplementedError
+
+    def write_fileno(self) -> int:  # pragma: no cover
+        """
+        .. versionadded:: NEXT_VERSION
+
+        Returns:
+            The file descriptor used for I/O writing. May return a negative value if the transport is closed.
+        """
+        raise NotImplementedError
 
     def _retry[R](self, callback: Callable[[], R], timeout: float) -> tuple[R, float]:
         """
         Calls `callback` without argument and returns the output.
 
-        If the callable raises :class:`WouldBlockOnRead` or :class:`WouldBlockOnWrite`, waits for
-        :attr:`~.WouldBlockOnRead.fileno` to be available for reading or writing respectively, and retries to call the callback.
+        If the callable raises :class:`WouldBlockOnRead` or :class:`WouldBlockOnWrite`, waits for the corresponding
+        ``fileno`` to be available for reading or writing respectively, and retries to call the callback.
 
         Parameters:
             callback: the function to call.
             timeout: the maximum amount of seconds to wait for the file descriptor to be available.
 
         Raises:
-            TimeoutError: timed out
+            TimeoutError: timed out.
+            OSError: The selector failed to poll the file descriptor.
 
         Returns:
             a tuple with the result of the callback and the timeout which is deduced from the waited time.
@@ -119,18 +126,18 @@ class SelectorBaseTransport(transports.BaseTransport):
         :meta public:
         """
         timeout = _utils.validate_timeout_delay(timeout, positive_check=True)
-        retry_interval = self._retry_interval
+        retry_interval = self.__retry_interval
         event: int
         fileno: int
         while True:
             try:
                 return callback(), timeout
-            except WouldBlockOnRead as exc:
+            except WouldBlockOnRead:
                 event = selectors.EVENT_READ
-                fileno = exc.fileno
-            except WouldBlockOnWrite as exc:
+                fileno = self.read_fileno()
+            except WouldBlockOnWrite:
                 event = selectors.EVENT_WRITE
-                fileno = exc.fileno
+                fileno = self.write_fileno()
             if timeout <= 0:
                 break
             is_retry_interval: bool
@@ -141,7 +148,7 @@ class SelectorBaseTransport(transports.BaseTransport):
             else:
                 is_retry_interval = True
                 wait_time = retry_interval
-            with self._selector_factory() as selector:
+            with self.__selector_factory() as selector:
                 try:
                     selector.register(fileno, event)
                 except ValueError as exc:
@@ -154,10 +161,17 @@ class SelectorBaseTransport(transports.BaseTransport):
                     with _utils.ElapsedTime() as elapsed:
                         available = bool(selector.select(wait_time))
                     timeout = elapsed.recompute_timeout(timeout)
-                    if not available:
-                        if not is_retry_interval:
-                            break
+                    if not available and not is_retry_interval:
+                        break
         raise _utils.error_from_errno(_errno.ETIMEDOUT)
+
+    @property
+    def _retry_interval(self) -> float:
+        return self.__retry_interval
+
+    @property
+    def _selector_factory(self) -> Callable[[], selectors.BaseSelector]:
+        return self.__selector_factory
 
 
 class SelectorStreamReadTransport(SelectorBaseTransport, transports.StreamReadTransport):
@@ -166,6 +180,11 @@ class SelectorStreamReadTransport(SelectorBaseTransport, transports.StreamReadTr
     """
 
     __slots__ = ()
+
+    @abstractmethod
+    @_utils.inherit_doc(SelectorBaseTransport)
+    def read_fileno(self) -> int:
+        raise NotImplementedError
 
     def recv_noblock(self, bufsize: int) -> bytes:
         """
@@ -316,6 +335,11 @@ class SelectorStreamWriteTransport(SelectorBaseTransport, transports.StreamWrite
     __slots__ = ()
 
     @abstractmethod
+    @_utils.inherit_doc(SelectorBaseTransport)
+    def write_fileno(self) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
     def send_noblock(self, data: bytes | bytearray | memoryview) -> int:
         """
         Send the `data` bytes to the remote peer.
@@ -398,6 +422,11 @@ class SelectorDatagramReadTransport(SelectorBaseTransport, transports.DatagramRe
     __slots__ = ()
 
     @abstractmethod
+    @_utils.inherit_doc(SelectorBaseTransport)
+    def read_fileno(self) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
     def recv_noblock(self) -> bytes:
         """
         Read and return the next available packet.
@@ -459,6 +488,11 @@ class SelectorDatagramWriteTransport(SelectorBaseTransport, transports.DatagramW
     """
 
     __slots__ = ()
+
+    @abstractmethod
+    @_utils.inherit_doc(SelectorBaseTransport)
+    def write_fileno(self) -> int:
+        raise NotImplementedError
 
     @abstractmethod
     def send_noblock(self, data: bytes | bytearray | memoryview) -> None:

--- a/src/easynetwork/lowlevel/api_sync/transports/socket.py
+++ b/src/easynetwork/lowlevel/api_sync/transports/socket.py
@@ -107,18 +107,26 @@ class SocketStreamTransport(base_selector.SelectorStreamTransport):
         _close_stream_socket(self.__socket)
 
     @_utils.inherit_doc(base_selector.SelectorStreamTransport)
+    def read_fileno(self) -> int:
+        return self.__socket.fileno()
+
+    @_utils.inherit_doc(base_selector.SelectorStreamTransport)
+    def write_fileno(self) -> int:
+        return self.__socket.fileno()
+
+    @_utils.inherit_doc(base_selector.SelectorStreamTransport)
     def recv_noblock(self, bufsize: int) -> bytes:
         try:
             return self.__socket.recv(bufsize)
         except (BlockingIOError, InterruptedError):
-            raise base_selector.WouldBlockOnRead(self.__socket.fileno()) from None
+            raise base_selector.WouldBlockOnRead from None
 
     @_utils.inherit_doc(base_selector.SelectorStreamTransport)
     def recv_noblock_into(self, buffer: Buffer) -> int:
         try:
             return self.__socket.recv_into(buffer)
         except (BlockingIOError, InterruptedError):
-            raise base_selector.WouldBlockOnRead(self.__socket.fileno()) from None
+            raise base_selector.WouldBlockOnRead from None
 
     if sys.platform != "win32" and hasattr(socket.socket, "recvmsg"):
 
@@ -129,7 +137,7 @@ class SocketStreamTransport(base_selector.SelectorStreamTransport):
             try:
                 msg, ancdata, _, _ = self.__socket.recvmsg(bufsize, ancillary_bufsize)
             except (BlockingIOError, InterruptedError):
-                raise base_selector.WouldBlockOnRead(self.__socket.fileno()) from None
+                raise base_selector.WouldBlockOnRead from None
             else:
                 return msg, ancdata
 
@@ -146,7 +154,7 @@ class SocketStreamTransport(base_selector.SelectorStreamTransport):
             try:
                 nbytes, ancdata, _, _ = self.__socket.recvmsg_into([buffer], ancillary_bufsize)
             except (BlockingIOError, InterruptedError):
-                raise base_selector.WouldBlockOnRead(self.__socket.fileno()) from None
+                raise base_selector.WouldBlockOnRead from None
             else:
                 return nbytes, ancdata
 
@@ -155,7 +163,7 @@ class SocketStreamTransport(base_selector.SelectorStreamTransport):
         try:
             return self.__socket.send(data)
         except (BlockingIOError, InterruptedError):
-            raise base_selector.WouldBlockOnWrite(self.__socket.fileno()) from None
+            raise base_selector.WouldBlockOnWrite from None
 
     if sys.platform != "win32" and hasattr(socket.socket, "sendmsg"):
 
@@ -174,7 +182,7 @@ class SocketStreamTransport(base_selector.SelectorStreamTransport):
                 try:
                     sent = self.__socket.sendmsg(itertools.islice(buffers, constants.SC_IOV_MAX), ancillary_data)
                 except (BlockingIOError, InterruptedError):
-                    raise base_selector.WouldBlockOnWrite(self.__socket.fileno()) from None
+                    raise base_selector.WouldBlockOnWrite from None
                 _utils.adjust_leftover_buffer(buffers, sent)
                 if buffers:
                     raise _utils.error_from_errno(errno.EMSGSIZE)
@@ -203,7 +211,7 @@ class SocketStreamTransport(base_selector.SelectorStreamTransport):
                     try:
                         return socket_sendmsg(itertools.islice(buffers, constants.SC_IOV_MAX))
                     except (BlockingIOError, InterruptedError):
-                        raise base_selector.WouldBlockOnWrite(self.__socket.fileno()) from None
+                        raise base_selector.WouldBlockOnWrite from None
 
                 while True:
                     sent, timeout = self._retry(try_sendmsg, timeout)
@@ -338,6 +346,14 @@ class SSLStreamTransport(base_selector.SelectorStreamTransport):
             _close_stream_socket(self.__socket)
 
     @_utils.inherit_doc(base_selector.SelectorStreamTransport)
+    def read_fileno(self) -> int:
+        return self.__socket.fileno()
+
+    @_utils.inherit_doc(base_selector.SelectorStreamTransport)
+    def write_fileno(self) -> int:
+        return self.__socket.fileno()
+
+    @_utils.inherit_doc(base_selector.SelectorStreamTransport)
     def recv_noblock(self, bufsize: int) -> bytes:
         try:
             return self._try_ssl_method(self.__socket.recv, bufsize)
@@ -376,9 +392,9 @@ class SSLStreamTransport(base_selector.SelectorStreamTransport):
         try:
             return socket_method(*args, **kwargs)
         except (_ssl_module.SSLWantReadError, _ssl_module.SSLSyscallError):
-            raise base_selector.WouldBlockOnRead(self.__socket.fileno()) from None
+            raise base_selector.WouldBlockOnRead from None
         except _ssl_module.SSLWantWriteError:
-            raise base_selector.WouldBlockOnWrite(self.__socket.fileno()) from None
+            raise base_selector.WouldBlockOnWrite from None
 
     @property
     @_utils.inherit_doc(base_selector.SelectorStreamTransport)
@@ -443,12 +459,20 @@ class SocketDatagramTransport(base_selector.SelectorDatagramTransport):
         self.__socket.close()
 
     @_utils.inherit_doc(base_selector.SelectorDatagramTransport)
+    def read_fileno(self) -> int:
+        return self.__socket.fileno()
+
+    @_utils.inherit_doc(base_selector.SelectorDatagramTransport)
+    def write_fileno(self) -> int:
+        return self.__socket.fileno()
+
+    @_utils.inherit_doc(base_selector.SelectorDatagramTransport)
     def recv_noblock(self) -> bytes:
         max_datagram_size: int = self.__max_datagram_size
         try:
             return self.__socket.recv(max_datagram_size)
         except (BlockingIOError, InterruptedError):
-            raise base_selector.WouldBlockOnRead(self.__socket.fileno()) from None
+            raise base_selector.WouldBlockOnRead from None
 
     if sys.platform != "win32" and hasattr(socket.socket, "recvmsg"):
 
@@ -460,7 +484,7 @@ class SocketDatagramTransport(base_selector.SelectorDatagramTransport):
             try:
                 msg, ancdata, _, _ = self.__socket.recvmsg(max_datagram_size, ancillary_bufsize)
             except (BlockingIOError, InterruptedError):
-                raise base_selector.WouldBlockOnRead(self.__socket.fileno()) from None
+                raise base_selector.WouldBlockOnRead from None
             else:
                 return msg, ancdata
 
@@ -469,7 +493,7 @@ class SocketDatagramTransport(base_selector.SelectorDatagramTransport):
         try:
             self.__socket.send(data)
         except (BlockingIOError, InterruptedError):
-            raise base_selector.WouldBlockOnWrite(self.__socket.fileno()) from None
+            raise base_selector.WouldBlockOnWrite from None
 
     if sys.platform != "win32" and hasattr(socket.socket, "sendmsg"):
 
@@ -484,7 +508,7 @@ class SocketDatagramTransport(base_selector.SelectorDatagramTransport):
             try:
                 self.__socket.sendmsg([data], ancillary_data)
             except (BlockingIOError, InterruptedError):
-                raise base_selector.WouldBlockOnWrite(self.__socket.fileno()) from None
+                raise base_selector.WouldBlockOnWrite from None
 
         @_utils.inherit_doc(base_selector.SelectorDatagramTransport)
         def send_with_ancillary(

--- a/tests/unit_test/test_sync/test_lowlevel_api/test_transports/test_selector.py
+++ b/tests/unit_test/test_sync/test_lowlevel_api/test_transports/test_selector.py
@@ -25,6 +25,24 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
+class _MockSelectorTransport(SelectorBaseTransport):
+    _internal_read_fd = 123
+    _internal_write_fd = 456
+
+    def close(self) -> None:
+        self._internal_read_fd = -1
+        self._internal_write_fd = -1
+
+    def is_closed(self) -> bool:
+        return self._internal_write_fd < 0 or self._internal_read_fd < 0
+
+    def read_fileno(self) -> int:
+        return self._internal_read_fd
+
+    def write_fileno(self) -> int:
+        return self._internal_write_fd
+
+
 class TestSelectorBaseTransport:
     @pytest.fixture(autouse=True)
     @staticmethod
@@ -57,23 +75,19 @@ class TestSelectorBaseTransport:
 
     @pytest.fixture
     @staticmethod
-    def mock_transport(retry_interval: float, mock_selector: MagicMock, mocker: MockerFixture) -> MagicMock:
-        mock_transport = mocker.NonCallableMagicMock(spec=SelectorBaseTransport)
-        SelectorBaseTransport.__init__(mock_transport, retry_interval, lambda: mock_selector)
-        return mock_transport
+    def mock_transport(retry_interval: float, mock_selector: MagicMock) -> _MockSelectorTransport:
+        return _MockSelectorTransport(retry_interval, lambda: mock_selector)
 
     @pytest.mark.parametrize("retry_interval", [math.nan, -4, 0], ids=repr)
     def test____dunder_init____invalid_retry_interval(
         self,
         retry_interval: float,
-        mocker: MockerFixture,
     ) -> None:
         # Arrange
-        mock_transport = mocker.NonCallableMagicMock(spec=SelectorBaseTransport)
 
         # Act & Assert
         with pytest.raises(ValueError):
-            SelectorBaseTransport.__init__(mock_transport, retry_interval)
+            _MockSelectorTransport(retry_interval)
 
     def test____dunder_init____selector_factory____default_to_PollSelector(
         self,
@@ -81,10 +95,9 @@ class TestSelectorBaseTransport:
     ) -> None:
         # Arrange
         mock_selector_cls = mocker.patch("selectors.PollSelector", create=True)
-        mock_transport = mocker.NonCallableMagicMock(spec=SelectorBaseTransport)
 
         # Act
-        SelectorBaseTransport.__init__(mock_transport, math.inf)
+        mock_transport = _MockSelectorTransport(math.inf)
 
         # Assert
         assert mock_transport._selector_factory is mock_selector_cls
@@ -96,11 +109,10 @@ class TestSelectorBaseTransport:
     ) -> None:
         # Arrange
         mock_selector_cls = mocker.patch("selectors.SelectSelector")
-        mock_transport = mocker.NonCallableMagicMock(spec=SelectorBaseTransport)
         monkeypatch.delattr("selectors.PollSelector", raising=False)
 
         # Act
-        SelectorBaseTransport.__init__(mock_transport, math.inf)
+        mock_transport = _MockSelectorTransport(math.inf)
 
         # Assert
         assert mock_transport._selector_factory is mock_selector_cls
@@ -109,7 +121,7 @@ class TestSelectorBaseTransport:
     def test____retry____invalid_timeout_value(
         self,
         timeout: float,
-        mock_transport: MagicMock,
+        mock_transport: _MockSelectorTransport,
         mocker: MockerFixture,
     ) -> None:
         # Arrange
@@ -117,7 +129,7 @@ class TestSelectorBaseTransport:
 
         # Act & Assert
         with pytest.raises(ValueError):
-            SelectorBaseTransport._retry(mock_transport, callback, timeout)
+            mock_transport._retry(callback, timeout)
 
         callback.assert_not_called()
 
@@ -132,21 +144,24 @@ class TestSelectorBaseTransport:
         self,
         blocking_error: type[WouldBlockOnRead] | type[WouldBlockOnWrite],
         selector_event: int,
-        mock_transport: MagicMock,
+        mock_transport: _MockSelectorTransport,
         mock_selector_register: MagicMock,
         mock_selector_select: MagicMock,
         mocker: MockerFixture,
     ) -> None:
         # Arrange
         callback = mocker.stub()
-        callback.side_effect = [blocking_error(mocker.sentinel.fd), mocker.sentinel.result]
+        callback.side_effect = [blocking_error, mocker.sentinel.result]
 
         # Act
-        result, timeout = SelectorBaseTransport._retry(mock_transport, callback, math.inf)
+        result, timeout = mock_transport._retry(callback, math.inf)
 
         # Assert
         assert callback.call_args_list == [mocker.call() for _ in range(2)]
-        mock_selector_register.assert_called_once_with(mocker.sentinel.fd, selector_event)
+        if selector_event == EVENT_READ:
+            mock_selector_register.assert_called_once_with(mock_transport._internal_read_fd, selector_event)
+        else:
+            mock_selector_register.assert_called_once_with(mock_transport._internal_write_fd, selector_event)
         mock_selector_select.assert_called_once_with()
         assert result is mocker.sentinel.result
         assert timeout == math.inf
@@ -162,94 +177,81 @@ class TestSelectorBaseTransport:
         self,
         blocking_error: type[WouldBlockOnRead] | type[WouldBlockOnWrite],
         selector_event: int,
-        mock_transport: MagicMock,
+        mock_transport: _MockSelectorTransport,
         mock_selector_register: MagicMock,
         mock_selector_select: MagicMock,
         mocker: MockerFixture,
     ) -> None:
         # Arrange
+        mock_transport.close()
         callback = mocker.stub()
-        callback.side_effect = [blocking_error(mocker.sentinel.fd), mocker.sentinel.result]
+        callback.side_effect = [blocking_error, mocker.sentinel.result]
         mock_selector_register.side_effect = ValueError
 
         # Act & Assert
         with pytest.raises(OSError) as exc_info:
-            SelectorBaseTransport._retry(mock_transport, callback, math.inf)
+            mock_transport._retry(callback, math.inf)
 
         # Assert
         callback.assert_called_once_with()
-        mock_selector_register.assert_called_once_with(mocker.sentinel.fd, selector_event)
+        mock_selector_register.assert_called_once_with(-1, selector_event)
         mock_selector_select.assert_not_called()
         assert exc_info.value.errno == errno.EBADF
         assert isinstance(exc_info.value.__cause__, ValueError)
 
-    @pytest.mark.parametrize(
-        ["blocking_error", "selector_event"],
-        [
-            pytest.param(WouldBlockOnRead, EVENT_READ),
-            pytest.param(WouldBlockOnWrite, EVENT_WRITE),
-        ],
-    )
+    @pytest.mark.parametrize("blocking_error", [WouldBlockOnRead, WouldBlockOnWrite])
     def test____retry____runtime_error_fd_not_available(
         self,
         blocking_error: type[WouldBlockOnRead] | type[WouldBlockOnWrite],
-        selector_event: int,
-        mock_transport: MagicMock,
+        mock_transport: _MockSelectorTransport,
         mock_selector_register: MagicMock,
         mock_selector_select: MagicMock,
         mocker: MockerFixture,
     ) -> None:
         # Arrange
         callback = mocker.stub()
-        callback.side_effect = [blocking_error(mocker.sentinel.fd), mocker.sentinel.result]
+        callback.side_effect = [blocking_error, mocker.sentinel.result]
         mock_selector_select.side_effect = [[]]
 
         # Act & Assert
         with pytest.raises(RuntimeError, match=r"^timeout error with infinite timeout$"):
-            SelectorBaseTransport._retry(mock_transport, callback, math.inf)
+            mock_transport._retry(callback, math.inf)
 
         # Assert
         callback.assert_called_once_with()
-        mock_selector_register.assert_called_once_with(mocker.sentinel.fd, selector_event)
+        mock_selector_register.assert_called_once()
         mock_selector_select.assert_called_once_with()
 
     @pytest.mark.parametrize("blocking_error", [WouldBlockOnRead, WouldBlockOnWrite])
     def test____retry____null_timeout(
         self,
         blocking_error: type[WouldBlockOnRead] | type[WouldBlockOnWrite],
-        mock_transport: MagicMock,
+        mock_transport: _MockSelectorTransport,
         mock_selector_register: MagicMock,
         mock_selector_select: MagicMock,
         mocker: MockerFixture,
     ) -> None:
         # Arrange
         callback = mocker.stub()
-        callback.side_effect = [blocking_error(mocker.sentinel.fd), mocker.sentinel.result]
+        callback.side_effect = [blocking_error, mocker.sentinel.result]
 
         # Act & Assert
         with pytest.raises(TimeoutError):
-            SelectorBaseTransport._retry(mock_transport, callback, 0.0)
+            mock_transport._retry(callback, 0.0)
 
         # Assert
         callback.assert_called_once_with()
         mock_selector_register.assert_not_called()
         mock_selector_select.assert_not_called()
 
-    @pytest.mark.parametrize(
-        ["blocking_error", "selector_event"],
-        [
-            pytest.param(WouldBlockOnRead, EVENT_READ),
-            pytest.param(WouldBlockOnWrite, EVENT_WRITE),
-        ],
-    )
+    @pytest.mark.parametrize("blocking_error", [WouldBlockOnRead, WouldBlockOnWrite])
     @pytest.mark.parametrize("available", [False, True], ids=lambda p: f"available=={p}")
     @pytest.mark.parametrize("retry_interval", [math.inf, 5], ids=lambda p: f"retry_interval=={p}", indirect=True)
     def test____retry____timeout(
         self,
         blocking_error: type[WouldBlockOnRead] | type[WouldBlockOnWrite],
-        selector_event: int,
         available: bool,
-        mock_transport: MagicMock,
+        mock_transport: _MockSelectorTransport,
         mock_selector_register: MagicMock,
         mock_selector_select: MagicMock,
         mock_time_perfcounter: MagicMock,
@@ -257,7 +259,7 @@ class TestSelectorBaseTransport:
     ) -> None:
         # Arrange
         callback = mocker.stub()
-        callback.side_effect = [blocking_error(mocker.sentinel.fd), mocker.sentinel.result]
+        callback.side_effect = [blocking_error, mocker.sentinel.result]
         if not available:
             mock_selector_select.return_value = []
         now = 12345
@@ -271,10 +273,10 @@ class TestSelectorBaseTransport:
         result = None
         reduced_timeout = None
         with pytest.raises(TimeoutError) if not available else contextlib.nullcontext():
-            result, reduced_timeout = SelectorBaseTransport._retry(mock_transport, callback, timeout)
+            result, reduced_timeout = mock_transport._retry(callback, timeout)
 
         # Assert
-        mock_selector_register.assert_called_once_with(mocker.sentinel.fd, selector_event)
+        mock_selector_register.assert_called_once()
         mock_selector_select.assert_called_once_with(timeout)
         if available:
             assert callback.call_args_list == [mocker.call() for _ in range(2)]
@@ -300,7 +302,7 @@ class TestSelectorBaseTransport:
         selector_event: int,
         available: bool,
         retry_interval: float,
-        mock_transport: MagicMock,
+        mock_transport: _MockSelectorTransport,
         mock_selector_register: MagicMock,
         mock_selector_select: MagicMock,
         mock_time_perfcounter: MagicMock,
@@ -309,9 +311,9 @@ class TestSelectorBaseTransport:
         # Arrange
         callback = mocker.stub()
         callback.side_effect = [
-            blocking_error(mocker.sentinel.fd),
-            blocking_error(mocker.sentinel.fd),
-            blocking_error(mocker.sentinel.fd),
+            blocking_error,
+            blocking_error,
+            blocking_error,
             mocker.sentinel.result,
         ]
         if not available:
@@ -332,10 +334,17 @@ class TestSelectorBaseTransport:
         result = None
         reduced_timeout = None
         with pytest.raises(TimeoutError) if not available else contextlib.nullcontext():
-            result, reduced_timeout = SelectorBaseTransport._retry(mock_transport, callback, timeout)
+            result, reduced_timeout = mock_transport._retry(callback, timeout)
 
         # Assert
-        assert mock_selector_register.call_args_list == [mocker.call(mocker.sentinel.fd, selector_event) for _ in range(3)]
+        if selector_event == EVENT_READ:
+            assert mock_selector_register.call_args_list == [
+                mocker.call(mock_transport._internal_read_fd, selector_event) for _ in range(3)
+            ]
+        else:
+            assert mock_selector_register.call_args_list == [
+                mocker.call(mock_transport._internal_write_fd, selector_event) for _ in range(3)
+            ]
         assert mock_selector_select.call_args_list == [mocker.call(retry_interval) for _ in range(2)] + [mocker.call(0.5)]
         if available:
             assert callback.call_args_list == [mocker.call() for _ in range(4)]
@@ -368,8 +377,8 @@ class TestSelectorStreamTransport:
     ) -> None:
         # Arrange
         mock_transport.recv_noblock.side_effect = [
-            WouldBlockOnRead(mocker.sentinel.fd),
-            WouldBlockOnWrite(mocker.sentinel.fd),
+            WouldBlockOnRead,
+            WouldBlockOnWrite,
             (mocker.sentinel.bytes, mocker.sentinel.timeout),
         ]
 
@@ -388,8 +397,8 @@ class TestSelectorStreamTransport:
     ) -> None:
         # Arrange
         mock_transport.recv_noblock_into.side_effect = [
-            WouldBlockOnRead(mocker.sentinel.fd),
-            WouldBlockOnWrite(mocker.sentinel.fd),
+            WouldBlockOnRead,
+            WouldBlockOnWrite,
             (mocker.sentinel.nb_bytes_written, mocker.sentinel.timeout),
         ]
 
@@ -408,8 +417,8 @@ class TestSelectorStreamTransport:
     ) -> None:
         # Arrange
         mock_transport.recv_noblock_with_ancillary.side_effect = [
-            WouldBlockOnRead(mocker.sentinel.fd),
-            WouldBlockOnWrite(mocker.sentinel.fd),
+            WouldBlockOnRead,
+            WouldBlockOnWrite,
             ((mocker.sentinel.bytes, mocker.sentinel.ancillary_data), mocker.sentinel.timeout),
         ]
 
@@ -436,8 +445,8 @@ class TestSelectorStreamTransport:
     ) -> None:
         # Arrange
         mock_transport.recv_noblock_with_ancillary_into.side_effect = [
-            WouldBlockOnRead(mocker.sentinel.fd),
-            WouldBlockOnWrite(mocker.sentinel.fd),
+            WouldBlockOnRead,
+            WouldBlockOnWrite,
             ((mocker.sentinel.nb_bytes_written, mocker.sentinel.ancillary_data), mocker.sentinel.timeout),
         ]
 
@@ -528,8 +537,8 @@ class TestSelectorStreamTransport:
     ) -> None:
         # Arrange
         mock_transport.send_noblock.side_effect = [
-            WouldBlockOnRead(mocker.sentinel.fd),
-            WouldBlockOnWrite(mocker.sentinel.fd),
+            WouldBlockOnRead,
+            WouldBlockOnWrite,
             (mocker.sentinel.nb_sent_bytes, mocker.sentinel.timeout),
         ]
 
@@ -548,8 +557,8 @@ class TestSelectorStreamTransport:
     ) -> None:
         # Arrange
         mock_transport.send_all_noblock_with_ancillary.side_effect = [
-            WouldBlockOnRead(mocker.sentinel.fd),
-            WouldBlockOnWrite(mocker.sentinel.fd),
+            WouldBlockOnRead,
+            WouldBlockOnWrite,
             (None, mocker.sentinel.timeout),
         ]
 
@@ -574,8 +583,8 @@ class TestSelectorStreamTransport:
     ) -> None:
         # Arrange
         mock_transport.send_all_noblock_with_ancillary.side_effect = [
-            WouldBlockOnRead(mocker.sentinel.fd),
-            WouldBlockOnWrite(mocker.sentinel.fd),
+            WouldBlockOnRead,
+            WouldBlockOnWrite,
             (None, mocker.sentinel.timeout),
         ]
 
@@ -607,8 +616,8 @@ class TestSelectorDatagramTransport:
     ) -> None:
         # Arrange
         mock_transport.recv_noblock.side_effect = [
-            WouldBlockOnRead(mocker.sentinel.fd),
-            WouldBlockOnWrite(mocker.sentinel.fd),
+            WouldBlockOnRead,
+            WouldBlockOnWrite,
             (mocker.sentinel.bytes, mocker.sentinel.timeout),
         ]
 
@@ -627,8 +636,8 @@ class TestSelectorDatagramTransport:
     ) -> None:
         # Arrange
         mock_transport.recv_noblock_with_ancillary.side_effect = [
-            WouldBlockOnRead(mocker.sentinel.fd),
-            WouldBlockOnWrite(mocker.sentinel.fd),
+            WouldBlockOnRead,
+            WouldBlockOnWrite,
             ((mocker.sentinel.bytes, mocker.sentinel.ancillary_data), mocker.sentinel.timeout),
         ]
 
@@ -654,8 +663,8 @@ class TestSelectorDatagramTransport:
     ) -> None:
         # Arrange
         mock_transport.send_noblock.side_effect = [
-            WouldBlockOnRead(mocker.sentinel.fd),
-            WouldBlockOnWrite(mocker.sentinel.fd),
+            WouldBlockOnRead,
+            WouldBlockOnWrite,
             (None, mocker.sentinel.timeout),
         ]
 
@@ -673,8 +682,8 @@ class TestSelectorDatagramTransport:
     ) -> None:
         # Arrange
         mock_transport.send_noblock_with_ancillary.side_effect = [
-            WouldBlockOnRead(mocker.sentinel.fd),
-            WouldBlockOnWrite(mocker.sentinel.fd),
+            WouldBlockOnRead,
+            WouldBlockOnWrite,
             (None, mocker.sentinel.timeout),
         ]
 

--- a/tests/unit_test/test_sync/test_lowlevel_api/test_transports/test_socket.py
+++ b/tests/unit_test/test_sync/test_lowlevel_api/test_transports/test_socket.py
@@ -11,7 +11,7 @@ from socket import AF_INET, SHUT_RDWR, SHUT_WR
 from typing import TYPE_CHECKING, Any
 
 from easynetwork.exceptions import TypedAttributeLookupError, UnsupportedOperation
-from easynetwork.lowlevel.api_sync.transports.base_selector import WouldBlockOnRead, WouldBlockOnWrite
+from easynetwork.lowlevel.api_sync.transports.base_selector import SelectorBaseTransport, WouldBlockOnRead, WouldBlockOnWrite
 from easynetwork.lowlevel.api_sync.transports.socket import SocketDatagramTransport, SocketStreamTransport, SSLStreamTransport
 from easynetwork.lowlevel.constants import (
     CLOSED_SOCKET_ERRNOS,
@@ -32,12 +32,14 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
-def _retry_side_effect(self: Any, callback: Callable[[], Any], timeout: float) -> tuple[Any, float]:
+def _retry_side_effect(self: SelectorBaseTransport, callback: Callable[[], Any], timeout: float) -> tuple[Any, float]:
     while True:
         try:
             return callback(), timeout
-        except (WouldBlockOnRead, WouldBlockOnWrite):
-            pass
+        except WouldBlockOnRead:
+            self.read_fileno()
+        except WouldBlockOnWrite:
+            self.write_fileno()
 
 
 _SUPPORTS_ANCILLARY = ("AF_UNIX",)
@@ -202,6 +204,34 @@ class TestSocketStreamTransport(BaseTestSocketTransport, MixinTestSocketSendMSG)
         # Assert
         assert mock_stream_socket.mock_calls == [mocker.call.shutdown(SHUT_RDWR), mocker.call.close()]
 
+    @pytest.mark.parametrize("socket_fileno", [0, 12345, -1, -42], indirect=True)
+    def test____read_fileno____socket_fileno(
+        self,
+        socket_fileno: int,
+        transport: SocketStreamTransport,
+    ) -> None:
+        # Arrange
+
+        # Act
+        fd = transport.read_fileno()
+
+        # Assert
+        assert fd == socket_fileno
+
+    @pytest.mark.parametrize("socket_fileno", [0, 12345, -1, -42], indirect=True)
+    def test____write_fileno____socket_fileno(
+        self,
+        socket_fileno: int,
+        transport: SocketStreamTransport,
+    ) -> None:
+        # Arrange
+
+        # Act
+        fd = transport.write_fileno()
+
+        # Assert
+        assert fd == socket_fileno
+
     def test____recv_noblock____default(
         self,
         transport: SocketStreamTransport,
@@ -231,13 +261,12 @@ class TestSocketStreamTransport(BaseTestSocketTransport, MixinTestSocketSendMSG)
         mock_stream_socket.recv.side_effect = error
 
         # Act
-        with pytest.raises(WouldBlockOnRead) as exc_info:
+        with pytest.raises(WouldBlockOnRead):
             transport.recv_noblock(mocker.sentinel.bufsize)
 
         # Assert
         mock_stream_socket.recv.assert_called_once_with(mocker.sentinel.bufsize)
-        mock_stream_socket.fileno.assert_called_once()
-        assert exc_info.value.fileno is mock_stream_socket.fileno.return_value
+        mock_stream_socket.fileno.assert_not_called()
 
     def test____recv_noblock_into____default(
         self,
@@ -268,13 +297,12 @@ class TestSocketStreamTransport(BaseTestSocketTransport, MixinTestSocketSendMSG)
         mock_stream_socket.recv_into.side_effect = error
 
         # Act
-        with pytest.raises(WouldBlockOnRead) as exc_info:
+        with pytest.raises(WouldBlockOnRead):
             transport.recv_noblock_into(mocker.sentinel.buffer)
 
         # Assert
         mock_stream_socket.recv_into.assert_called_once_with(mocker.sentinel.buffer)
-        mock_stream_socket.fileno.assert_called_once()
-        assert exc_info.value.fileno is mock_stream_socket.fileno.return_value
+        mock_stream_socket.fileno.assert_not_called()
 
     @PlatformMarkers.supports_socket_recvmsg
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
@@ -329,13 +357,12 @@ class TestSocketStreamTransport(BaseTestSocketTransport, MixinTestSocketSendMSG)
         mock_stream_socket.recvmsg.side_effect = error
 
         # Act
-        with pytest.raises(WouldBlockOnRead) as exc_info:
+        with pytest.raises(WouldBlockOnRead):
             transport.recv_noblock_with_ancillary(mocker.sentinel.bufsize, mocker.sentinel.ancbufsize)
 
         # Assert
         mock_stream_socket.recvmsg.assert_called_once_with(mocker.sentinel.bufsize, mocker.sentinel.ancbufsize)
-        mock_stream_socket.fileno.assert_called_once()
-        assert exc_info.value.fileno is mock_stream_socket.fileno.return_value
+        mock_stream_socket.fileno.assert_not_called()
 
     @PlatformMarkers.supports_socket_recvmsg_into
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
@@ -400,13 +427,12 @@ class TestSocketStreamTransport(BaseTestSocketTransport, MixinTestSocketSendMSG)
         mock_stream_socket.recvmsg_into.side_effect = error
 
         # Act
-        with pytest.raises(WouldBlockOnRead) as exc_info:
+        with pytest.raises(WouldBlockOnRead):
             transport.recv_noblock_with_ancillary_into(mocker.sentinel.buffer, mocker.sentinel.ancbufsize)
 
         # Assert
         mock_stream_socket.recvmsg_into.assert_called_once_with([mocker.sentinel.buffer], mocker.sentinel.ancbufsize)
-        mock_stream_socket.fileno.assert_called_once()
-        assert exc_info.value.fileno is mock_stream_socket.fileno.return_value
+        mock_stream_socket.fileno.assert_not_called()
 
     def test____send_noblock____default(
         self,
@@ -437,13 +463,12 @@ class TestSocketStreamTransport(BaseTestSocketTransport, MixinTestSocketSendMSG)
         mock_stream_socket.send.side_effect = error
 
         # Act
-        with pytest.raises(WouldBlockOnWrite) as exc_info:
+        with pytest.raises(WouldBlockOnWrite):
             transport.send_noblock(mocker.sentinel.data)
 
         # Assert
         mock_stream_socket.send.assert_called_once_with(mocker.sentinel.data)
-        mock_stream_socket.fileno.assert_called_once()
-        assert exc_info.value.fileno is mock_stream_socket.fileno.return_value
+        mock_stream_socket.fileno.assert_not_called()
 
     @PlatformMarkers.supports_socket_sendmsg
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
@@ -568,13 +593,12 @@ class TestSocketStreamTransport(BaseTestSocketTransport, MixinTestSocketSendMSG)
         mock_stream_socket.sendmsg.side_effect = error
 
         # Act
-        with pytest.raises(WouldBlockOnWrite) as exc_info:
+        with pytest.raises(WouldBlockOnWrite):
             transport.send_all_noblock_with_ancillary(iter([b"data", b"to", b"send"]), mocker.sentinel.ancdata)
 
         # Assert
         mock_stream_socket.sendmsg.assert_called_once_with(mocker.ANY, mocker.sentinel.ancdata)
-        mock_stream_socket.fileno.assert_called_once()
-        assert exc_info.value.fileno is mock_stream_socket.fileno.return_value
+        mock_stream_socket.fileno.assert_not_called()
 
     @PlatformMarkers.supports_socket_sendmsg
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
@@ -1197,6 +1221,34 @@ class TestSSLStreamTransport:
             ]
             mock_transport_retry.assert_not_called()
 
+    @pytest.mark.parametrize("socket_fileno", [0, 12345, -1, -42], indirect=True)
+    def test____read_fileno____socket_fileno(
+        self,
+        socket_fileno: int,
+        transport: SSLStreamTransport,
+    ) -> None:
+        # Arrange
+
+        # Act
+        fd = transport.read_fileno()
+
+        # Assert
+        assert fd == socket_fileno
+
+    @pytest.mark.parametrize("socket_fileno", [0, 12345, -1, -42], indirect=True)
+    def test____write_fileno____socket_fileno(
+        self,
+        socket_fileno: int,
+        transport: SSLStreamTransport,
+    ) -> None:
+        # Arrange
+
+        # Act
+        fd = transport.write_fileno()
+
+        # Assert
+        assert fd == socket_fileno
+
     def test____recv_noblock____default(
         self,
         transport: SSLStreamTransport,
@@ -1234,14 +1286,12 @@ class TestSSLStreamTransport:
         mock_ssl_socket.recv.side_effect = error
 
         # Act
-        with pytest.raises(expected_blocking_error) as exc_info:
+        with pytest.raises(expected_blocking_error):
             transport.recv_noblock(mocker.sentinel.bufsize)
 
         # Assert
         mock_ssl_socket.recv.assert_called_once_with(mocker.sentinel.bufsize)
-        mock_ssl_socket.fileno.assert_called_once()
-        assert isinstance(exc_info.value, (WouldBlockOnRead, WouldBlockOnWrite))
-        assert exc_info.value.fileno is mock_ssl_socket.fileno.return_value
+        mock_ssl_socket.fileno.assert_not_called()
 
     def test____recv_noblock____SSLZeroReturnError(
         self,
@@ -1297,14 +1347,12 @@ class TestSSLStreamTransport:
         mock_ssl_socket.recv_into.side_effect = error
 
         # Act
-        with pytest.raises(expected_blocking_error) as exc_info:
+        with pytest.raises(expected_blocking_error):
             transport.recv_noblock_into(mocker.sentinel.buffer)
 
         # Assert
         mock_ssl_socket.recv_into.assert_called_once_with(mocker.sentinel.buffer)
-        mock_ssl_socket.fileno.assert_called_once()
-        assert isinstance(exc_info.value, (WouldBlockOnRead, WouldBlockOnWrite))
-        assert exc_info.value.fileno is mock_ssl_socket.fileno.return_value
+        mock_ssl_socket.fileno.assert_not_called()
 
     def test____recv_noblock_into____SSLZeroReturnError(
         self,
@@ -1360,14 +1408,12 @@ class TestSSLStreamTransport:
         mock_ssl_socket.send.side_effect = error
 
         # Act
-        with pytest.raises(expected_blocking_error) as exc_info:
+        with pytest.raises(expected_blocking_error):
             transport.send_noblock(mocker.sentinel.data)
 
         # Assert
         mock_ssl_socket.send.assert_called_once_with(mocker.sentinel.data)
-        mock_ssl_socket.fileno.assert_called_once()
-        assert isinstance(exc_info.value, (WouldBlockOnRead, WouldBlockOnWrite))
-        assert exc_info.value.fileno is mock_ssl_socket.fileno.return_value
+        mock_ssl_socket.fileno.assert_not_called()
 
     def test____send_noblock____SSLZeroReturnError(
         self,
@@ -1655,6 +1701,34 @@ class TestSocketDatagramTransport(BaseTestSocketTransport):
         # Assert
         assert mock_datagram_socket.mock_calls == [mocker.call.close()]
 
+    @pytest.mark.parametrize("socket_fileno", [0, 12345, -1, -42], indirect=True)
+    def test____read_fileno____socket_fileno(
+        self,
+        socket_fileno: int,
+        transport: SocketDatagramTransport,
+    ) -> None:
+        # Arrange
+
+        # Act
+        fd = transport.read_fileno()
+
+        # Assert
+        assert fd == socket_fileno
+
+    @pytest.mark.parametrize("socket_fileno", [0, 12345, -1, -42], indirect=True)
+    def test____write_fileno____socket_fileno(
+        self,
+        socket_fileno: int,
+        transport: SocketDatagramTransport,
+    ) -> None:
+        # Arrange
+
+        # Act
+        fd = transport.write_fileno()
+
+        # Assert
+        assert fd == socket_fileno
+
     @pytest.mark.parametrize("max_datagram_size", [None, 1024], ids=lambda p: f"max_datagram_size=={p}", indirect=True)
     def test____recv_noblock____default(
         self,
@@ -1690,7 +1764,7 @@ class TestSocketDatagramTransport(BaseTestSocketTransport):
         mock_datagram_socket.recv.side_effect = error
 
         # Act
-        with pytest.raises(WouldBlockOnRead) as exc_info:
+        with pytest.raises(WouldBlockOnRead):
             transport.recv_noblock()
 
         # Assert
@@ -1698,8 +1772,7 @@ class TestSocketDatagramTransport(BaseTestSocketTransport):
             mock_datagram_socket.recv.assert_called_once_with(MAX_DATAGRAM_BUFSIZE)
         else:
             mock_datagram_socket.recv.assert_called_once_with(max_datagram_size)
-        mock_datagram_socket.fileno.assert_called_once()
-        assert exc_info.value.fileno is mock_datagram_socket.fileno.return_value
+        mock_datagram_socket.fileno.assert_not_called()
 
     @PlatformMarkers.supports_socket_recvmsg
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
@@ -1761,7 +1834,7 @@ class TestSocketDatagramTransport(BaseTestSocketTransport):
         mock_datagram_socket.recvmsg.side_effect = error
 
         # Act
-        with pytest.raises(WouldBlockOnRead) as exc_info:
+        with pytest.raises(WouldBlockOnRead):
             transport.recv_noblock_with_ancillary(mocker.sentinel.ancbufsize)
 
         # Assert
@@ -1769,8 +1842,7 @@ class TestSocketDatagramTransport(BaseTestSocketTransport):
             mock_datagram_socket.recvmsg.assert_called_once_with(MAX_DATAGRAM_BUFSIZE, mocker.sentinel.ancbufsize)
         else:
             mock_datagram_socket.recvmsg.assert_called_once_with(max_datagram_size, mocker.sentinel.ancbufsize)
-        mock_datagram_socket.fileno.assert_called_once()
-        assert exc_info.value.fileno is mock_datagram_socket.fileno.return_value
+        mock_datagram_socket.fileno.assert_not_called()
 
     def test____send_noblock____default(
         self,
@@ -1801,13 +1873,12 @@ class TestSocketDatagramTransport(BaseTestSocketTransport):
         mock_datagram_socket.send.side_effect = error
 
         # Act
-        with pytest.raises(WouldBlockOnWrite) as exc_info:
+        with pytest.raises(WouldBlockOnWrite):
             transport.send_noblock(mocker.sentinel.data)
 
         # Assert
         mock_datagram_socket.send.assert_called_once_with(mocker.sentinel.data)
-        mock_datagram_socket.fileno.assert_called_once()
-        assert exc_info.value.fileno is mock_datagram_socket.fileno.return_value
+        mock_datagram_socket.fileno.assert_not_called()
 
     @PlatformMarkers.supports_socket_sendmsg
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
@@ -1861,13 +1932,12 @@ class TestSocketDatagramTransport(BaseTestSocketTransport):
         mock_datagram_socket.sendmsg.side_effect = error
 
         # Act
-        with pytest.raises(WouldBlockOnWrite) as exc_info:
+        with pytest.raises(WouldBlockOnWrite):
             transport.send_noblock_with_ancillary(mocker.sentinel.data, mocker.sentinel.ancdata)
 
         # Assert
         mock_datagram_socket.sendmsg.assert_called_once_with([mocker.sentinel.data], mocker.sentinel.ancdata)
-        mock_datagram_socket.fileno.assert_called_once()
-        assert exc_info.value.fileno is mock_datagram_socket.fileno.return_value
+        mock_datagram_socket.fileno.assert_not_called()
 
     @PlatformMarkers.supports_socket_sendmsg
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)


### PR DESCRIPTION
- Removed `fileno` attributes from `WouldBlockOnRead` and `WouldBlockOnWrite`.
- Added `SelectorBaseTransport.read_fileno()` and `SelectorBaseTransport.write_fileno()`