### PR TITLE
Removed "=" and ":" characters from test parameters IDs

### DIFF
--- a/micro_benchmarks/serializers/bench_cbor.py
+++ b/micro_benchmarks/serializers/bench_cbor.py
@@ -49,7 +49,7 @@ def bench_CBORSerializer_incremental_serialize(
 
 
 @pytest.mark.benchmark(group=SerializerGroup.JSON_INCREMENTAL_DESERIALIZE)
-@pytest.mark.parametrize("buffered", [False, True], ids=lambda p: f"buffered=={p}")
+@pytest.mark.parametrize("buffered", [False, True], ids=lambda p: f"buffered__{p}")
 def bench_CBORSerializer_incremental_deserialize(
     buffered: bool,
     benchmark: BenchmarkFixture,

--- a/micro_benchmarks/serializers/bench_json.py
+++ b/micro_benchmarks/serializers/bench_json.py
@@ -39,7 +39,7 @@ def bench_JSONSerializer_deserialize(
 
 
 @pytest.mark.benchmark(group=SerializerGroup.JSON_INCREMENTAL_SERIALIZE)
-@pytest.mark.parametrize("use_lines", [False, True], ids=lambda p: f"use_lines=={p}")
+@pytest.mark.parametrize("use_lines", [False, True], ids=lambda p: f"use_lines__{p}")
 def bench_JSONSerializer_incremental_serialize(
     use_lines: bool,
     benchmark: BenchmarkFixture,
@@ -51,8 +51,8 @@ def bench_JSONSerializer_incremental_serialize(
 
 
 @pytest.mark.benchmark(group=SerializerGroup.JSON_INCREMENTAL_DESERIALIZE)
-@pytest.mark.parametrize("use_lines", [False, True], ids=lambda p: f"use_lines=={p}")
-@pytest.mark.parametrize("buffered", [False, True], ids=lambda p: f"buffered=={p}")
+@pytest.mark.parametrize("use_lines", [False, True], ids=lambda p: f"use_lines__{p}")
+@pytest.mark.parametrize("buffered", [False, True], ids=lambda p: f"buffered__{p}")
 def bench_JSONSerializer_incremental_deserialize(
     use_lines: bool,
     buffered: bool,

--- a/micro_benchmarks/serializers/bench_line.py
+++ b/micro_benchmarks/serializers/bench_line.py
@@ -22,7 +22,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
             "line_str",
             list(metafunc.config.getoption(PAYLOAD_SIZE_LEVEL)),
             indirect=True,
-            ids=lambda p: f"size=={p}kb",
+            ids=lambda p: f"size__{p}kb",
         )
 
 
@@ -51,7 +51,7 @@ def bench_StringLineSerializer_serialize(
 
 
 @pytest.mark.benchmark(group=SerializerGroup.LINE_DESERIALIZE)
-@pytest.mark.parametrize("keep_end", [False, True], ids=lambda p: f"keep_end=={p}")
+@pytest.mark.parametrize("keep_end", [False, True], ids=lambda p: f"keep_end__{p}")
 def bench_StringLineSerializer_deserialize(
     keep_end: bool,
     benchmark: BenchmarkFixture,
@@ -82,8 +82,8 @@ def bench_StringLineSerializer_incremental_serialize(
 
 
 @pytest.mark.benchmark(group=SerializerGroup.LINE_INCREMENTAL_DESERIALIZE)
-@pytest.mark.parametrize("keep_end", [False, True], ids=lambda p: f"keep_end=={p}")
-@pytest.mark.parametrize("buffered", [False, True], ids=lambda p: f"buffered=={p}")
+@pytest.mark.parametrize("keep_end", [False, True], ids=lambda p: f"keep_end__{p}")
+@pytest.mark.parametrize("buffered", [False, True], ids=lambda p: f"buffered__{p}")
 def bench_StringLineSerializer_incremental_deserialize(
     keep_end: bool,
     buffered: bool,

--- a/micro_benchmarks/serializers/bench_msgpack.py
+++ b/micro_benchmarks/serializers/bench_msgpack.py
@@ -49,7 +49,7 @@ def bench_MessagePackSerializer_incremental_serialize(
 
 
 @pytest.mark.benchmark(group=SerializerGroup.JSON_INCREMENTAL_DESERIALIZE)
-@pytest.mark.parametrize("buffered", [False, True], ids=lambda p: f"buffered=={p}")
+@pytest.mark.parametrize("buffered", [False, True], ids=lambda p: f"buffered__{p}")
 def bench_MessagePackSerializer_incremental_deserialize(
     buffered: bool,
     benchmark: BenchmarkFixture,

--- a/micro_benchmarks/serializers/bench_pickle.py
+++ b/micro_benchmarks/serializers/bench_pickle.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.benchmark(group=SerializerGroup.PICKLE_SERIALIZE)
-@pytest.mark.parametrize("pickler_optimize", [False, True], ids=lambda p: f"pickler_optimize=={p}")
+@pytest.mark.parametrize("pickler_optimize", [False, True], ids=lambda p: f"pickler_optimize__{p}")
 def bench_PickleSerializer_serialize(
     pickler_optimize: bool,
     benchmark: BenchmarkFixture,

--- a/tests/functional_test/test_async/test_backend/test_asyncio_backend.py
+++ b/tests/functional_test/test_async/test_backend/test_asyncio_backend.py
@@ -90,7 +90,7 @@ class TestAsyncioBackend:
         await task
         assert not task.cancelled()
 
-    @pytest.mark.parametrize("cancel_message", ["something", None], ids=lambda p: f"cancel_message=={p!r}")
+    @pytest.mark.parametrize("cancel_message", ["something", None], ids=lambda p: f"cancel_message__{p!r}")
     async def test____cancel_shielded_coro_yield____cancel_at_the_next_checkpoint(
         self,
         cancel_message: str | None,
@@ -146,7 +146,7 @@ class TestAsyncioBackend:
         assert task.cancelling() > 0
         assert checkpoints == [0, 1]
 
-    @pytest.mark.parametrize("direct_raise", [False, True], ids=lambda p: f"direct_raise=={p}")
+    @pytest.mark.parametrize("direct_raise", [False, True], ids=lambda p: f"direct_raise__{p}")
     async def test____ignore_cancellation____exception_raised_in_task(
         self,
         direct_raise: bool,
@@ -212,8 +212,8 @@ class TestAsyncioBackend:
         with pytest.raises(RuntimeError, match=r"^Task cannot await on itself: .+$"):
             await backend.ignore_cancellation(coroutine())
 
-    @pytest.mark.parametrize("with_delay", [False, True], ids=lambda p: f"with_delay=={p}")
-    @pytest.mark.parametrize("cancel_method", ["fut_cancel", "raise"], ids=lambda p: f"cancel_method=={p}")
+    @pytest.mark.parametrize("with_delay", [False, True], ids=lambda p: f"with_delay__{p}")
+    @pytest.mark.parametrize("cancel_method", ["fut_cancel", "raise"], ids=lambda p: f"cancel_method__{p}")
     async def test____ignore_cancellation____coroutine_cancelled_itself(
         self,
         cancel_method: Literal["fut_cancel", "raise"],

--- a/tests/functional_test/test_async/test_futures.py
+++ b/tests/functional_test/test_async/test_futures.py
@@ -104,7 +104,7 @@ class TestAsyncExecutor:
         await executor.shutdown()
         await executor.shutdown()
 
-    @pytest.mark.parametrize("max_workers", [1], indirect=True, ids=lambda nb: f"max_workers=={nb}")
+    @pytest.mark.parametrize("max_workers", [1], indirect=True, ids=lambda nb: f"max_workers__{nb}")
     async def test____shutdown____cancel_futures(
         self,
         executor: AsyncExecutor[concurrent.futures.Executor],
@@ -140,7 +140,7 @@ class TestUnwrapFuture:
 
         assert await unwrap_future(future, backend) == 42
 
-    @pytest.mark.parametrize("future_running", [None, "before", "after"], ids=lambda state: f"future_running=={state}")
+    @pytest.mark.parametrize("future_running", [None, "before", "after"], ids=lambda state: f"future_running__{state}")
     async def test____unwrap_future____cancel_future_if_task_is_cancelled____result(
         self,
         future_running: str | None,
@@ -173,7 +173,7 @@ class TestUnwrapFuture:
             assert future.cancelled()
             assert task.cancelled()
 
-    @pytest.mark.parametrize("future_running", [None, "before", "after"], ids=lambda state: f"future_running=={state}")
+    @pytest.mark.parametrize("future_running", [None, "before", "after"], ids=lambda state: f"future_running__{state}")
     async def test____unwrap_future____cancel_future_if_task_is_cancelled____exception(
         self,
         future_running: str | None,

--- a/tests/functional_test/test_communication/test_async/conftest.py
+++ b/tests/functional_test/test_communication/test_async/conftest.py
@@ -6,7 +6,7 @@ import pytest
 import pytest_asyncio
 
 
-@pytest_asyncio.fixture(params=[True, False], ids=lambda p: f"enable_eager_tasks=={p}")
+@pytest_asyncio.fixture(params=[True, False], ids=lambda p: f"enable_eager_tasks__{p}")
 async def enable_eager_tasks(request: pytest.FixtureRequest) -> bool:
     enable_eager_tasks = bool(request.param)
     if enable_eager_tasks:

--- a/tests/functional_test/test_communication/test_async/test_server/base.py
+++ b/tests/functional_test/test_communication/test_async/test_server/base.py
@@ -114,7 +114,7 @@ class BaseTestAsyncServer:
 
             await server.shutdown()
 
-    @pytest.mark.parametrize("server_is_up", [False, True], ids=lambda p: f"server_is_up=={p}")
+    @pytest.mark.parametrize("server_is_up", [False, True], ids=lambda p: f"server_is_up__{p}")
     async def test____serve_forever____concurrent_shutdown(
         self,
         server_is_up: bool,

--- a/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_tcp.py
@@ -451,7 +451,7 @@ class _BaseTestAsyncTCPNetworkServer(BaseTestAsyncServer):
     @pytest.mark.parametrize(
         "log_client_connection",
         [True, False, None],
-        ids=lambda p: f"log_client_connection=={p}",
+        ids=lambda p: f"log_client_connection__{p}",
         indirect=True,
     )
     async def test____serve_forever____accept_client(
@@ -685,8 +685,8 @@ class _BaseTestAsyncTCPNetworkServer(BaseTestAsyncServer):
         # ECONNRESET not logged
         assert len(caplog.records) == 0
 
-    @pytest.mark.parametrize("mute_thrown_exception", [False, True], ids=lambda p: f"mute_thrown_exception=={p}")
-    @pytest.mark.parametrize("read_on_connection", [False, True], ids=lambda p: f"read_on_connection=={p}")
+    @pytest.mark.parametrize("mute_thrown_exception", [False, True], ids=lambda p: f"mute_thrown_exception__{p}")
+    @pytest.mark.parametrize("read_on_connection", [False, True], ids=lambda p: f"read_on_connection__{p}")
     @pytest.mark.parametrize("request_handler", [ErrorInRequestHandler], indirect=True)
     @pytest.mark.parametrize(
         "stream_protocol",
@@ -734,7 +734,7 @@ class _BaseTestAsyncTCPNetworkServer(BaseTestAsyncServer):
             assert caplog.records[1].exc_info is not None
             assert type(caplog.records[1].exc_info[1]) is RuntimeError
 
-    @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised=={p}")
+    @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised__{p}")
     async def test____serve_forever____unexpected_error_during_process(
         self,
         excgrp: bool,
@@ -802,7 +802,7 @@ class _BaseTestAsyncTCPNetworkServer(BaseTestAsyncServer):
         assert caplog.records[1].exc_info is not None
         assert type(caplog.records[1].exc_info[1]) is OSError
 
-    @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised=={p}")
+    @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised__{p}")
     async def test____serve_forever____use_of_a_closed_client_in_request_handler(
         self,
         excgrp: bool,
@@ -856,7 +856,7 @@ class _BaseTestAsyncTCPNetworkServer(BaseTestAsyncServer):
         assert caplog.records[0].getMessage() == "ConnectionError raised in request_handler.on_disconnection()"
         assert caplog.records[0].levelno == logging.WARNING
 
-    @pytest.mark.parametrize("forcefully_closed", [False, True], ids=lambda p: f"forcefully_closed=={p}")
+    @pytest.mark.parametrize("forcefully_closed", [False, True], ids=lambda p: f"forcefully_closed__{p}")
     async def test____serve_forever____explicitly_closed_by_request_handler(
         self,
         forcefully_closed: bool,
@@ -908,8 +908,8 @@ class _BaseTestAsyncTCPNetworkServer(BaseTestAsyncServer):
         ],
         indirect=True,
     )
-    @pytest.mark.parametrize("request_timeout", [0.0, 1.0], ids=lambda p: f"timeout=={p}")
-    @pytest.mark.parametrize("timeout_on_second_yield", [False, True], ids=lambda p: f"timeout_on_second_yield=={p}")
+    @pytest.mark.parametrize("request_timeout", [0.0, 1.0], ids=lambda p: f"timeout__{p}")
+    @pytest.mark.parametrize("timeout_on_second_yield", [False, True], ids=lambda p: f"timeout_on_second_yield__{p}")
     async def test____serve_forever____throw_cancelled_error(
         self,
         request_timeout: float,
@@ -964,7 +964,7 @@ class _BaseTestAsyncTCPNetworkServer(BaseTestAsyncServer):
         assert type(caplog.records[1].exc_info[1]) is RandomError
 
     @pytest.mark.parametrize("request_handler", [RequestRefusedHandler], indirect=True)
-    @pytest.mark.parametrize("refuse_after", [0, 5], ids=lambda p: f"refuse_after=={p}")
+    @pytest.mark.parametrize("refuse_after", [0, 5], ids=lambda p: f"refuse_after__{p}")
     async def test____serve_forever____request_handler_did_not_yield(
         self,
         refuse_after: int,
@@ -990,7 +990,7 @@ class _BaseTestAsyncTCPNetworkServer(BaseTestAsyncServer):
         assert len(caplog.records) == 0
 
     @pytest.mark.parametrize("request_handler", [InitialHandshakeRequestHandler], indirect=True)
-    @pytest.mark.parametrize("handshake_2fa", [True, False], ids=lambda p: f"handshake_2fa=={p}")
+    @pytest.mark.parametrize("handshake_2fa", [True, False], ids=lambda p: f"handshake_2fa__{p}")
     async def test____serve_forever____request_handler_on_connection_is_async_gen(
         self,
         client_factory: Callable[[], Awaitable[AsyncStreamSocket]],
@@ -1010,7 +1010,7 @@ class _BaseTestAsyncTCPNetworkServer(BaseTestAsyncServer):
         assert await client.readline() == b"something\n"
 
     @pytest.mark.parametrize("request_handler", [InitialHandshakeRequestHandler], indirect=True)
-    @pytest.mark.parametrize("handshake_2fa", [True, False], ids=lambda p: f"handshake_2fa=={p}")
+    @pytest.mark.parametrize("handshake_2fa", [True, False], ids=lambda p: f"handshake_2fa__{p}")
     async def test____serve_forever____request_handler_on_connection_is_async_gen____close_connection(
         self,
         client_factory: Callable[[], Awaitable[AsyncStreamSocket]],
@@ -1031,7 +1031,7 @@ class _BaseTestAsyncTCPNetworkServer(BaseTestAsyncServer):
         assert await client.recv(1024) == b""
 
     @pytest.mark.parametrize("request_handler", [InitialHandshakeRequestHandler], indirect=True)
-    @pytest.mark.parametrize("handshake_2fa", [True, False], ids=lambda p: f"handshake_2fa=={p}")
+    @pytest.mark.parametrize("handshake_2fa", [True, False], ids=lambda p: f"handshake_2fa__{p}")
     async def test____serve_forever____request_handler_on_connection_is_async_gen____throw_cancel_error_within_generator(
         self,
         client_factory: Callable[[], Awaitable[AsyncStreamSocket]],
@@ -1060,7 +1060,7 @@ class _BaseTestAsyncTCPNetworkServer(BaseTestAsyncServer):
         assert await client.readline() == b"something_else\n"
 
     @pytest.mark.parametrize("use_ssl", ["USE_SSL"], indirect=True)
-    @pytest.mark.parametrize("ssl_handshake_timeout", [pytest.param(1, id="timeout==1sec")], indirect=True)
+    @pytest.mark.parametrize("ssl_handshake_timeout", [pytest.param(1, id="timeout__1sec")], indirect=True)
     async def test____serve_forever____ssl_handshake_timeout_error(
         self,
         server: MyAsyncTCPServer,
@@ -1082,8 +1082,8 @@ class _BaseTestAsyncTCPNetworkServer(BaseTestAsyncServer):
         assert len(caplog.records) == 0
 
     @pytest.mark.parametrize("use_ssl", ["USE_SSL"], indirect=True)
-    @pytest.mark.parametrize("ssl_handshake_timeout", [pytest.param(1, id="timeout==1sec")], indirect=True)
-    @pytest.mark.parametrize("ssl_standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("ssl_handshake_timeout", [pytest.param(1, id="timeout__1sec")], indirect=True)
+    @pytest.mark.parametrize("ssl_standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     @pytest.mark.parametrize(
         "request_handler",
         [

--- a/tests/functional_test/test_communication/test_async/test_server/test_udp.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_udp.py
@@ -465,7 +465,7 @@ class _BaseTestAsyncUDPNetworkServer(BaseTestAsyncServer):
                 assert caplog.records[1].exc_info is not None
                 assert type(caplog.records[1].exc_info[1]) is RuntimeError
 
-    @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised=={p}")
+    @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised__{p}")
     async def test____serve_forever____unexpected_error_during_process(
         self,
         excgrp: bool,
@@ -526,7 +526,7 @@ class _BaseTestAsyncUDPNetworkServer(BaseTestAsyncServer):
         assert caplog.records[1].exc_info is not None
         assert type(caplog.records[1].exc_info[1]) is OSError
 
-    @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised=={p}")
+    @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised__{p}")
     async def test____serve_forever____use_of_a_closed_client_in_request_handler(  # In a world where this thing happen
         self,
         excgrp: bool,
@@ -557,8 +557,8 @@ class _BaseTestAsyncUDPNetworkServer(BaseTestAsyncServer):
         ],
         indirect=True,
     )
-    @pytest.mark.parametrize("request_timeout", [0.0, 1.0], ids=lambda p: f"timeout=={p}")
-    @pytest.mark.parametrize("timeout_on_third_yield", [False, True], ids=lambda p: f"timeout_on_third_yield=={p}")
+    @pytest.mark.parametrize("request_timeout", [0.0, 1.0], ids=lambda p: f"timeout__{p}")
+    @pytest.mark.parametrize("timeout_on_third_yield", [False, True], ids=lambda p: f"timeout_on_third_yield__{p}")
     async def test____serve_forever____throw_cancelled_error(
         self,
         request_timeout: float,
@@ -616,7 +616,7 @@ class _BaseTestAsyncUDPNetworkServer(BaseTestAsyncServer):
         assert (await endpoint.recvfrom())[0] == b"hello world"
 
     @pytest.mark.parametrize("request_handler", [RequestRefusedHandler], indirect=True)
-    @pytest.mark.parametrize("refuse_after", [0, 5], ids=lambda p: f"refuse_after=={p}")
+    @pytest.mark.parametrize("refuse_after", [0, 5], ids=lambda p: f"refuse_after__{p}")
     async def test____serve_forever____request_handler_did_not_yield(
         self,
         refuse_after: int,
@@ -657,7 +657,7 @@ class _BaseTestAsyncUDPNetworkServer(BaseTestAsyncServer):
             assert (await endpoint.recvfrom())[0] == b"After wait: hello, world."
 
     @pytest.mark.parametrize("request_handler", [ConcurrencyTestRequestHandler], indirect=True)
-    @pytest.mark.parametrize("ignore_cancellation", [False, True], ids=lambda p: f"ignore_cancellation=={p}")
+    @pytest.mark.parametrize("ignore_cancellation", [False, True], ids=lambda p: f"ignore_cancellation__{p}")
     async def test____serve_forever____datagram_while_request_handle_is_performed____server_shutdown(
         self,
         server: MyAsyncUDPServer,
@@ -680,7 +680,7 @@ class _BaseTestAsyncUDPNetworkServer(BaseTestAsyncServer):
             await server.shutdown()
 
     @pytest.mark.parametrize("request_handler", [ConcurrencyTestRequestHandler], indirect=True)
-    @pytest.mark.parametrize("recreate_generator", [False, True], ids=lambda p: f"recreate_generator=={p}")
+    @pytest.mark.parametrize("recreate_generator", [False, True], ids=lambda p: f"recreate_generator__{p}")
     async def test____serve_forever____too_many_datagrams_while_request_handle_is_performed(
         self,
         recreate_generator: bool,

--- a/tests/functional_test/test_communication/test_async/test_server/test_unix_datagram.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_unix_datagram.py
@@ -593,7 +593,7 @@ if sys.platform != "win32":
             "unnamed_addresses_behavior",
             [None, "ignore", "handle", "warn"],
             indirect=True,
-            ids=lambda p: f"unnamed_addresses_behavior=={p!r}",
+            ids=lambda p: f"unnamed_addresses_behavior__{p!r}",
         )
         @pytest.mark.parametrize("server_recv_method", ["RECV", "RECVMSG"], indirect=True)
         @pytest.mark.parametrize("server_send_method", ["SEND", "SENDMSG"], indirect=True)
@@ -882,7 +882,7 @@ if sys.platform != "win32":
                     assert caplog.records[1].exc_info is not None
                     assert type(caplog.records[1].exc_info[1]) is RuntimeError
 
-        @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised=={p}")
+        @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised__{p}")
         async def test____serve_forever____unexpected_error_during_process(
             self,
             excgrp: bool,
@@ -946,7 +946,7 @@ if sys.platform != "win32":
             assert caplog.records[1].exc_info is not None
             assert type(caplog.records[1].exc_info[1]) is OSError
 
-        @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised=={p}")
+        @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised__{p}")
         async def test____serve_forever____use_of_a_closed_client_in_request_handler(  # In a world where this thing happen
             self,
             excgrp: bool,
@@ -979,8 +979,8 @@ if sys.platform != "win32":
             ],
             indirect=True,
         )
-        @pytest.mark.parametrize("request_timeout", [0.0, 1.0], ids=lambda p: f"timeout=={p}")
-        @pytest.mark.parametrize("timeout_on_third_yield", [False, True], ids=lambda p: f"timeout_on_third_yield=={p}")
+        @pytest.mark.parametrize("request_timeout", [0.0, 1.0], ids=lambda p: f"timeout__{p}")
+        @pytest.mark.parametrize("timeout_on_third_yield", [False, True], ids=lambda p: f"timeout_on_third_yield__{p}")
         async def test____serve_forever____throw_cancelled_error(
             self,
             request_timeout: float,
@@ -1038,7 +1038,7 @@ if sys.platform != "win32":
             assert (await endpoint.recvfrom())[0] == b"hello world"
 
         @pytest.mark.parametrize("request_handler", [RequestRefusedHandler], indirect=True)
-        @pytest.mark.parametrize("refuse_after", [0, 5], ids=lambda p: f"refuse_after=={p}")
+        @pytest.mark.parametrize("refuse_after", [0, 5], ids=lambda p: f"refuse_after__{p}")
         async def test____serve_forever____request_handler_did_not_yield(
             self,
             refuse_after: int,
@@ -1080,7 +1080,7 @@ if sys.platform != "win32":
                 assert (await endpoint.recvfrom())[0] == b"After wait: hello, world."
 
         @pytest.mark.parametrize("request_handler", [ConcurrencyTestRequestHandler], indirect=True)
-        @pytest.mark.parametrize("ignore_cancellation", [False, True], ids=lambda p: f"ignore_cancellation=={p}")
+        @pytest.mark.parametrize("ignore_cancellation", [False, True], ids=lambda p: f"ignore_cancellation__{p}")
         @pytest.mark.parametrize("server_recv_method", ["RECV", "RECVMSG"], indirect=True)
         async def test____serve_forever____datagram_while_request_handle_is_performed____server_shutdown(
             self,
@@ -1104,7 +1104,7 @@ if sys.platform != "win32":
                 await server.shutdown()
 
         @pytest.mark.parametrize("request_handler", [ConcurrencyTestRequestHandler], indirect=True)
-        @pytest.mark.parametrize("recreate_generator", [False, True], ids=lambda p: f"recreate_generator=={p}")
+        @pytest.mark.parametrize("recreate_generator", [False, True], ids=lambda p: f"recreate_generator__{p}")
         @pytest.mark.parametrize("server_recv_method", ["RECV", "RECVMSG"], indirect=True)
         async def test____serve_forever____too_many_datagrams_while_request_handle_is_performed(
             self,

--- a/tests/functional_test/test_communication/test_async/test_server/test_unix_stream.py
+++ b/tests/functional_test/test_communication/test_async/test_server/test_unix_stream.py
@@ -638,7 +638,7 @@ if sys.platform != "win32":
         @pytest.mark.parametrize(
             "log_client_connection",
             [True, False, None],
-            ids=lambda p: f"log_client_connection=={p}",
+            ids=lambda p: f"log_client_connection__{p}",
             indirect=True,
         )
         @pytest.mark.parametrize("server_recv_method", ["RECV", "RECVMSG"], indirect=True)
@@ -907,8 +907,8 @@ if sys.platform != "win32":
             # ECONNRESET not logged
             assert len(caplog.records) == 0
 
-        @pytest.mark.parametrize("mute_thrown_exception", [False, True], ids=lambda p: f"mute_thrown_exception=={p}")
-        @pytest.mark.parametrize("read_on_connection", [False, True], ids=lambda p: f"read_on_connection=={p}")
+        @pytest.mark.parametrize("mute_thrown_exception", [False, True], ids=lambda p: f"mute_thrown_exception__{p}")
+        @pytest.mark.parametrize("read_on_connection", [False, True], ids=lambda p: f"read_on_connection__{p}")
         @pytest.mark.parametrize("request_handler", [ErrorInRequestHandler], indirect=True)
         @pytest.mark.parametrize("server_recv_method", ["RECV", "RECVMSG"], indirect=True)
         @pytest.mark.parametrize(
@@ -957,8 +957,8 @@ if sys.platform != "win32":
                 assert caplog.records[1].exc_info is not None
                 assert type(caplog.records[1].exc_info[1]) is RuntimeError
 
-        @pytest.mark.parametrize("mute_thrown_exception", [False, True], ids=lambda p: f"mute_thrown_exception=={p}")
-        @pytest.mark.parametrize("read_on_connection", [False, True], ids=lambda p: f"read_on_connection=={p}")
+        @pytest.mark.parametrize("mute_thrown_exception", [False, True], ids=lambda p: f"mute_thrown_exception__{p}")
+        @pytest.mark.parametrize("read_on_connection", [False, True], ids=lambda p: f"read_on_connection__{p}")
         @pytest.mark.parametrize("request_handler", [ErrorInRequestHandler], indirect=True)
         @pytest.mark.parametrize("server_recv_method", ["RECVMSG"], indirect=True)
         async def test____serve_forever____internal_error____ancillary_data_callback(
@@ -998,7 +998,7 @@ if sys.platform != "win32":
                 assert caplog.records[1].exc_info is not None
                 assert type(caplog.records[1].exc_info[1]) is RuntimeError
 
-        @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised=={p}")
+        @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised__{p}")
         async def test____serve_forever____unexpected_error_during_process(
             self,
             excgrp: bool,
@@ -1073,7 +1073,7 @@ if sys.platform != "win32":
             assert caplog.records[1].exc_info is not None
             assert type(caplog.records[1].exc_info[1]) is OSError
 
-        @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised=={p}")
+        @pytest.mark.parametrize("excgrp", [False, True], ids=lambda p: f"exception_group_raised__{p}")
         @pytest.mark.parametrize("server_send_method", ["SEND", "SENDMSG"], indirect=True)
         async def test____serve_forever____use_of_a_closed_client_in_request_handler(
             self,
@@ -1130,7 +1130,7 @@ if sys.platform != "win32":
             assert caplog.records[0].getMessage() == "ConnectionError raised in request_handler.on_disconnection()"
             assert caplog.records[0].levelno == logging.WARNING
 
-        @pytest.mark.parametrize("forcefully_closed", [False, True], ids=lambda p: f"forcefully_closed=={p}")
+        @pytest.mark.parametrize("forcefully_closed", [False, True], ids=lambda p: f"forcefully_closed__{p}")
         @pytest.mark.parametrize("server_send_method", ["SEND", "SENDMSG"], indirect=True)
         async def test____serve_forever____explicitly_closed_by_request_handler(
             self,
@@ -1191,8 +1191,8 @@ if sys.platform != "win32":
             ],
             indirect=True,
         )
-        @pytest.mark.parametrize("request_timeout", [0.0, 1.0], ids=lambda p: f"timeout=={p}")
-        @pytest.mark.parametrize("timeout_on_second_yield", [False, True], ids=lambda p: f"timeout_on_second_yield=={p}")
+        @pytest.mark.parametrize("request_timeout", [0.0, 1.0], ids=lambda p: f"timeout__{p}")
+        @pytest.mark.parametrize("timeout_on_second_yield", [False, True], ids=lambda p: f"timeout_on_second_yield__{p}")
         async def test____serve_forever____throw_cancelled_error(
             self,
             request_timeout: float,
@@ -1247,7 +1247,7 @@ if sys.platform != "win32":
             assert type(caplog.records[1].exc_info[1]) is RandomError
 
         @pytest.mark.parametrize("request_handler", [RequestRefusedHandler], indirect=True)
-        @pytest.mark.parametrize("refuse_after", [0, 5], ids=lambda p: f"refuse_after=={p}")
+        @pytest.mark.parametrize("refuse_after", [0, 5], ids=lambda p: f"refuse_after__{p}")
         async def test____serve_forever____request_handler_did_not_yield(
             self,
             refuse_after: int,
@@ -1273,7 +1273,7 @@ if sys.platform != "win32":
             assert len(caplog.records) == 0
 
         @pytest.mark.parametrize("request_handler", [InitialHandshakeRequestHandler], indirect=True)
-        @pytest.mark.parametrize("handshake_2fa", [True, False], ids=lambda p: f"handshake_2fa=={p}")
+        @pytest.mark.parametrize("handshake_2fa", [True, False], ids=lambda p: f"handshake_2fa__{p}")
         @pytest.mark.parametrize(
             "check_sent_credential",
             [
@@ -1286,7 +1286,7 @@ if sys.platform != "win32":
                 ),
                 False,
             ],
-            ids=lambda p: f"check_sent_credential=={p}",
+            ids=lambda p: f"check_sent_credential__{p}",
         )
         async def test____serve_forever____request_handler_on_connection_is_async_gen(
             self,
@@ -1309,7 +1309,7 @@ if sys.platform != "win32":
             assert await client.readline() == b"something\n"
 
         @pytest.mark.parametrize("request_handler", [InitialHandshakeRequestHandler], indirect=True)
-        @pytest.mark.parametrize("handshake_2fa", [True, False], ids=lambda p: f"handshake_2fa=={p}")
+        @pytest.mark.parametrize("handshake_2fa", [True, False], ids=lambda p: f"handshake_2fa__{p}")
         @pytest.mark.parametrize(
             "check_sent_credential",
             [
@@ -1322,7 +1322,7 @@ if sys.platform != "win32":
                 ),
                 False,
             ],
-            ids=lambda p: f"check_sent_credential=={p}",
+            ids=lambda p: f"check_sent_credential__{p}",
         )
         async def test____serve_forever____request_handler_on_connection_is_async_gen____close_connection(
             self,
@@ -1346,7 +1346,7 @@ if sys.platform != "win32":
             assert await client.recv(1024) == b""
 
         @pytest.mark.parametrize("request_handler", [InitialHandshakeRequestHandler], indirect=True)
-        @pytest.mark.parametrize("handshake_2fa", [True, False], ids=lambda p: f"handshake_2fa=={p}")
+        @pytest.mark.parametrize("handshake_2fa", [True, False], ids=lambda p: f"handshake_2fa__{p}")
         @pytest.mark.parametrize(
             "check_sent_credential",
             [
@@ -1359,7 +1359,7 @@ if sys.platform != "win32":
                 ),
                 False,
             ],
-            ids=lambda p: f"check_sent_credential=={p}",
+            ids=lambda p: f"check_sent_credential__{p}",
         )
         async def test____serve_forever____request_handler_on_connection_is_async_gen____throw_cancel_error_within_generator(
             self,

--- a/tests/functional_test/test_communication/test_end2end.py
+++ b/tests/functional_test/test_communication/test_end2end.py
@@ -43,7 +43,7 @@ class BaseTestNetworkServer:
             pytest.param("asyncio"),
             pytest.param("trio", marks=pytest.mark.feature_trio(async_test_auto_mark=False)),
         ],
-        ids=lambda p: f"server_backend=={p!r}",
+        ids=lambda p: f"server_backend__{p!r}",
     )
     @staticmethod
     def server_backend(request: pytest.FixtureRequest) -> BuiltinAsyncBackendLiteral:
@@ -54,7 +54,7 @@ class BaseTestNetworkServer:
             pytest.param("asyncio", marks=pytest.mark.asyncio),
             pytest.param("trio", marks=pytest.mark.feature_trio(async_test_auto_mark=True)),
         ],
-        ids=lambda p: f"async_client_backend=={p!r}",
+        ids=lambda p: f"async_client_backend__{p!r}",
     )
     @staticmethod
     def async_client_backend(request: pytest.FixtureRequest) -> BuiltinAsyncBackendLiteral:

--- a/tests/functional_test/test_communication/test_sync/test_client/test_unix_datagram.py
+++ b/tests/functional_test/test_communication/test_sync/test_client/test_unix_datagram.py
@@ -145,7 +145,7 @@ if sys.platform != "win32":
             assert received_packet == "ABCDEF"
             assert len(list(received_ancillary.iter_fds())) == 1
 
-        @pytest.mark.parametrize("with_ancillary_data", [False, True], ids=lambda p: f"with_ancillary_data=={p}")
+        @pytest.mark.parametrize("with_ancillary_data", [False, True], ids=lambda p: f"with_ancillary_data__{p}")
         def test____recv_packet____timeout(
             self,
             with_ancillary_data: bool,

--- a/tests/functional_test/test_serializers/test_base64.py
+++ b/tests/functional_test/test_serializers/test_base64.py
@@ -59,7 +59,7 @@ class BaseTestBase64EncoderSerializer(BaseTestBufferedIncrementalSerializer):
 
     #### Packets to test
 
-    @pytest.fixture(scope="class", params=[pytest.param(p, id=f"packet: {id}") for p, id in SAMPLES])
+    @pytest.fixture(scope="class", params=[pytest.param(p, id=f"packet__{id}") for p, id in SAMPLES])
     @staticmethod
     def packet_to_serialize(request: Any) -> Any:
         return request.param
@@ -139,7 +139,7 @@ class BaseTestBase64EncoderSerializer(BaseTestBufferedIncrementalSerializer):
 
 @final
 class TestBase64EncoderSerializerChecksum(BaseTestBase64EncoderSerializer):
-    @pytest.fixture(scope="class", params=[False, True], ids=lambda boolean: f"checksum=={boolean}")
+    @pytest.fixture(scope="class", params=[False, True], ids=lambda boolean: f"checksum__{boolean}")
     @staticmethod
     def checksum(request: pytest.FixtureRequest) -> bool:
         return request.param

--- a/tests/functional_test/test_serializers/test_cbor.py
+++ b/tests/functional_test/test_serializers/test_cbor.py
@@ -35,7 +35,7 @@ class TestCBORSerializer(BaseTestBufferedIncrementalSerializer, BaseTestSerializ
 
     #### Packets to test
 
-    @pytest.fixture(scope="class", params=[pytest.param(p, id=f"packet: {id}") for p, id in SAMPLES])
+    @pytest.fixture(scope="class", params=[pytest.param(p, id=f"packet__{id}") for p, id in SAMPLES])
     @staticmethod
     def packet_to_serialize(request: Any) -> Any:
         return request.param

--- a/tests/functional_test/test_serializers/test_compressors.py
+++ b/tests/functional_test/test_serializers/test_compressors.py
@@ -28,7 +28,7 @@ class BaseTestCompressorSerializer(BaseTestBufferedIncrementalSerializer, BaseTe
 
     #### Packets to test
 
-    @pytest.fixture(scope="class", params=[pytest.param(p, id=f"packet: {id}") for p, id in SAMPLES])
+    @pytest.fixture(scope="class", params=[pytest.param(p, id=f"packet__{id}") for p, id in SAMPLES])
     @staticmethod
     def packet_to_serialize(request: Any) -> Any:
         return request.param
@@ -71,7 +71,7 @@ class BaseTestCompressorSerializer(BaseTestBufferedIncrementalSerializer, BaseTe
 
 @final
 class TestBZ2CompressorSerializer(BaseTestCompressorSerializer):
-    @pytest.fixture(scope="class", params=list(range(1, 10)), ids=lambda level: f"level=={level}")
+    @pytest.fixture(scope="class", params=list(range(1, 10)), ids=lambda level: f"level__{level}")
     @staticmethod
     def compress_level(request: Any) -> Any:
         return request.param
@@ -107,7 +107,7 @@ class TestBZ2CompressorSerializer(BaseTestCompressorSerializer):
 
 @final
 class TestZlibCompressorSerializer(BaseTestCompressorSerializer):
-    @pytest.fixture(scope="class", params=list(range(1, 10)), ids=lambda level: f"level=={level}")
+    @pytest.fixture(scope="class", params=list(range(1, 10)), ids=lambda level: f"level__{level}")
     @staticmethod
     def compress_level(request: Any) -> Any:
         return request.param

--- a/tests/functional_test/test_serializers/test_json.py
+++ b/tests/functional_test/test_serializers/test_json.py
@@ -32,7 +32,7 @@ class TestJSONSerializer(BaseTestBufferedIncrementalSerializer, BaseTestSerializ
     def encoder_config() -> JSONEncoderConfig:
         return JSONEncoderConfig(ensure_ascii=False)
 
-    @pytest.fixture(scope="class", params=[False, True], ids=lambda p: f"use_lines=={p}")
+    @pytest.fixture(scope="class", params=[False, True], ids=lambda p: f"use_lines__{p}")
     @staticmethod
     def use_lines(request: Any) -> bool:
         return request.param
@@ -49,7 +49,7 @@ class TestJSONSerializer(BaseTestBufferedIncrementalSerializer, BaseTestSerializ
 
     #### Packets to test
 
-    @pytest.fixture(scope="class", params=[pytest.param(p, id=f"packet: {id}") for p, id in SAMPLES])
+    @pytest.fixture(scope="class", params=[pytest.param(p, id=f"packet__{id}") for p, id in SAMPLES])
     @staticmethod
     def packet_to_serialize(request: Any) -> Any:
         return request.param

--- a/tests/functional_test/test_serializers/test_msgpack.py
+++ b/tests/functional_test/test_serializers/test_msgpack.py
@@ -35,7 +35,7 @@ class TestMessagePackSerializer(BaseTestBufferedIncrementalSerializer, BaseTestS
 
     #### Packets to test
 
-    @pytest.fixture(scope="class", params=[pytest.param(p, id=f"packet: {id}") for p, id in SAMPLES])
+    @pytest.fixture(scope="class", params=[pytest.param(p, id=f"packet__{id}") for p, id in SAMPLES])
     @staticmethod
     def packet_to_serialize(request: Any) -> Any:
         return request.param

--- a/tests/functional_test/test_serializers/test_namedtuple.py
+++ b/tests/functional_test/test_serializers/test_namedtuple.py
@@ -56,7 +56,7 @@ class TestNamedTupleStructSerializer(BaseTestBufferedIncrementalSerializer, Base
     @pytest.fixture(
         scope="class",
         params=[
-            pytest.param(p, id=f"packet: {p!r}")
+            pytest.param(p, id=f"packet__{p!r}")
             for p in [
                 Point("", 0, b"\0"),
                 Point("string", -4, b"y"),

--- a/tests/functional_test/test_serializers/test_pickle.py
+++ b/tests/functional_test/test_serializers/test_pickle.py
@@ -17,7 +17,7 @@ ALL_PROTOCOLS: tuple[int, ...] = tuple(range(0, pickle.HIGHEST_PROTOCOL + 1))
 
 @final
 class TestPickleSerializer(BaseTestSerializerExtraData):
-    @pytest.fixture(scope="class", params=ALL_PROTOCOLS, ids=lambda p: f"pickle_data_protocol=={p}")
+    @pytest.fixture(scope="class", params=ALL_PROTOCOLS, ids=lambda p: f"pickle_data_protocol__{p}")
     @staticmethod
     def pickle_data_protocol(request: Any) -> int:
         return request.param
@@ -29,7 +29,7 @@ class TestPickleSerializer(BaseTestSerializerExtraData):
     def pickler_config(pickle_data_protocol: int) -> PicklerConfig:
         return PicklerConfig(protocol=pickle_data_protocol)
 
-    @pytest.fixture(scope="class", params=[False, True], ids=lambda boolean: f"optimize=={boolean}")
+    @pytest.fixture(scope="class", params=[False, True], ids=lambda boolean: f"optimize__{boolean}")
     @staticmethod
     def pickler_optimize(request: Any) -> bool:
         return request.param
@@ -55,7 +55,7 @@ class TestPickleSerializer(BaseTestSerializerExtraData):
 
     #### Packets to test
 
-    @pytest.fixture(scope="class", params=[pytest.param(p, id=f"packet: {id}") for p, id in SAMPLES])
+    @pytest.fixture(scope="class", params=[pytest.param(p, id=f"packet__{id}") for p, id in SAMPLES])
     @staticmethod
     def packet_to_serialize(request: Any) -> Any:
         return request.param

--- a/tests/functional_test/test_serializers/test_struct.py
+++ b/tests/functional_test/test_serializers/test_struct.py
@@ -42,7 +42,7 @@ class TestStructSerializer(BaseTestBufferedIncrementalSerializer, BaseTestSerial
     @pytest.fixture(
         scope="class",
         params=[
-            pytest.param(p, id=f"packet: {p!r}")
+            pytest.param(p, id=f"packet__{p!r}")
             for p in [
                 (b"".ljust(10), 0, b"\0"),
                 (b"string".ljust(10), -4, b"y"),

--- a/tests/unit_test/test_async/test_api/test_client/test_tcp.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_tcp.py
@@ -204,7 +204,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
             assert client.is_connected()
             yield client
 
-    @pytest_asyncio.fixture(params=[False, True], ids=lambda boolean: f"client_connected=={boolean}")
+    @pytest_asyncio.fixture(params=[False, True], ids=lambda boolean: f"client_connected__{boolean}")
     @staticmethod
     async def client_connected_or_not(
         request: pytest.FixtureRequest,
@@ -229,7 +229,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
                 assert not client.is_connected()
             yield client
 
-    @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size=={p}")
+    @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size__{p}")
     async def test____dunder_init____connect_to_remote(
         self,
         max_recv_size: int | None,
@@ -277,7 +277,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
         ]
         assert isinstance(client.socket, SocketProxy)
 
-    @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size=={p}")
+    @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size__{p}")
     async def test____dunder_init____use_given_socket(
         self,
         max_recv_size: int | None,
@@ -406,7 +406,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
                 backend=mock_backend,
             )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     async def test____dunder_init____protocol____invalid_value(
         self,
         request: pytest.FixtureRequest,
@@ -431,7 +431,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
                     mock_backend,
                 )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     async def test____dunder_init____backend____invalid_value(
         self,
         request: pytest.FixtureRequest,
@@ -457,8 +457,8 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
                     invalid_backend,
                 )
 
-    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size=={p}")
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size__{p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     async def test____dunder_init____max_recv_size____invalid_value(
         self,
         request: pytest.FixtureRequest,
@@ -486,7 +486,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
                     max_recv_size=max_recv_size,
                 )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     async def test____dunder_init____ssl(
         self,
         async_finalizer: AsyncFinalizer,
@@ -569,7 +569,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
         )
         assert isinstance(client.socket, SocketProxy)
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     async def test____dunder_init____ssl____default_values(
         self,
         async_finalizer: AsyncFinalizer,
@@ -620,7 +620,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
             standard_compatible=True,
         )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     @pytest.mark.parametrize(
         "ssl_parameter",
         [
@@ -704,7 +704,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
             standard_compatible=mocker.sentinel.ssl_standard_compatible,
         )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     async def test____dunder_init____ssl____server_hostname____do_not_disable_hostname_check_for_external_context(
         self,
         async_finalizer: AsyncFinalizer,
@@ -764,7 +764,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
         )
         assert mock_ssl_context.check_hostname is True
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     async def test____dunder_init____ssl____server_hostname____no_host_to_use(
         self,
         use_socket: bool,
@@ -805,8 +805,8 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
                     ssl_standard_compatible=mocker.sentinel.ssl_standard_compatible,
                 )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
-    @pytest.mark.parametrize("OP_IGNORE_UNEXPECTED_EOF", [False, True], ids=lambda p: f"OP_IGNORE_UNEXPECTED_EOF=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
+    @pytest.mark.parametrize("OP_IGNORE_UNEXPECTED_EOF", [False, True], ids=lambda p: f"OP_IGNORE_UNEXPECTED_EOF__{p}")
     async def test____dunder_init____ssl____create_default_context(
         self,
         async_finalizer: AsyncFinalizer,
@@ -871,7 +871,7 @@ class TestAsyncTCPNetworkClient(BaseTestClient):
             standard_compatible=mocker.sentinel.ssl_standard_compatible,
         )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     async def test____dunder_init____ssl____create_default_context____disable_hostname_check(
         self,
         async_finalizer: AsyncFinalizer,

--- a/tests/unit_test/test_async/test_api/test_client/test_udp.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_udp.py
@@ -141,7 +141,7 @@ class TestAsyncUDPNetworkClient(BaseTestClient):
             assert client.is_connected()
             yield client
 
-    @pytest_asyncio.fixture(params=[False, True], ids=lambda boolean: f"client_connected=={boolean}")
+    @pytest_asyncio.fixture(params=[False, True], ids=lambda boolean: f"client_connected__{boolean}")
     @staticmethod
     async def client_connected_or_not(
         request: pytest.FixtureRequest,
@@ -412,7 +412,7 @@ class TestAsyncUDPNetworkClient(BaseTestClient):
                 backend=mock_backend,
             )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     async def test____dunder_init____protocol____invalid_value(
         self,
         use_socket: bool,
@@ -438,7 +438,7 @@ class TestAsyncUDPNetworkClient(BaseTestClient):
                     backend=mock_backend,
                 )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     async def test____dunder_init____backend____invalid_value(
         self,
         request: pytest.FixtureRequest,

--- a/tests/unit_test/test_async/test_api/test_client/test_unix_datagram.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_unix_datagram.py
@@ -178,7 +178,7 @@ if sys.platform != "win32":
                 assert client.is_connected()
                 yield client
 
-        @pytest_asyncio.fixture(params=[False, True], ids=lambda boolean: f"client_connected=={boolean}")
+        @pytest_asyncio.fixture(params=[False, True], ids=lambda boolean: f"client_connected__{boolean}")
         @staticmethod
         async def client_connected_or_not(
             request: pytest.FixtureRequest,
@@ -516,7 +516,7 @@ if sys.platform != "win32":
                     backend=mock_backend,
                 )
 
-        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
         async def test____dunder_init____protocol____invalid_value(
             self,
             use_socket: bool,
@@ -542,7 +542,7 @@ if sys.platform != "win32":
                         backend=mock_backend,
                     )
 
-        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
         async def test____dunder_init____backend____invalid_value(
             self,
             request: pytest.FixtureRequest,

--- a/tests/unit_test/test_async/test_api/test_client/test_unix_stream.py
+++ b/tests/unit_test/test_async/test_api/test_client/test_unix_stream.py
@@ -187,7 +187,7 @@ if sys.platform != "win32":
                 assert client.is_connected()
                 yield client
 
-        @pytest_asyncio.fixture(params=[False, True], ids=lambda boolean: f"client_connected=={boolean}")
+        @pytest_asyncio.fixture(params=[False, True], ids=lambda boolean: f"client_connected__{boolean}")
         @staticmethod
         async def client_connected_or_not(
             request: pytest.FixtureRequest,
@@ -220,7 +220,7 @@ if sys.platform != "win32":
                 case _:
                     pytest.fail(f"Invalid ancillary_data param: {request.param}")
 
-        @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size=={p}")
+        @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size__{p}")
         async def test____dunder_init____connect_to_remote(
             self,
             max_recv_size: int | None,
@@ -348,7 +348,7 @@ if sys.platform != "win32":
             # Assert
             mock_backend.create_unix_stream_connection.assert_awaited_once_with(remote_address, local_path="")
 
-        @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size=={p}")
+        @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size__{p}")
         async def test____dunder_init____use_given_socket(
             self,
             max_recv_size: int | None,
@@ -448,7 +448,7 @@ if sys.platform != "win32":
                     backend=mock_backend,
                 )
 
-        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
         async def test____dunder_init____protocol____invalid_value(
             self,
             request: pytest.FixtureRequest,
@@ -473,7 +473,7 @@ if sys.platform != "win32":
                         mock_backend,
                     )
 
-        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
         async def test____dunder_init____backend____invalid_value(
             self,
             request: pytest.FixtureRequest,
@@ -499,8 +499,8 @@ if sys.platform != "win32":
                         invalid_backend,
                     )
 
-        @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size=={p}")
-        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+        @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size__{p}")
+        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
         async def test____dunder_init____max_recv_size____invalid_value(
             self,
             request: pytest.FixtureRequest,

--- a/tests/unit_test/test_async/test_api/test_server/test_tcp.py
+++ b/tests/unit_test/test_async/test_api/test_server/test_tcp.py
@@ -89,7 +89,7 @@ class TestAsyncTCPNetworkServer:
                 **kwargs,
             )
 
-    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size=={p}")
+    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size__{p}")
     async def test____dunder_init____max_recv_size____invalid_value(
         self,
         max_recv_size: Any,

--- a/tests/unit_test/test_async/test_api/test_server/test_unix_datagram.py
+++ b/tests/unit_test/test_async/test_api/test_server/test_unix_datagram.py
@@ -466,7 +466,7 @@ if sys.platform != "win32":
             mock_datagram_server.send_packet_to.assert_not_called()
 
         @pytest.mark.parametrize("method", ["server_close", "service_shutdown"])
-        @pytest.mark.parametrize("with_ancillary_data", [False, True], ids=lambda p: f"with_ancillary_data=={p}")
+        @pytest.mark.parametrize("with_ancillary_data", [False, True], ids=lambda p: f"with_ancillary_data__{p}")
         async def test____send_packet____closed_client(
             self,
             method: Literal["server_close", "service_shutdown"],

--- a/tests/unit_test/test_async/test_api/test_server/test_unix_stream.py
+++ b/tests/unit_test/test_async/test_api/test_server/test_unix_stream.py
@@ -168,7 +168,7 @@ if sys.platform != "win32":
             with pytest.raises(TypeError, match=r"^Expected an AsyncStreamRequestHandler object, got .*$"):
                 _ = AsyncUnixStreamServer("/path/to/sock", mock_stream_protocol, mock_datagram_request_handler, mock_backend)
 
-        @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size=={p}")
+        @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size__{p}")
         async def test____dunder_init____max_recv_size____invalid_value(
             self,
             max_recv_size: Any,
@@ -510,7 +510,7 @@ if sys.platform != "win32":
             mock_unix_stream_socket.getsockopt.assert_not_called()
 
         @pytest.mark.parametrize("method", ["close", "force_disconnect"])
-        @pytest.mark.parametrize("with_ancillary_data", [False, True], ids=lambda p: f"with_ancillary_data=={p}")
+        @pytest.mark.parametrize("with_ancillary_data", [False, True], ids=lambda p: f"with_ancillary_data__{p}")
         async def test____send_packet____closed_client(
             self,
             method: Literal["close", "force_disconnect"],

--- a/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_backend.py
@@ -250,9 +250,9 @@ class TestAsyncIOBackend:
         assert resolved_addr is mocker.sentinel.resolved_addr
         mock_loop_getnameinfo.assert_awaited_once_with(mocker.sentinel.sockaddr, mocker.sentinel.flags)
 
-    @pytest.mark.parametrize("happy_eyeballs_delay", [None, 42], ids=lambda p: f"happy_eyeballs_delay=={p}")
-    @pytest.mark.parametrize("local_address", [("local_address", 12345), None], ids=lambda addr: f"local_address=={addr}")
-    @pytest.mark.parametrize("remote_address", [("remote_address", 5000)], ids=lambda addr: f"remote_address=={addr}")
+    @pytest.mark.parametrize("happy_eyeballs_delay", [None, 42], ids=lambda p: f"happy_eyeballs_delay__{p}")
+    @pytest.mark.parametrize("local_address", [("local_address", 12345), None], ids=lambda addr: f"local_address__{addr}")
+    @pytest.mark.parametrize("remote_address", [("remote_address", 5000)], ids=lambda addr: f"remote_address__{addr}")
     async def test____create_tcp_connection____use_loop_create_connection(
         self,
         happy_eyeballs_delay: float | None,
@@ -321,7 +321,7 @@ class TestAsyncIOBackend:
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -331,7 +331,7 @@ class TestAsyncIOBackend:
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         async def test____create_unix_stream_connection____use_loop_create_unix_connection(
             self,
@@ -385,7 +385,7 @@ class TestAsyncIOBackend:
                 "\0local_sock",
                 b"\x00local_sock",
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -395,7 +395,7 @@ class TestAsyncIOBackend:
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "bind_error",
@@ -403,7 +403,7 @@ class TestAsyncIOBackend:
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
                 OSError("AF_UNIX path too long."),
             ],
-            ids=lambda exc: f"bind_error=={exc!r}",
+            ids=lambda exc: f"bind_error__{exc!r}",
         )
         async def test____create_unix_stream_connection____bind_error(
             self,
@@ -456,7 +456,7 @@ class TestAsyncIOBackend:
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "connect_error",
@@ -464,7 +464,7 @@ class TestAsyncIOBackend:
                 OSError(errno.ECONNREFUSED, os.strerror(errno.ECONNREFUSED)),
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
             ],
-            ids=lambda exc: f"connect_error=={exc!r}",
+            ids=lambda exc: f"connect_error__{exc!r}",
         )
         async def test____create_unix_stream_connection____connect_error(
             self,
@@ -744,9 +744,9 @@ class TestAsyncIOBackend:
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
-        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode=={mode!r}")
+        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode__{mode!r}")
         async def test____create_unix_stream_listener____open_listener_socket(
             self,
             backend: AsyncIOBackend,
@@ -801,7 +801,7 @@ class TestAsyncIOBackend:
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "bind_error",
@@ -809,9 +809,9 @@ class TestAsyncIOBackend:
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
                 OSError("AF_UNIX path too long."),
             ],
-            ids=lambda exc: f"bind_error=={exc!r}",
+            ids=lambda exc: f"bind_error__{exc!r}",
         )
-        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode=={mode!r}")
+        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode__{mode!r}")
         async def test____create_unix_stream_listener____bind_failed(
             self,
             backend: AsyncIOBackend,
@@ -858,7 +858,7 @@ class TestAsyncIOBackend:
                 "/path/to/local.sock",
                 b"/path/to/local.sock",
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         async def test____create_unix_stream_listener____chmod_failed(
             self,
@@ -895,9 +895,9 @@ class TestAsyncIOBackend:
             mock_os_chmod.assert_called_once()
             mock_ListenerSocketAdapter.assert_not_called()
 
-    @pytest.mark.parametrize("socket_family", [None, AF_INET, AF_INET6], ids=lambda p: f"family=={p}")
-    @pytest.mark.parametrize("local_address", [("local_address", 12345), None], ids=lambda addr: f"local_address=={addr}")
-    @pytest.mark.parametrize("remote_address", [("remote_address", 5000)], ids=lambda addr: f"remote_address=={addr}")
+    @pytest.mark.parametrize("socket_family", [None, AF_INET, AF_INET6], ids=lambda p: f"family__{p}")
+    @pytest.mark.parametrize("local_address", [("local_address", 12345), None], ids=lambda addr: f"local_address__{addr}")
+    @pytest.mark.parametrize("remote_address", [("remote_address", 5000)], ids=lambda addr: f"remote_address__{addr}")
     async def test____create_udp_endpoint____use_loop_create_datagram_endpoint(
         self,
         local_address: tuple[str, int] | None,
@@ -957,7 +957,7 @@ class TestAsyncIOBackend:
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -967,7 +967,7 @@ class TestAsyncIOBackend:
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         async def test____create_unix_datagram_endpoint____use_loop_create_datagram_endpoint(
             self,
@@ -1024,7 +1024,7 @@ class TestAsyncIOBackend:
                 "\0local_sock",
                 b"\x00local_sock",
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -1034,7 +1034,7 @@ class TestAsyncIOBackend:
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "bind_error",
@@ -1042,7 +1042,7 @@ class TestAsyncIOBackend:
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
                 OSError("AF_UNIX path too long."),
             ],
-            ids=lambda exc: f"bind_error=={exc!r}",
+            ids=lambda exc: f"bind_error__{exc!r}",
         )
         async def test____create_unix_datagram_endpoint____bind_error(
             self,
@@ -1098,7 +1098,7 @@ class TestAsyncIOBackend:
                 "\0local_sock",
                 b"\x00local_sock",
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -1108,14 +1108,14 @@ class TestAsyncIOBackend:
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "connect_error",
             [
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
             ],
-            ids=lambda exc: f"connect_error=={exc!r}",
+            ids=lambda exc: f"connect_error__{exc!r}",
         )
         async def test____create_unix_datagram_endpoint____connect_error(
             self,
@@ -1403,9 +1403,9 @@ class TestAsyncIOBackend:
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
-        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode=={mode!r}")
+        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode__{mode!r}")
         async def test____create_unix_datagram_listener____open_listener_socket(
             self,
             backend: AsyncIOBackend,
@@ -1452,7 +1452,7 @@ class TestAsyncIOBackend:
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "bind_error",
@@ -1460,9 +1460,9 @@ class TestAsyncIOBackend:
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
                 OSError("AF_UNIX path too long."),
             ],
-            ids=lambda exc: f"bind_error=={exc!r}",
+            ids=lambda exc: f"bind_error__{exc!r}",
         )
-        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode=={mode!r}")
+        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode__{mode!r}")
         async def test____create_unix_datagram_listener____bind_failed(
             self,
             backend: AsyncIOBackend,
@@ -1508,7 +1508,7 @@ class TestAsyncIOBackend:
                 "/path/to/local.sock",
                 b"/path/to/local.sock",
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         async def test____create_unix_datagram_listener____chmod_failed(
             self,
@@ -1543,7 +1543,7 @@ class TestAsyncIOBackend:
             mock_os_chmod.assert_called_once()
             mock_RawUnixDatagramListenerAdapter.assert_not_called()
 
-    @pytest.mark.parametrize("fair_lock", [False, True], ids=lambda p: f"fair_lock=={p}")
+    @pytest.mark.parametrize("fair_lock", [False, True], ids=lambda p: f"fair_lock__{p}")
     async def test____create_lock____use_asyncio_Lock_class(
         self,
         fair_lock: bool,
@@ -1615,7 +1615,7 @@ class TestAsyncIOBackend:
         # Assert
         mock_Condition.assert_not_called()
 
-    @pytest.mark.parametrize("abandon_on_cancel", [False, True], ids=lambda p: f"abandon_on_cancel=={p}")
+    @pytest.mark.parametrize("abandon_on_cancel", [False, True], ids=lambda p: f"abandon_on_cancel__{p}")
     async def test____run_in_thread____use_loop_run_in_executor(
         self,
         abandon_on_cancel: bool,

--- a/tests/unit_test/test_async/test_asyncio_backend/test_datagram.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_datagram.py
@@ -51,9 +51,9 @@ class CustomException(Exception):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("local_address", ["local_address", None], ids=lambda p: f"local_address=={p}")
-@pytest.mark.parametrize("remote_address", ["remote_address", None], ids=lambda p: f"remote_address=={p}")
-@pytest.mark.parametrize("reuse_port", [False, True], ids=lambda p: f"reuse_port=={p}")
+@pytest.mark.parametrize("local_address", ["local_address", None], ids=lambda p: f"local_address__{p}")
+@pytest.mark.parametrize("remote_address", ["remote_address", None], ids=lambda p: f"remote_address__{p}")
+@pytest.mark.parametrize("reuse_port", [False, True], ids=lambda p: f"reuse_port__{p}")
 async def test____create_datagram_endpoint____return_DatagramEndpoint_instance(
     local_address: Any | None,
     remote_address: Any | None,
@@ -194,7 +194,7 @@ class TestDatagramEndpoint:
 
         mock_asyncio_transport.close.assert_called()
 
-    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing=={p}")
+    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing__{p}")
     async def test____aclose____close_transport_and_wait(
         self,
         transport_is_closing: bool,
@@ -217,7 +217,7 @@ class TestDatagramEndpoint:
             mock_asyncio_protocol._get_close_waiter.assert_awaited_once_with()
         mock_asyncio_transport.abort.assert_not_called()
 
-    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing=={p}")
+    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing__{p}")
     async def test____aclose____abort_transport_if_cancelled(
         self,
         transport_is_closing: bool,
@@ -391,7 +391,7 @@ class TestDatagramEndpoint:
         mock_asyncio_recv_queue.get.assert_awaited_once_with()
 
     @pytest.mark.parametrize("address", [("127.0.0.1", 12345), "/path/to/unix.sock", b"\x00abstract_sock", None], ids=repr)
-    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing=={p}")
+    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing__{p}")
     async def test____sendto____send_and_await_drain(
         self,
         transport_is_closing: bool,
@@ -647,7 +647,7 @@ class TestDatagramEndpointProtocol:
             await protocol._drain_helper()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("cancel_tasks", [False, True], ids=lambda p: f"cancel_tasks_before=={p}")
+    @pytest.mark.parametrize("cancel_tasks", [False, True], ids=lambda p: f"cancel_tasks_before__{p}")
     async def test____drain_helper____wait_during_writing_pause(
         self,
         cancel_tasks: bool,
@@ -678,7 +678,7 @@ class TestDatagramEndpointProtocol:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("exception", [None, OSError("Something bad happen")])
-    @pytest.mark.parametrize("cancel_tasks", [False, True], ids=lambda p: f"cancel_tasks_before=={p}")
+    @pytest.mark.parametrize("cancel_tasks", [False, True], ids=lambda p: f"cancel_tasks_before__{p}")
     async def test____drain_helper____wait_during_writing_pause____connection_lost_while_waiting(
         self,
         cancel_tasks: bool,
@@ -825,7 +825,7 @@ class TestAsyncioTransportDatagramSocketAdapter(BaseTestAsyncioDatagramTransport
         mock_endpoint.aclose.assert_awaited_once_with()
         mock_endpoint.close_nowait.assert_not_called()
 
-    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed=={p}")
+    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed__{p}")
     async def test____is_closing____return_internal_flag(
         self,
         transport_closed: bool,
@@ -951,7 +951,7 @@ if sys.platform != "win32":
             # Assert
             mock_datagram_socket.close.assert_called_once_with()
 
-        @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed=={p}")
+        @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed__{p}")
         async def test____is_closing____default(
             self,
             transport_closed: bool,
@@ -1223,7 +1223,7 @@ if sys.platform != "win32":
             assert chunks == [[b"data"]]
 
         @PlatformMarkers.supports_socket_sendmsg
-        @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator=={p}")
+        @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator__{p}")
         async def test____send_with_ancillary____blocking_error____correctly_handle_iterables(
             self,
             ancillary_data_is_iterator: bool,
@@ -1336,7 +1336,7 @@ if sys.platform != "win32":
                 pytest.param("recv"),
                 pytest.param("recv_with_ancillary", marks=[PlatformMarkers.supports_socket_recvmsg]),
             ],
-            ids=lambda p: f"b:{p}",
+            ids=lambda p: f"b__{p}",
         )
         @pytest.mark.parametrize(
             "incoming_recv_method",
@@ -1344,7 +1344,7 @@ if sys.platform != "win32":
                 pytest.param("recv"),
                 pytest.param("recv_with_ancillary", marks=[PlatformMarkers.supports_socket_recvmsg]),
             ],
-            ids=lambda p: f"i:{p}",
+            ids=lambda p: f"i__{p}",
         )
         async def test____special_case____recv____busy(
             self,
@@ -1445,7 +1445,7 @@ if sys.platform != "win32":
                 pytest.param("send"),
                 pytest.param("send_with_ancillary", marks=[PlatformMarkers.supports_socket_sendmsg]),
             ],
-            ids=lambda p: f"b:{p}",
+            ids=lambda p: f"b__{p}",
         )
         @pytest.mark.parametrize(
             "incoming_send_method",
@@ -1453,7 +1453,7 @@ if sys.platform != "win32":
                 pytest.param("send"),
                 pytest.param("send_with_ancillary", marks=[PlatformMarkers.supports_socket_sendmsg]),
             ],
-            ids=lambda p: f"i:{p}",
+            ids=lambda p: f"i__{p}",
         )
         async def test____special_case____send____busy(
             self,
@@ -1583,7 +1583,7 @@ class TestDatagramListenerSocketAdapter(BaseTestAsyncioDatagramTransport):
 
         mock_asyncio_transport.close.assert_called()
 
-    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing=={p}")
+    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing__{p}")
     async def test____aclose____close_transport_and_wait(
         self,
         transport_is_closing: bool,
@@ -1606,7 +1606,7 @@ class TestDatagramListenerSocketAdapter(BaseTestAsyncioDatagramTransport):
             mock_asyncio_protocol._get_close_waiter.assert_awaited_once_with()
         mock_asyncio_transport.abort.assert_not_called()
 
-    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing=={p}")
+    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing__{p}")
     async def test____aclose____abort_transport_if_cancelled(
         self,
         transport_is_closing: bool,
@@ -1632,7 +1632,7 @@ class TestDatagramListenerSocketAdapter(BaseTestAsyncioDatagramTransport):
             mock_asyncio_protocol._get_close_waiter.assert_awaited_once_with()
         mock_asyncio_transport.abort.assert_not_called()
 
-    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed=={p}")
+    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed__{p}")
     async def test____is_closing____return_internal_flag(
         self,
         transport_closed: bool,
@@ -1651,7 +1651,7 @@ class TestDatagramListenerSocketAdapter(BaseTestAsyncioDatagramTransport):
         mock_asyncio_transport.is_closing.assert_not_called()
         assert state is transport_closed
 
-    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group=={p}")
+    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group__{p}")
     async def test____serve____task_group(
         self,
         external_group: bool,
@@ -1675,7 +1675,7 @@ class TestDatagramListenerSocketAdapter(BaseTestAsyncioDatagramTransport):
         else:
             mock_asyncio_protocol.serve.assert_awaited_once_with(datagram_received_cb, mocker.ANY)
 
-    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing=={p}")
+    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing__{p}")
     async def test____send_to____write_and_drain(
         self,
         transport_is_closing: bool,
@@ -1783,7 +1783,7 @@ if sys.platform != "win32":
             # Assert
             mock_datagram_socket.close.assert_called_once_with()
 
-        @pytest.mark.parametrize("listener_closed", [False, True], ids=lambda p: f"listener_closed=={p}")
+        @pytest.mark.parametrize("listener_closed", [False, True], ids=lambda p: f"listener_closed__{p}")
         async def test____is_closing____default(
             self,
             listener_closed: bool,
@@ -1799,7 +1799,7 @@ if sys.platform != "win32":
             # Assert
             assert state is listener_closed
 
-        @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group=={p}")
+        @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group__{p}")
         @pytest.mark.parametrize(
             ["sender_address_1", "sender_address_2", "sender_address_3"],
             [
@@ -1880,7 +1880,7 @@ if sys.platform != "win32":
             mock_event_loop_add_writer.assert_not_called()
 
         @PlatformMarkers.supports_socket_recvmsg
-        @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group=={p}")
+        @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group__{p}")
         @pytest.mark.parametrize(
             ["sender_address_1", "sender_address_2", "sender_address_3"],
             [
@@ -2089,7 +2089,7 @@ if sys.platform != "win32":
             assert chunks == [[b"data"]]
 
         @PlatformMarkers.supports_socket_sendmsg
-        @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator=={p}")
+        @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator__{p}")
         @pytest.mark.parametrize("destination_address", ["/path/to/unix.sock", b"\x00abstract_address"])
         async def test____send_with_ancillary____blocking_error____correctly_handle_iterables(
             self,
@@ -2204,7 +2204,7 @@ if sys.platform != "win32":
                 pytest.param("serve"),
                 pytest.param("serve_with_ancillary", marks=[PlatformMarkers.supports_socket_recvmsg]),
             ],
-            ids=lambda p: f"b:{p}",
+            ids=lambda p: f"b__{p}",
         )
         @pytest.mark.parametrize(
             "incoming_serve_method",
@@ -2212,7 +2212,7 @@ if sys.platform != "win32":
                 pytest.param("serve"),
                 pytest.param("serve_with_ancillary", marks=[PlatformMarkers.supports_socket_recvmsg]),
             ],
-            ids=lambda p: f"i:{p}",
+            ids=lambda p: f"i__{p}",
         )
         async def test____special_case____serve____busy(
             self,
@@ -2315,7 +2315,7 @@ if sys.platform != "win32":
                 pytest.param("send_to"),
                 pytest.param("send_with_ancillary_to", marks=[PlatformMarkers.supports_socket_sendmsg]),
             ],
-            ids=lambda p: f"b:{p}",
+            ids=lambda p: f"b__{p}",
         )
         @pytest.mark.parametrize(
             "incoming_send_method",
@@ -2323,7 +2323,7 @@ if sys.platform != "win32":
                 pytest.param("send_to"),
                 pytest.param("send_with_ancillary_to", marks=[PlatformMarkers.supports_socket_sendmsg]),
             ],
-            ids=lambda p: f"i:{p}",
+            ids=lambda p: f"i__{p}",
         )
         async def test____special_case____send____busy(
             self,
@@ -2557,7 +2557,7 @@ class TestDatagramListenerProtocol:
         ]
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("event_loop_debug", [False, True], ids=lambda p: f"event_loop_debug=={p}")
+    @pytest.mark.parametrize("event_loop_debug", [False, True], ids=lambda p: f"event_loop_debug__{p}")
     async def test____error_received____log_error(
         self,
         event_loop_debug: bool,
@@ -2584,7 +2584,7 @@ class TestDatagramListenerProtocol:
             assert caplog.records[0].exc_info is None
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("event_loop_debug", [False, True], ids=lambda p: f"event_loop_debug=={p}")
+    @pytest.mark.parametrize("event_loop_debug", [False, True], ids=lambda p: f"event_loop_debug__{p}")
     async def test____error_received____do_not_log_after_connection_lost(
         self,
         event_loop_debug: bool,
@@ -2652,7 +2652,7 @@ class TestDatagramListenerProtocol:
             await protocol.writer_drain()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("cancel_tasks", [False, True], ids=lambda p: f"cancel_tasks_before=={p}")
+    @pytest.mark.parametrize("cancel_tasks", [False, True], ids=lambda p: f"cancel_tasks_before__{p}")
     async def test____drain_helper____wait_during_writing_pause(
         self,
         cancel_tasks: bool,
@@ -2683,7 +2683,7 @@ class TestDatagramListenerProtocol:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("exception", [None, OSError("Something bad happen")])
-    @pytest.mark.parametrize("cancel_tasks", [False, True], ids=lambda p: f"cancel_tasks_before=={p}")
+    @pytest.mark.parametrize("cancel_tasks", [False, True], ids=lambda p: f"cancel_tasks_before__{p}")
     async def test____drain_helper____wait_during_writing_pause____connection_lost_while_waiting(
         self,
         cancel_tasks: bool,

--- a/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_stream.py
@@ -155,7 +155,7 @@ class BaseTestTransportWithSSL(BaseTestTransportStreamSocket):
 
 @pytest.mark.asyncio
 class TestListenerSocketAdapter(BaseTestSocketTransport, BaseTestAsyncSocket):
-    @pytest.fixture(params=[False, True], ids=lambda p: f"add_reader=={p}", autouse=True)
+    @pytest.fixture(params=[False, True], ids=lambda p: f"add_reader__{p}", autouse=True)
     @staticmethod
     def add_reader_supported(
         request: pytest.FixtureRequest,
@@ -359,8 +359,8 @@ class TestListenerSocketAdapter(BaseTestSocketTransport, BaseTestAsyncSocket):
         # Assert
         mock_stream_listener_socket.close.assert_called_once_with()
 
-    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group=={p}")
-    @pytest.mark.parametrize("add_reader_supported", [False], ids=lambda p: f"add_reader=={p}", indirect=True)
+    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group__{p}")
+    @pytest.mark.parametrize("add_reader_supported", [False], ids=lambda p: f"add_reader__{p}", indirect=True)
     async def test____serve____default(
         self,
         asyncio_backend: AsyncIOBackend,
@@ -407,7 +407,7 @@ class TestListenerSocketAdapter(BaseTestSocketTransport, BaseTestAsyncSocket):
         ],
         ids=repr,
     )
-    @pytest.mark.parametrize("add_reader_supported", [False], ids=lambda p: f"add_reader=={p}", indirect=True)
+    @pytest.mark.parametrize("add_reader_supported", [False], ids=lambda p: f"add_reader__{p}", indirect=True)
     async def test____serve____connect____error_raised(
         self,
         exc: BaseException,
@@ -847,10 +847,10 @@ class TestAsyncioTransportStreamSocketAdapter(BaseTestTransportWithSSL):
 
         mock_asyncio_transport.close.assert_called()
 
-    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing=={p}")
-    @pytest.mark.parametrize("can_write_eof", [False, True], ids=lambda p: f"can_write_eof=={p}")
-    @pytest.mark.parametrize("wait_close_raise_error", [False, True], ids=lambda p: f"wait_close_raise_error=={p}")
-    @pytest.mark.parametrize("write_eof_raise_error", [False, True], ids=lambda p: f"write_eof_raise_error=={p}")
+    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing__{p}")
+    @pytest.mark.parametrize("can_write_eof", [False, True], ids=lambda p: f"can_write_eof__{p}")
+    @pytest.mark.parametrize("wait_close_raise_error", [False, True], ids=lambda p: f"wait_close_raise_error__{p}")
+    @pytest.mark.parametrize("write_eof_raise_error", [False, True], ids=lambda p: f"write_eof_raise_error__{p}")
     async def test____aclose____close_transport_and_wait(
         self,
         transport_is_closing: bool,
@@ -888,7 +888,7 @@ class TestAsyncioTransportStreamSocketAdapter(BaseTestTransportWithSSL):
             mock_asyncio_protocol._get_close_waiter.assert_awaited_once_with()
             mock_asyncio_transport.abort.assert_not_called()
 
-    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing=={p}")
+    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing__{p}")
     async def test____aclose____abort_transport_if_cancelled(
         self,
         transport_is_closing: bool,
@@ -914,7 +914,7 @@ class TestAsyncioTransportStreamSocketAdapter(BaseTestTransportWithSSL):
             mock_asyncio_protocol._get_close_waiter.assert_awaited_once_with()
         mock_asyncio_transport.abort.assert_not_called()
 
-    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed=={p}")
+    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed__{p}")
     async def test____is_closing____return_internal_flag(
         self,
         transport_closed: bool,
@@ -995,7 +995,7 @@ class TestAsyncioTransportStreamSocketAdapter(BaseTestTransportWithSSL):
         mock_asyncio_protocol.receive_data_into.assert_awaited_once_with(buffer)
         assert nbytes == 0
 
-    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing=={p}")
+    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing__{p}")
     async def test____send_all____write_and_drain(
         self,
         transport_is_closing: bool,
@@ -1014,7 +1014,7 @@ class TestAsyncioTransportStreamSocketAdapter(BaseTestTransportWithSSL):
         mock_asyncio_transport.writelines.assert_not_called()
         mock_asyncio_protocol.writer_drain.assert_awaited_once_with()
 
-    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing=={p}")
+    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing__{p}")
     async def test____send_all_from_iterable____writelines_and_drain(
         self,
         transport_is_closing: bool,
@@ -1036,7 +1036,7 @@ class TestAsyncioTransportStreamSocketAdapter(BaseTestTransportWithSSL):
         mock_asyncio_protocol.writer_drain.assert_awaited_once_with()
         assert written_chunks == [b"data", b"to", b"send"]
 
-    @pytest.mark.parametrize("can_write_eof", [False, True], ids=lambda p: f"can_write_eof=={p}")
+    @pytest.mark.parametrize("can_write_eof", [False, True], ids=lambda p: f"can_write_eof__{p}")
     async def test____send_eof____write_eof(
         self,
         can_write_eof: bool,
@@ -1152,7 +1152,7 @@ if sys.platform != "win32":
             # Assert
             mock_stream_socket.close.assert_called_once_with()
 
-        @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed=={p}")
+        @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed__{p}")
         async def test____is_closing____default(
             self,
             transport_closed: bool,
@@ -1652,7 +1652,7 @@ if sys.platform != "win32":
 
         @PlatformMarkers.supports_socket_sendmsg
         @pytest.mark.usefixtures("SC_IOV_MAX")
-        @pytest.mark.parametrize("SC_IOV_MAX", [2], ids=lambda p: f"SC_IOV_MAX=={p}", indirect=True)
+        @pytest.mark.parametrize("SC_IOV_MAX", [2], ids=lambda p: f"SC_IOV_MAX__{p}", indirect=True)
         async def test____send_all_with_ancillary____message_too_long____nb_buffers_greather_than_SC_IOV_MAX(
             self,
             transport: RawUnixStreamSocketAdapter,
@@ -1682,8 +1682,8 @@ if sys.platform != "win32":
             assert chunks == [[b"a", b"b"]]
 
         @PlatformMarkers.supports_socket_sendmsg
-        @pytest.mark.parametrize("data_is_iterator", [False, True], ids=lambda p: f"data_is_iterator=={p}")
-        @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator=={p}")
+        @pytest.mark.parametrize("data_is_iterator", [False, True], ids=lambda p: f"data_is_iterator__{p}")
+        @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator__{p}")
         async def test____send_all_with_ancillary____blocking_error____correctly_handle_iterables(
             self,
             data_is_iterator: bool,
@@ -1777,7 +1777,7 @@ if sys.platform != "win32":
 
         @PlatformMarkers.supports_socket_sendmsg
         @pytest.mark.usefixtures("SC_IOV_MAX")
-        @pytest.mark.parametrize("SC_IOV_MAX", [2], ids=lambda p: f"SC_IOV_MAX=={p}", indirect=True)
+        @pytest.mark.parametrize("SC_IOV_MAX", [2], ids=lambda p: f"SC_IOV_MAX__{p}", indirect=True)
         async def test____send_all_from_iterable____use_socket_sendmsg____nb_buffers_greather_than_SC_IOV_MAX(
             self,
             transport: RawUnixStreamSocketAdapter,
@@ -2054,7 +2054,7 @@ if sys.platform != "win32":
                 pytest.param("recv_with_ancillary", marks=[PlatformMarkers.supports_socket_recvmsg]),
                 pytest.param("recv_with_ancillary_into", marks=[PlatformMarkers.supports_socket_recvmsg_into]),
             ],
-            ids=lambda p: f"b:{p}",
+            ids=lambda p: f"b__{p}",
         )
         @pytest.mark.parametrize(
             "incoming_recv_method",
@@ -2064,7 +2064,7 @@ if sys.platform != "win32":
                 pytest.param("recv_with_ancillary", marks=[PlatformMarkers.supports_socket_recvmsg]),
                 pytest.param("recv_with_ancillary_into", marks=[PlatformMarkers.supports_socket_recvmsg_into]),
             ],
-            ids=lambda p: f"i:{p}",
+            ids=lambda p: f"i__{p}",
         )
         async def test____special_case____recv____busy(
             self,
@@ -2190,7 +2190,7 @@ if sys.platform != "win32":
                 pytest.param("send_all_with_ancillary", marks=[PlatformMarkers.supports_socket_sendmsg]),
                 pytest.param("send_all_from_iterable", marks=[PlatformMarkers.supports_socket_sendmsg]),
             ],
-            ids=lambda p: f"b:{p}",
+            ids=lambda p: f"b__{p}",
         )
         @pytest.mark.parametrize(
             "incoming_send_method",
@@ -2199,7 +2199,7 @@ if sys.platform != "win32":
                 pytest.param("send_all_with_ancillary", marks=[PlatformMarkers.supports_socket_sendmsg]),
                 pytest.param("send_all_from_iterable", marks=[PlatformMarkers.supports_socket_sendmsg]),
             ],
-            ids=lambda p: f"i:{p}",
+            ids=lambda p: f"i__{p}",
         )
         async def test____special_case____send____busy(
             self,
@@ -2439,7 +2439,7 @@ class TestStreamReaderBufferedProtocol(BaseTestTransportWithSSL):
         assert protocol.eof_received() is False
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("blocking", [False, True], ids=lambda p: f"blocking=={p}")
+    @pytest.mark.parametrize("blocking", [False, True], ids=lambda p: f"blocking__{p}")
     async def test____receive_data____default(
         self,
         blocking: bool,
@@ -2483,7 +2483,7 @@ class TestStreamReaderBufferedProtocol(BaseTestTransportWithSSL):
         mock_asyncio_transport.resume_reading.assert_not_called()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("blocking", [False, True], ids=lambda p: f"blocking=={p}")
+    @pytest.mark.parametrize("blocking", [False, True], ids=lambda p: f"blocking__{p}")
     @pytest.mark.parametrize("data_receiver", ["data"], indirect=True)
     async def test____receive_data____owned_data____buffer_updated_several_times(
         self,
@@ -2511,7 +2511,7 @@ class TestStreamReaderBufferedProtocol(BaseTestTransportWithSSL):
         mock_asyncio_transport.resume_reading.assert_not_called()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("blocking", [False, True], ids=lambda p: f"blocking=={p}")
+    @pytest.mark.parametrize("blocking", [False, True], ids=lambda p: f"blocking__{p}")
     @pytest.mark.parametrize("data_receiver", ["buffer"], indirect=True)
     async def test____receive_data____into_buffer____buffer_updated_several_times(
         self,
@@ -2562,7 +2562,7 @@ class TestStreamReaderBufferedProtocol(BaseTestTransportWithSSL):
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("eof_reason", ["eof_received", "connection_lost"])
-    @pytest.mark.parametrize("blocking", [False, True], ids=lambda p: f"blocking=={p}")
+    @pytest.mark.parametrize("blocking", [False, True], ids=lambda p: f"blocking__{p}")
     async def test____receive_data____eof(
         self,
         blocking: bool,
@@ -2598,7 +2598,7 @@ class TestStreamReaderBufferedProtocol(BaseTestTransportWithSSL):
         mock_asyncio_transport.resume_reading.assert_not_called()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("blocking", [False, True], ids=lambda p: f"blocking=={p}")
+    @pytest.mark.parametrize("blocking", [False, True], ids=lambda p: f"blocking__{p}")
     async def test____receive_data____connection_lost_by_unrelated_error(
         self,
         blocking: bool,
@@ -2760,7 +2760,7 @@ class TestStreamReaderBufferedProtocol(BaseTestTransportWithSSL):
                     pytest.fail("Invalid param")
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing=={p}")
+    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing__{p}")
     async def test____drain_helper____quick_exit_if_not_paused(
         self,
         transport_is_closing: bool,
@@ -2818,7 +2818,7 @@ class TestStreamReaderBufferedProtocol(BaseTestTransportWithSSL):
         assert exc_info.value is exception
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("cancel_tasks", [False, True], ids=lambda p: f"cancel_tasks_before=={p}")
+    @pytest.mark.parametrize("cancel_tasks", [False, True], ids=lambda p: f"cancel_tasks_before__{p}")
     async def test____drain_helper____wait_during_writing_pause(
         self,
         cancel_tasks: bool,
@@ -2849,7 +2849,7 @@ class TestStreamReaderBufferedProtocol(BaseTestTransportWithSSL):
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("exception", [None, OSError("Something bad happen")])
-    @pytest.mark.parametrize("cancel_tasks", [False, True], ids=lambda p: f"cancel_tasks_before=={p}")
+    @pytest.mark.parametrize("cancel_tasks", [False, True], ids=lambda p: f"cancel_tasks_before__{p}")
     async def test____drain_helper____wait_during_writing_pause____connection_lost_while_waiting(
         self,
         cancel_tasks: bool,

--- a/tests/unit_test/test_async/test_asyncio_backend/test_utils.py
+++ b/tests/unit_test/test_async/test_asyncio_backend/test_utils.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
         pytest.param(wait_until_writable, "add_writer", "remove_writer", id="write"),
     ],
 )
-@pytest.mark.parametrize("future_cancelled", [False, True], ids=lambda p: f"future_cancelled=={p}")
+@pytest.mark.parametrize("future_cancelled", [False, True], ids=lambda p: f"future_cancelled__{p}")
 async def test____wait_until___event_wakeup(
     waiter: Callable[[SocketType, asyncio.AbstractEventLoop], asyncio.Future[None]],
     event_loop_add_event_func_name: str,

--- a/tests/unit_test/test_async/test_lowlevel_api/test_backend/test_common_tools/test_dns_resolver.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_backend/test_common_tools/test_dns_resolver.py
@@ -405,7 +405,7 @@ class _AddrInfoListFactory(TypingProtocol):
     ) -> Sequence[tuple[int, int, int, str, tuple[Any, ...]]]: ...
 
 
-@pytest.fixture(params=[SOCK_STREAM, SOCK_DGRAM], ids=lambda sock_type: f"sock_type=={sock_type!r}")
+@pytest.fixture(params=[SOCK_STREAM, SOCK_DGRAM], ids=lambda sock_type: f"{sock_type.name}")
 def connection_socktype(request: pytest.FixtureRequest) -> int:
     return request.param
 
@@ -428,7 +428,7 @@ def create_connection_of_socktype(dns_resolver: MockedDNSResolver, connection_so
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("with_local_address", [False, True], ids=lambda boolean: f"with_local_address=={boolean}")
+@pytest.mark.parametrize("with_local_address", [False, True], ids=lambda boolean: f"with_local_address__{boolean}")
 async def test____create_connection____default(
     asyncio_backend: AsyncBackend,
     dns_resolver: MockedDNSResolver,
@@ -488,7 +488,7 @@ async def test____create_connection____default(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("fail_on", ["socket", "bind", "connect"], ids=lambda fail_on: f"fail_on=={fail_on}")
+@pytest.mark.parametrize("fail_on", ["socket", "bind", "connect"], ids=lambda fail_on: f"fail_on__{fail_on}")
 async def test____create_connection____first_failed(
     fail_on: Literal["socket", "bind", "connect"],
     asyncio_backend: AsyncBackend,
@@ -569,7 +569,7 @@ async def test____create_connection____first_failed(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("fail_on", ["socket", "bind", "connect"], ids=lambda fail_on: f"fail_on=={fail_on}")
+@pytest.mark.parametrize("fail_on", ["socket", "bind", "connect"], ids=lambda fail_on: f"fail_on__{fail_on}")
 async def test____create_connection____all_failed(
     fail_on: Literal["socket", "bind", "connect"],
     asyncio_backend: AsyncBackend,
@@ -649,7 +649,7 @@ async def test____create_connection____all_failed(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("fail_on", ["socket", "connect"], ids=lambda fail_on: f"fail_on=={fail_on}")
+@pytest.mark.parametrize("fail_on", ["socket", "connect"], ids=lambda fail_on: f"fail_on__{fail_on}")
 async def test____create_connection____unrelated_exception(
     fail_on: Literal["socket", "connect"],
     connection_socktype: int,
@@ -689,7 +689,7 @@ async def test____create_connection____unrelated_exception(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("fail_on", ["remote_address", "local_address"], ids=lambda fail_on: f"fail_on=={fail_on}")
+@pytest.mark.parametrize("fail_on", ["remote_address", "local_address"], ids=lambda fail_on: f"fail_on__{fail_on}")
 async def test____create_connection____getaddrinfo_returned_empty_list(
     fail_on: Literal["remote_address", "local_address"],
     connection_socktype: int,
@@ -763,7 +763,7 @@ async def test____create_connection____getaddrinfo_return_mismatch(
 
 @PlatformMarkers.skipif_platform_bsd_because("test failures are all too frequent on CI", skip_only_on_ci=True)
 @pytest.mark.asyncio
-@pytest.mark.parametrize("connection_socktype", [SOCK_STREAM], indirect=True, ids=repr)
+@pytest.mark.parametrize("connection_socktype", [pytest.param(SOCK_STREAM, id=pytest.HIDDEN_PARAM)], indirect=True)
 @pytest.mark.flaky(retries=3)
 async def test____create_stream_connection____happy_eyeballs_delay____connect_cancellation(
     asyncio_backend: AsyncBackend,
@@ -807,7 +807,7 @@ async def test____create_stream_connection____happy_eyeballs_delay____connect_ca
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("connection_socktype", [SOCK_STREAM], indirect=True, ids=repr)
+@pytest.mark.parametrize("connection_socktype", [pytest.param(SOCK_STREAM, id=pytest.HIDDEN_PARAM)], indirect=True)
 async def test____create_stream_connection____happy_eyeballs_delay____connect_too_late(
     asyncio_backend: AsyncBackend,
     dns_resolver: MockedDNSResolver,
@@ -845,7 +845,7 @@ async def test____create_stream_connection____happy_eyeballs_delay____connect_to
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("connection_socktype", [SOCK_STREAM], indirect=True, ids=repr)
+@pytest.mark.parametrize("connection_socktype", [pytest.param(SOCK_STREAM, id=pytest.HIDDEN_PARAM)], indirect=True)
 async def test____create_stream_connection____happy_eyeballs_delay____winner_closed_because_of_exception_in_another_task(
     asyncio_backend: AsyncBackend,
     dns_resolver: MockedDNSResolver,
@@ -886,7 +886,7 @@ async def test____create_stream_connection____happy_eyeballs_delay____winner_clo
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("connection_socktype", [SOCK_STREAM], indirect=True, ids=repr)
+@pytest.mark.parametrize("connection_socktype", [pytest.param(SOCK_STREAM, id=pytest.HIDDEN_PARAM)], indirect=True)
 async def test____create_stream_connection____happy_eyeballs_delay____addrinfo_reordering____prioritize_ipv6_over_ipv4(
     asyncio_backend: AsyncBackend,
     dns_resolver: MockedDNSResolver,
@@ -916,7 +916,7 @@ async def test____create_stream_connection____happy_eyeballs_delay____addrinfo_r
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("connection_socktype", [SOCK_STREAM], indirect=True, ids=repr)
+@pytest.mark.parametrize("connection_socktype", [pytest.param(SOCK_STREAM, id=pytest.HIDDEN_PARAM)], indirect=True)
 async def test____create_stream_connection____happy_eyeballs_delay____addrinfo_reordering____interleave_families(
     asyncio_backend: AsyncBackend,
     dns_resolver: MockedDNSResolver,

--- a/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream/base.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream/base.py
@@ -319,7 +319,7 @@ class BaseAsyncEndpointReceiveTests(BaseAsyncEndpointTests):
         # Assert
         assert exc_info.value is expected_error
 
-    @pytest.mark.parametrize("before_transport_reading", [False, True], ids=lambda p: f"before_transport_reading=={p}")
+    @pytest.mark.parametrize("before_transport_reading", [False, True], ids=lambda p: f"before_transport_reading__{p}")
     async def test____recv_packet____protocol_crashed(
         self,
         before_transport_reading: bool,
@@ -520,7 +520,7 @@ class BaseAsyncEndpointReceiveTests(BaseAsyncEndpointTests):
         assert exc_info.value is expected_error
         ancillary_data_received.assert_called_once_with(mocker.sentinel.ancdata)
 
-    @pytest.mark.parametrize("before_transport_reading", [False, True], ids=lambda p: f"before_transport_reading=={p}")
+    @pytest.mark.parametrize("before_transport_reading", [False, True], ids=lambda p: f"before_transport_reading__{p}")
     async def test____recv_packet_with_ancillary____protocol_crashed(
         self,
         before_transport_reading: bool,

--- a/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream/test_fullduplex.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream/test_fullduplex.py
@@ -67,7 +67,7 @@ class TestAsyncStreamEndpoint(BaseAsyncEndpointSendTests, BaseAsyncEndpointRecei
         with pytest.raises(TypeError, match=r"^Expected a StreamProtocol or a BufferedStreamProtocol object, got .*$"):
             _ = AsyncStreamEndpoint(mock_stream_transport, mock_invalid_protocol, max_recv_size)
 
-    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size=={p}")
+    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size__{p}")
     async def test____dunder_init____max_recv_size____invalid_value(
         self,
         mock_stream_transport: MagicMock,
@@ -102,7 +102,7 @@ class TestAsyncStreamEndpoint(BaseAsyncEndpointSendTests, BaseAsyncEndpointRecei
 
         mock_stream_transport.aclose.assert_not_called()
 
-    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed=={p}")
+    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed__{p}")
     async def test____send_eof____default(
         self,
         transport_closed: bool,
@@ -127,7 +127,7 @@ class TestAsyncStreamEndpoint(BaseAsyncEndpointSendTests, BaseAsyncEndpointRecei
         mock_stream_transport.send_all_from_iterable.assert_not_called()
         mock_stream_transport.send_all_with_ancillary.assert_not_called()
 
-    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed=={p}")
+    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed__{p}")
     async def test____send_eof____idempotent(
         self,
         transport_closed: bool,
@@ -149,7 +149,7 @@ class TestAsyncStreamEndpoint(BaseAsyncEndpointSendTests, BaseAsyncEndpointRecei
         with pytest.raises(RuntimeError, match=r"^send_eof\(\) has been called earlier$"):
             await endpoint.send_packet_with_ancillary(mocker.sentinel.packet, mocker.sentinel.ancdata)
 
-    @pytest.mark.parametrize("with_ancillary", [False, True], ids=lambda p: f"with_ancillary=={p}")
+    @pytest.mark.parametrize("with_ancillary", [False, True], ids=lambda p: f"with_ancillary__{p}")
     async def test____special_case____send_packet____eof_error____still_try_socket_send(
         self,
         stream_protocol_mode: Literal["data", "buffer"],

--- a/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream/test_readonly.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_endpoints/test_stream/test_readonly.py
@@ -66,7 +66,7 @@ class TestAsyncStreamReceiverEndpoint(BaseAsyncEndpointReceiveTests):
         with pytest.raises(TypeError, match=r"^Expected a StreamProtocol or a BufferedStreamProtocol object, got .*$"):
             _ = AsyncStreamReceiverEndpoint(mock_stream_transport, mock_invalid_protocol, max_recv_size)
 
-    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size=={p}")
+    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size__{p}")
     async def test____dunder_init____max_recv_size____invalid_value(
         self,
         mock_stream_transport: MagicMock,

--- a/tests/unit_test/test_async/test_lowlevel_api/test_futures.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_futures.py
@@ -25,7 +25,7 @@ class TestAsyncExecutor:
         executor.shutdown.return_value = None
         return executor
 
-    @pytest.fixture(params=[False, True], ids=lambda p: f"handle_context=={p}")
+    @pytest.fixture(params=[False, True], ids=lambda p: f"handle_context__{p}")
     @staticmethod
     def executor_handle_contexts(request: pytest.FixtureRequest) -> bool:
         return request.param

--- a/tests/unit_test/test_async/test_lowlevel_api/test_servers/test_datagram.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_servers/test_datagram.py
@@ -128,8 +128,8 @@ class TestAsyncDatagramServer(BaseTestWithDatagramProtocol):
         # Assert
         mock_datagram_listener.aclose.assert_awaited_once_with()
 
-    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group=={p}")
-    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary=={p}")
+    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group__{p}")
+    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary__{p}")
     async def test____serve____task_group(
         self,
         external_group: bool,
@@ -172,8 +172,8 @@ class TestAsyncDatagramServer(BaseTestWithDatagramProtocol):
             mock_backend.create_task_group.assert_called_once_with()
             mock_task_group.__aenter__.assert_awaited_once()
 
-    @pytest.mark.parametrize("after_first_yield", [False, True], ids=lambda p: f"after_first_yield=={p}")
-    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary=={p}")
+    @pytest.mark.parametrize("after_first_yield", [False, True], ids=lambda p: f"after_first_yield__{p}")
+    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary__{p}")
     async def test____serve____timeout____old_method_is_forbidden(
         self,
         after_first_yield: bool,
@@ -233,8 +233,8 @@ class TestAsyncDatagramServer(BaseTestWithDatagramProtocol):
             ancillary_data_unused.assert_called_once_with(mocker.sentinel.ancdata, mocker.sentinel.address)
 
     @pytest.mark.parametrize("invalid_timeout", [-1.0, math.nan])
-    @pytest.mark.parametrize("invalid_timeout_after_first_yield", [False, True], ids=lambda p: f"after_first_yield=={p}")
-    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary=={p}")
+    @pytest.mark.parametrize("invalid_timeout_after_first_yield", [False, True], ids=lambda p: f"after_first_yield__{p}")
+    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary__{p}")
     async def test____serve____invalid_timeout(
         self,
         invalid_timeout: float,
@@ -308,7 +308,7 @@ class TestAsyncDatagramServer(BaseTestWithDatagramProtocol):
 
         assert not caplog.records
 
-    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary=={p}")
+    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary__{p}")
     async def test____serve____unhandled_exception____from_system(
         self,
         recv_with_ancillary: bool,
@@ -362,7 +362,7 @@ class TestAsyncDatagramServer(BaseTestWithDatagramProtocol):
         assert isinstance(caplog.records[0].exc_info[1], DatagramProtocolParseError)
         assert caplog.records[0].getMessage().startswith("Unhandled exception:")
 
-    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary=={p}")
+    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary__{p}")
     async def test____serve____unhandled_exception____from_request_handler(
         self,
         recv_with_ancillary: bool,
@@ -408,7 +408,7 @@ class TestAsyncDatagramServer(BaseTestWithDatagramProtocol):
         assert isinstance(caplog.records[0].exc_info[1], ValueError)
         assert caplog.records[0].getMessage() == "Unhandled exception: something bad happened"
 
-    @pytest.mark.parametrize("after_first_yield", [False, True], ids=lambda p: f"after_first_yield=={p}")
+    @pytest.mark.parametrize("after_first_yield", [False, True], ids=lambda p: f"after_first_yield__{p}")
     async def test____serve____ancillary_data_asked_while_unsupported(
         self,
         after_first_yield: bool,
@@ -452,7 +452,7 @@ class TestAsyncDatagramServer(BaseTestWithDatagramProtocol):
 
         assert not caplog.records
 
-    @pytest.mark.parametrize("after_first_yield", [False, True], ids=lambda p: f"after_first_yield=={p}")
+    @pytest.mark.parametrize("after_first_yield", [False, True], ids=lambda p: f"after_first_yield__{p}")
     async def test____serve____recv_with_ancillary____ancillary_data_received_callback_crashed(
         self,
         after_first_yield: bool,
@@ -500,11 +500,11 @@ class TestAsyncDatagramServer(BaseTestWithDatagramProtocol):
 
         assert not caplog.records
 
-    @pytest.mark.parametrize("ancillary_data_unused", [False, True], ids=lambda p: f"ancillary_data_unused=={p}", indirect=True)
+    @pytest.mark.parametrize("ancillary_data_unused", [False, True], ids=lambda p: f"ancillary_data_unused__{p}", indirect=True)
     @pytest.mark.parametrize(
-        "ancillary_data_unused_callback_crash", [False, True], ids=lambda p: f"ancillary_data_unused_callback_crash=={p}"
+        "ancillary_data_unused_callback_crash", [False, True], ids=lambda p: f"ancillary_data_unused_callback_crash__{p}"
     )
-    @pytest.mark.parametrize("after_first_yield", [None, False, True], ids=lambda p: f"after_first_yield=={p}")
+    @pytest.mark.parametrize("after_first_yield", [None, False, True], ids=lambda p: f"after_first_yield__{p}")
     async def test____serve____recv_with_ancillary____ancillary_data_unused(
         self,
         after_first_yield: bool | None,
@@ -573,8 +573,8 @@ class TestAsyncDatagramServer(BaseTestWithDatagramProtocol):
                             mocker.call(mocker.sentinel.ancdata_2, mocker.sentinel.address),
                         ]
 
-    @pytest.mark.parametrize("after_first_yield", [None, False, True], ids=lambda p: f"after_first_yield=={p}")
-    @pytest.mark.parametrize("try_to_handle_ancillary_data", [False, True], ids=lambda p: f"try_to_handle_ancillary_data=={p}")
+    @pytest.mark.parametrize("after_first_yield", [None, False, True], ids=lambda p: f"after_first_yield__{p}")
+    @pytest.mark.parametrize("try_to_handle_ancillary_data", [False, True], ids=lambda p: f"try_to_handle_ancillary_data__{p}")
     async def test____serve____recv_with_ancillary____no_ancillary_data(
         self,
         after_first_yield: bool | None,
@@ -847,7 +847,7 @@ class TestClientData:
         assert self.get_client_state(client_data) is _ClientState.TASK_RUNNING
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("notify", [True, False], ids=lambda p: f"notify=={p}")
+    @pytest.mark.parametrize("notify", [True, False], ids=lambda p: f"notify__{p}")
     async def test____datagram_queue____push_datagram(
         self,
         notify: bool,
@@ -889,7 +889,7 @@ class TestClientData:
             queue_condition.notify.assert_not_called()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("no_wait", [False, True], ids=lambda p: f"no_wait=={p}")
+    @pytest.mark.parametrize("no_wait", [False, True], ids=lambda p: f"no_wait__{p}")
     async def test____datagram_queue____pop_datagram(
         self,
         no_wait: bool,

--- a/tests/unit_test/test_async/test_lowlevel_api/test_servers/test_stream.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_servers/test_stream.py
@@ -214,7 +214,7 @@ class TestAsyncStreamServer(BaseTestWithStreamProtocol):
         with pytest.raises(TypeError, match=r"^Expected a StreamProtocol or a BufferedStreamProtocol object, got .*$"):
             _ = AsyncStreamServer(mock_listener, mock_invalid_protocol, max_recv_size)
 
-    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size=={p}", indirect=True)
+    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size__{p}", indirect=True)
     async def test____dunder_init____max_recv_size____invalid_value(
         self,
         mock_listener: MagicMock,
@@ -329,8 +329,8 @@ class TestAsyncStreamServer(BaseTestWithStreamProtocol):
                 await server.serve(client_connected_cb, tg)
         client_connected_cb.assert_not_called()
 
-    @pytest.mark.parametrize("give_filter", [False, True], ids=lambda p: f"give_filter=={p}")
-    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary=={p}")
+    @pytest.mark.parametrize("give_filter", [False, True], ids=lambda p: f"give_filter__{p}")
+    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary__{p}")
     async def test____serve____disconnect_error_filter____mask_connection_error_on_receive(
         self,
         give_filter: bool,
@@ -384,7 +384,7 @@ class TestAsyncStreamServer(BaseTestWithStreamProtocol):
 
         exception_caught.assert_called_once_with(True if give_filter else False)
 
-    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary=={p}")
+    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary__{p}")
     async def test____serve____disconnect_error_filter____reraise_non_filtered_errors(
         self,
         recv_with_ancillary: bool,
@@ -464,7 +464,7 @@ class TestAsyncStreamServer(BaseTestWithStreamProtocol):
         assert not caplog.records
 
     @pytest.mark.parametrize("invalid_timeout", [-1.0, math.nan])
-    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary=={p}")
+    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary__{p}")
     async def test____serve____invalid_timeout(
         self,
         invalid_timeout: float,
@@ -507,7 +507,7 @@ class TestAsyncStreamServer(BaseTestWithStreamProtocol):
 
         assert not caplog.records
 
-    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary=={p}")
+    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary__{p}")
     async def test____serve____unhandled_exception____from_system(
         self,
         recv_with_ancillary: bool,
@@ -547,7 +547,7 @@ class TestAsyncStreamServer(BaseTestWithStreamProtocol):
         assert isinstance(caplog.records[0].exc_info[1], OSError)
         assert caplog.records[0].getMessage() == "Unhandled exception: recv() error"
 
-    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary=={p}")
+    @pytest.mark.parametrize("recv_with_ancillary", [False, True], ids=lambda p: f"recv_with_ancillary__{p}")
     async def test____serve____unhandled_exception____from_request_handler(
         self,
         recv_with_ancillary: bool,

--- a/tests/unit_test/test_async/test_lowlevel_api/test_transports/test_tls.py
+++ b/tests/unit_test/test_async/test_lowlevel_api/test_transports/test_tls.py
@@ -153,12 +153,12 @@ class TestAsyncTLSStreamTransport:
         assert tls_transport.extra(TLSAttribute.tls_version) is mocker.sentinel.tls_version
         assert tls_transport.extra(TLSAttribute.standard_compatible) is True
 
-    @pytest.mark.parametrize("server_hostname", [None, "server_hostname"], ids=lambda p: f"server_hostname=={p}")
-    @pytest.mark.parametrize("server_side", [True, False], ids=lambda p: f"server_side=={p}")
-    @pytest.mark.parametrize("session", [None, "session"], ids=lambda p: f"session=={p}")
-    @pytest.mark.parametrize("standard_compatible", [True, False], ids=lambda p: f"standard_compatible=={p}")
-    @pytest.mark.parametrize("handshake_timeout", [123465789], ids=lambda p: f"handshake_timeout=={p}")
-    @pytest.mark.parametrize("shutdown_timeout", [987654321], ids=lambda p: f"shutdown_timeout=={p}")
+    @pytest.mark.parametrize("server_hostname", [None, "server_hostname"], ids=lambda p: f"server_hostname__{p}")
+    @pytest.mark.parametrize("server_side", [True, False], ids=lambda p: f"server_side__{p}")
+    @pytest.mark.parametrize("session", [None, "session"], ids=lambda p: f"session__{p}")
+    @pytest.mark.parametrize("standard_compatible", [True, False], ids=lambda p: f"standard_compatible__{p}")
+    @pytest.mark.parametrize("handshake_timeout", [123465789], ids=lambda p: f"handshake_timeout__{p}")
+    @pytest.mark.parametrize("shutdown_timeout", [987654321], ids=lambda p: f"shutdown_timeout__{p}")
     async def test____wrap____with_parameters(
         self,
         async_finalizer: AsyncFinalizer,
@@ -221,8 +221,8 @@ class TestAsyncTLSStreamTransport:
     @pytest.mark.parametrize(
         ["server_hostname", "expected_server_side"],
         [
-            pytest.param(None, True, id="server_hostname==None"),
-            pytest.param("hostname", False, id="server_hostname=='hostname'"),
+            pytest.param(None, True, id="None"),
+            pytest.param("hostname", False, id="hostname"),
         ],
     )
     @pytest.mark.usefixtures("mock_tls_transport_retry")
@@ -326,7 +326,7 @@ class TestAsyncTLSStreamTransport:
 
         mock_wrapped_transport.aclose.assert_not_called()
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     async def test____aclose____close_transport(
         self,
         tls_transport: AsyncTLSStreamTransport,
@@ -354,7 +354,7 @@ class TestAsyncTLSStreamTransport:
             assert not write_bio.eof
         mock_wrapped_transport.aclose.assert_awaited_once_with()
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     async def test____aclose____idempotent(
         self,
         tls_transport: AsyncTLSStreamTransport,
@@ -383,8 +383,8 @@ class TestAsyncTLSStreamTransport:
             assert not write_bio.eof
         mock_wrapped_transport.aclose.assert_awaited_once()
 
-    @pytest.mark.parametrize("standard_compatible", [True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
-    @pytest.mark.parametrize("shutdown_timeout", [1], indirect=True, ids=lambda p: f"shutdown_timeout=={p}")
+    @pytest.mark.parametrize("standard_compatible", [True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
+    @pytest.mark.parametrize("shutdown_timeout", [1], indirect=True, ids=lambda p: f"shutdown_timeout__{p}")
     async def test____aclose____shutdown_timeout(
         self,
         tls_transport: AsyncTLSStreamTransport,
@@ -410,7 +410,7 @@ class TestAsyncTLSStreamTransport:
         assert not write_bio.eof
         mock_wrapped_transport.aclose.assert_awaited_once_with()
 
-    @pytest.mark.parametrize("standard_compatible", [True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     async def test____aclose____mask_unwrap_error(
         self,
         tls_transport: AsyncTLSStreamTransport,
@@ -475,7 +475,7 @@ class TestAsyncTLSStreamTransport:
         mock_tls_transport_retry.assert_awaited_once_with(tls_transport, mock_ssl_object.read, 0)
         mock_ssl_object.read.assert_called_once_with(0)
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     @pytest.mark.usefixtures("mock_tls_transport_retry")
     async def test____recv____SSLZeroReturnError(
         self,
@@ -491,7 +491,7 @@ class TestAsyncTLSStreamTransport:
         # Assert
         assert data == b""
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     @pytest.mark.usefixtures("mock_tls_transport_retry")
     async def test____recv____ragged_eof(
         self,
@@ -510,7 +510,7 @@ class TestAsyncTLSStreamTransport:
             data = await tls_transport.recv(123456)
             assert data == b""
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     @pytest.mark.usefixtures("mock_tls_transport_retry")
     async def test____recv____unrelated_ssl_error(
         self,
@@ -560,7 +560,7 @@ class TestAsyncTLSStreamTransport:
         mock_tls_transport_retry.assert_awaited_once_with(tls_transport, mock_ssl_object.read, 1024, buffer)
         mock_ssl_object.read.assert_called_once_with(1024, buffer)
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     @pytest.mark.usefixtures("mock_tls_transport_retry")
     async def test____recv_into____SSLZeroReturnError(
         self,
@@ -577,7 +577,7 @@ class TestAsyncTLSStreamTransport:
         # Assert
         assert nbytes == 0
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     @pytest.mark.usefixtures("mock_tls_transport_retry")
     async def test____recv_into____ragged_eof(
         self,
@@ -597,7 +597,7 @@ class TestAsyncTLSStreamTransport:
             nbytes = await tls_transport.recv_into(buffer)
             assert nbytes == 0
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     @pytest.mark.usefixtures("mock_tls_transport_retry")
     async def test____recv_into____unrelated_ssl_error(
         self,
@@ -681,7 +681,7 @@ class TestAsyncTLSStreamTransport:
         # Assert
         mock_ssl_object.write.assert_called_once_with(b"")
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     @pytest.mark.usefixtures("mock_tls_transport_retry")
     async def test____send_all____SSLZeroReturnError(
         self,
@@ -695,7 +695,7 @@ class TestAsyncTLSStreamTransport:
         with pytest.raises(ConnectionResetError):
             await tls_transport.send_all(b"decrypted-data")
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     @pytest.mark.usefixtures("mock_tls_transport_retry")
     async def test____send_all____ragged_eof(
         self,
@@ -709,7 +709,7 @@ class TestAsyncTLSStreamTransport:
         with pytest.raises(ssl.SSLEOFError):
             await tls_transport.send_all(b"decrypted-data")
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     @pytest.mark.usefixtures("mock_tls_transport_retry")
     async def test____send_all____unrelated_ssl_error(
         self,
@@ -723,7 +723,7 @@ class TestAsyncTLSStreamTransport:
         with pytest.raises(ssl.SSLError):
             await tls_transport.send_all(b"decrypted-data")
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     async def test____send_all____closed_transport(
         self,
         tls_transport: AsyncTLSStreamTransport,
@@ -784,7 +784,7 @@ class TestAsyncTLSStreamTransport:
             mocker.call(b"data-2"),
         ]
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     async def test____send_all_from_iterable____closed_transport(
         self,
         tls_transport: AsyncTLSStreamTransport,
@@ -826,7 +826,7 @@ class TestAsyncTLSStreamTransport:
         assert not read_bio.eof
         assert not write_bio.eof
 
-    @pytest.mark.parametrize("pending_write", [b"", b"encrypted-data\n"], ids=lambda p: f"pending_write=={p!r}")
+    @pytest.mark.parametrize("pending_write", [b"", b"encrypted-data\n"], ids=lambda p: f"pending_write__{p!r}")
     async def test____retry____default(
         self,
         tls_transport: AsyncTLSStreamTransport,
@@ -883,7 +883,7 @@ class TestAsyncTLSStreamTransport:
         mock_wrapped_transport.send_all.assert_awaited_once_with(b"encrypted-data\n")
         assert result is mocker.sentinel.result
 
-    @pytest.mark.parametrize("pending_write", [b"", b"encrypted-data\n"], ids=lambda p: f"pending_write=={p!r}")
+    @pytest.mark.parametrize("pending_write", [b"", b"encrypted-data\n"], ids=lambda p: f"pending_write__{p!r}")
     async def test____retry____SSLWantReadError(
         self,
         pending_write: bytes,
@@ -1118,7 +1118,7 @@ class TestAsyncTLSListener:
 
         mock_wrapped_listener.aclose.assert_not_called()
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible=={p}")
+    @pytest.mark.parametrize("standard_compatible", [False, True], indirect=True, ids=lambda p: f"standard_compatible__{p}")
     async def test____extra_attributes____default(
         self,
         tls_listener: AsyncTLSListener,
@@ -1137,7 +1137,7 @@ class TestAsyncTLSListener:
         assert tls_listener.extra(TLSAttribute.sslcontext) is mock_ssl_context
         assert tls_listener.extra(TLSAttribute.standard_compatible) is standard_compatible
 
-    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing=={p}")
+    @pytest.mark.parametrize("transport_is_closing", [False, True], ids=lambda p: f"transport_is_closing__{p}")
     async def test____is_closing____returns_wrapped_listener_state(
         self,
         transport_is_closing: bool,
@@ -1176,7 +1176,7 @@ class TestAsyncTLSListener:
         # Act & Assert
         assert tls_listener.backend() is mock_wrapped_listener.backend()
 
-    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group=={p}")
+    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group__{p}")
     async def test____serve____wrap_client_stream(
         self,
         external_group: bool,
@@ -1230,7 +1230,7 @@ class TestAsyncTLSListener:
         "hanshake_error_handler",
         ["default", "custom"],
         indirect=True,
-        ids=lambda p: f"hanshake_error_handler=={p}",
+        ids=lambda p: f"hanshake_error_handler__{p}",
     )
     async def test____serve____handshake_error(
         self,
@@ -1276,7 +1276,7 @@ class TestAsyncTLSListener:
         "hanshake_error_handler",
         ["custom"],
         indirect=True,
-        ids=lambda p: f"hanshake_error_handler=={p}",
+        ids=lambda p: f"hanshake_error_handler__{p}",
     )
     async def test____serve____handshake_error____error_handler_crashed_too(
         self,

--- a/tests/unit_test/test_async/test_trio_backend/test_backend.py
+++ b/tests/unit_test/test_async/test_trio_backend/test_backend.py
@@ -158,9 +158,9 @@ class TestTrioBackend:
         assert resolved_addr is mocker.sentinel.resolved_addr
         mock_trio_getnameinfo.assert_awaited_once_with(mocker.sentinel.sockaddr, mocker.sentinel.flags)
 
-    @pytest.mark.parametrize("happy_eyeballs_delay", [None, 42], ids=lambda p: f"happy_eyeballs_delay=={p}")
-    @pytest.mark.parametrize("local_address", [("local_address", 12345), None], ids=lambda addr: f"local_address=={addr}")
-    @pytest.mark.parametrize("remote_address", [("remote_address", 5000)], ids=lambda addr: f"remote_address=={addr}")
+    @pytest.mark.parametrize("happy_eyeballs_delay", [None, 42], ids=lambda p: f"happy_eyeballs_delay__{p}")
+    @pytest.mark.parametrize("local_address", [("local_address", 12345), None], ids=lambda addr: f"local_address__{addr}")
+    @pytest.mark.parametrize("remote_address", [("remote_address", 5000)], ids=lambda addr: f"remote_address__{addr}")
     async def test____create_tcp_connection____create_trio_stream(
         self,
         happy_eyeballs_delay: float | None,
@@ -229,7 +229,7 @@ class TestTrioBackend:
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -239,7 +239,7 @@ class TestTrioBackend:
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         async def test____create_unix_stream_connection____create_trio_stream(
             self,
@@ -300,7 +300,7 @@ class TestTrioBackend:
                 "\0local_sock",
                 b"\x00local_sock",
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -310,7 +310,7 @@ class TestTrioBackend:
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "bind_error",
@@ -318,7 +318,7 @@ class TestTrioBackend:
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
                 OSError("AF_UNIX path too long."),
             ],
-            ids=lambda exc: f"bind_error=={exc!r}",
+            ids=lambda exc: f"bind_error__{exc!r}",
         )
         async def test____create_unix_stream_connection____bind_error(
             self,
@@ -377,7 +377,7 @@ class TestTrioBackend:
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "connect_error",
@@ -385,7 +385,7 @@ class TestTrioBackend:
                 OSError(errno.ECONNREFUSED, os.strerror(errno.ECONNREFUSED)),
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
             ],
-            ids=lambda exc: f"connect_error=={exc!r}",
+            ids=lambda exc: f"connect_error__{exc!r}",
         )
         async def test____create_unix_stream_connection____connect_error(
             self,
@@ -433,7 +433,7 @@ class TestTrioBackend:
             mock_trio_SocketStream.assert_not_called()
             mock_TrioStreamSocketAdapter.assert_not_called()
 
-    @pytest.mark.parametrize("socket_family_name", ["INET", "UNIX"], ids=lambda p: f"family=={p}")
+    @pytest.mark.parametrize("socket_family_name", ["INET", "UNIX"], ids=lambda p: f"family__{p}")
     async def test____wrap_stream_socket____create_trio_stream(
         self,
         backend: TrioBackend,
@@ -653,9 +653,9 @@ class TestTrioBackend:
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
-        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode=={mode!r}")
+        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode__{mode!r}")
         async def test____create_unix_stream_listener____open_listener_socket(
             self,
             backend: TrioBackend,
@@ -713,7 +713,7 @@ class TestTrioBackend:
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "bind_error",
@@ -721,9 +721,9 @@ class TestTrioBackend:
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
                 OSError("AF_UNIX path too long."),
             ],
-            ids=lambda exc: f"bind_error=={exc!r}",
+            ids=lambda exc: f"bind_error__{exc!r}",
         )
-        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode=={mode!r}")
+        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode__{mode!r}")
         async def test____create_unix_stream_listener____bind_failed(
             self,
             backend: TrioBackend,
@@ -780,7 +780,7 @@ class TestTrioBackend:
                 "/path/to/local.sock",
                 b"/path/to/local.sock",
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         async def test____create_unix_stream_listener____chmod_failed(
             self,
@@ -827,9 +827,9 @@ class TestTrioBackend:
             mock_trio_SocketListener.assert_not_called()
             mock_ListenerSocketAdapter.assert_not_called()
 
-    @pytest.mark.parametrize("socket_family", [None, AF_INET, AF_INET6], ids=lambda p: f"family=={p}")
-    @pytest.mark.parametrize("local_address", [("local_address", 12345), None], ids=lambda addr: f"local_address=={addr}")
-    @pytest.mark.parametrize("remote_address", [("remote_address", 5000)], ids=lambda addr: f"remote_address=={addr}")
+    @pytest.mark.parametrize("socket_family", [None, AF_INET, AF_INET6], ids=lambda p: f"family__{p}")
+    @pytest.mark.parametrize("local_address", [("local_address", 12345), None], ids=lambda addr: f"local_address__{addr}")
+    @pytest.mark.parametrize("remote_address", [("remote_address", 5000)], ids=lambda addr: f"remote_address__{addr}")
     async def test____create_udp_endpoint____create_datagram_socket(
         self,
         local_address: tuple[str, int] | None,
@@ -887,7 +887,7 @@ class TestTrioBackend:
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -897,7 +897,7 @@ class TestTrioBackend:
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         async def test____create_unix_datagram_endpoint____create_datagram_socket(
             self,
@@ -953,7 +953,7 @@ class TestTrioBackend:
                 "\0local_sock",
                 b"\x00local_sock",
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -963,7 +963,7 @@ class TestTrioBackend:
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "bind_error",
@@ -971,7 +971,7 @@ class TestTrioBackend:
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
                 OSError("AF_UNIX path too long."),
             ],
-            ids=lambda exc: f"bind_error=={exc!r}",
+            ids=lambda exc: f"bind_error__{exc!r}",
         )
         async def test____create_unix_datagram_endpoint____bind_error(
             self,
@@ -1025,7 +1025,7 @@ class TestTrioBackend:
                 "\0local_sock",
                 b"\x00local_sock",
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -1035,14 +1035,14 @@ class TestTrioBackend:
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "connect_error",
             [
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
             ],
-            ids=lambda exc: f"connect_error=={exc!r}",
+            ids=lambda exc: f"connect_error__{exc!r}",
         )
         async def test____create_unix_datagram_endpoint____connect_error(
             self,
@@ -1087,7 +1087,7 @@ class TestTrioBackend:
             mock_trio_socket_from_stdlib.assert_not_called()
             mock_TrioDatagramSocketAdapter.assert_not_called()
 
-    @pytest.mark.parametrize("socket_family_name", ["INET", "UNIX"], ids=lambda p: f"family=={p}")
+    @pytest.mark.parametrize("socket_family_name", ["INET", "UNIX"], ids=lambda p: f"family__{p}")
     async def test____wrap_connected_datagram_socket____create_datagram_socket(
         self,
         backend: TrioBackend,
@@ -1280,9 +1280,9 @@ class TestTrioBackend:
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
-        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode=={mode!r}")
+        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode__{mode!r}")
         async def test____create_unix_datagram_listener____open_listener_socket(
             self,
             backend: TrioBackend,
@@ -1334,7 +1334,7 @@ class TestTrioBackend:
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "bind_error",
@@ -1342,9 +1342,9 @@ class TestTrioBackend:
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
                 OSError("AF_UNIX path too long."),
             ],
-            ids=lambda exc: f"bind_error=={exc!r}",
+            ids=lambda exc: f"bind_error__{exc!r}",
         )
-        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode=={mode!r}")
+        @pytest.mark.parametrize("mode", [None, 0o640], ids=lambda mode: f"mode__{mode!r}")
         async def test____create_unix_datagram_listener____bind_failed(
             self,
             backend: TrioBackend,
@@ -1395,7 +1395,7 @@ class TestTrioBackend:
                 "/path/to/local.sock",
                 b"/path/to/local.sock",
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         async def test____create_unix_datagram_listener____chmod_failed(
             self,
@@ -1524,7 +1524,7 @@ class TestTrioBackend:
         # Assert
         mock_Condition.assert_not_called()
 
-    @pytest.mark.parametrize("abandon_on_cancel", [False, True], ids=lambda p: f"abandon_on_cancel=={p}")
+    @pytest.mark.parametrize("abandon_on_cancel", [False, True], ids=lambda p: f"abandon_on_cancel__{p}")
     async def test____run_in_thread____use_loop_run_in_executor(
         self,
         abandon_on_cancel: bool,

--- a/tests/unit_test/test_async/test_trio_backend/test_datagram.py
+++ b/tests/unit_test/test_async/test_trio_backend/test_datagram.py
@@ -279,7 +279,7 @@ class TestTrioDatagramSocketAdapter(BaseTestSocketTransport):
 
     @PlatformMarkers.supports_socket_sendmsg
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
-    @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator=={p}")
+    @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator__{p}")
     async def test____send_with_ancillary____correctly_handle_iterables(
         self,
         ancillary_data_is_iterator: bool,
@@ -489,7 +489,7 @@ class TestTrioDatagramListenerSocketAdapter(BaseTestSocketTransport):
         mock_trio_lowlevel_notify_closing.assert_called_once_with(mock_datagram_listener_socket)
         mock_datagram_listener_socket.close.assert_called_once_with()
 
-    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group=={p}")
+    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group__{p}")
     @pytest.mark.parametrize(
         ["socket_family_name", "sender_address_1", "sender_address_2", "sender_address_3"],
         [
@@ -572,7 +572,7 @@ class TestTrioDatagramListenerSocketAdapter(BaseTestSocketTransport):
         handler.assert_not_awaited()
 
     @PlatformMarkers.supports_socket_recvmsg
-    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group=={p}")
+    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group__{p}")
     @pytest.mark.parametrize(
         ["socket_family_name", "sender_address_1", "sender_address_2", "sender_address_3"],
         [
@@ -678,7 +678,7 @@ class TestTrioDatagramListenerSocketAdapter(BaseTestSocketTransport):
 
         handler.assert_not_awaited()
 
-    @pytest.mark.parametrize("block_count", [2, 1, 0], ids=lambda count: f"block_count=={count}")
+    @pytest.mark.parametrize("block_count", [2, 1, 0], ids=lambda count: f"block_count__{count}")
     @pytest.mark.parametrize(
         ["socket_family_name", "destination_address"],
         [
@@ -745,7 +745,7 @@ class TestTrioDatagramListenerSocketAdapter(BaseTestSocketTransport):
         with pytest.raises(OSError, check=lambda exc: exc.errno == errno.EBADF):
             await listener.send_to(b"data to send", destination_address)
 
-    @pytest.mark.parametrize("block_count", [2, 1, 0], ids=lambda count: f"block_count=={count}")
+    @pytest.mark.parametrize("block_count", [2, 1, 0], ids=lambda count: f"block_count__{count}")
     @pytest.mark.parametrize(
         ["socket_family_name", "destination_address"],
         [
@@ -846,7 +846,7 @@ class TestTrioDatagramListenerSocketAdapter(BaseTestSocketTransport):
         ],
         indirect=["socket_family_name"],
     )
-    @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator=={p}")
+    @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator__{p}")
     async def test____send_with_ancillary____correctly_handle_iterables(
         self,
         ancillary_data_is_iterator: bool,

--- a/tests/unit_test/test_async/test_trio_backend/test_stream.py
+++ b/tests/unit_test/test_async/test_trio_backend/test_stream.py
@@ -534,7 +534,7 @@ class TestTrioStreamSocketAdapter(BaseTestTrioSocketStream, MixinTestSocketSendM
     @PlatformMarkers.supports_socket_sendmsg
     @pytest.mark.usefixtures("SC_IOV_MAX")
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
-    @pytest.mark.parametrize("SC_IOV_MAX", [2], ids=lambda p: f"SC_IOV_MAX=={p}", indirect=True)
+    @pytest.mark.parametrize("SC_IOV_MAX", [2], ids=lambda p: f"SC_IOV_MAX__{p}", indirect=True)
     async def test____send_all_with_ancillary____message_too_long____nb_buffers_greather_than_SC_IOV_MAX(
         self,
         transport: TrioStreamSocketAdapter,
@@ -576,8 +576,8 @@ class TestTrioStreamSocketAdapter(BaseTestTrioSocketStream, MixinTestSocketSendM
 
     @PlatformMarkers.supports_socket_sendmsg
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
-    @pytest.mark.parametrize("data_is_iterator", [False, True], ids=lambda p: f"data_is_iterator=={p}")
-    @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator=={p}")
+    @pytest.mark.parametrize("data_is_iterator", [False, True], ids=lambda p: f"data_is_iterator__{p}")
+    @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator__{p}")
     async def test____send_all_with_ancillary____correctly_handle_iterables(
         self,
         data_is_iterator: bool,
@@ -642,7 +642,7 @@ class TestTrioStreamSocketAdapter(BaseTestTrioSocketStream, MixinTestSocketSendM
 
     @PlatformMarkers.supports_socket_sendmsg
     @pytest.mark.usefixtures("SC_IOV_MAX")
-    @pytest.mark.parametrize("SC_IOV_MAX", [2], ids=lambda p: f"SC_IOV_MAX=={p}", indirect=True)
+    @pytest.mark.parametrize("SC_IOV_MAX", [2], ids=lambda p: f"SC_IOV_MAX__{p}", indirect=True)
     async def test____send_all_from_iterable____use_socket_sendmsg____nb_buffers_greather_than_SC_IOV_MAX(
         self,
         transport: TrioStreamSocketAdapter,
@@ -998,7 +998,7 @@ class TestTrioListenerSocketAdapter(BaseTestTrioSocketStream):
         assert listener.is_closing()
         mock_trio_socket_listener.aclose.assert_awaited_once_with()
 
-    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group=={p}")
+    @pytest.mark.parametrize("external_group", [True, False], ids=lambda p: f"external_group__{p}")
     async def test____serve____default(
         self,
         trio_backend: TrioBackend,

--- a/tests/unit_test/test_serializers/conftest.py
+++ b/tests/unit_test/test_serializers/conftest.py
@@ -3,6 +3,6 @@ from __future__ import annotations
 import pytest
 
 
-@pytest.fixture(params=[False, True], ids=lambda p: f"debug_mode=={p}")
+@pytest.fixture(params=[False, True], ids=lambda p: f"debug_mode__{p}")
 def debug_mode(request: pytest.FixtureRequest) -> bool:
     return bool(request.param)

--- a/tests/unit_test/test_serializers/test_abc.py
+++ b/tests/unit_test/test_serializers/test_abc.py
@@ -166,7 +166,7 @@ class TestAutoSeparatedPacketSerializer:
     def mock_deserialize_func(mocker: MockerFixture) -> MagicMock:
         return mocker.patch.object(_AutoSeparatedPacketSerializerForTest, "deserialize")
 
-    @pytest.fixture(params=[False, True], ids=lambda p: f"check_separator=={p}")
+    @pytest.fixture(params=[False, True], ids=lambda p: f"check_separator__{p}")
     @staticmethod
     def check_separator(request: pytest.FixtureRequest) -> bool:
         return request.param
@@ -177,7 +177,7 @@ class TestAutoSeparatedPacketSerializer:
         assert request.param in ("data", "buffer")
         return request.param
 
-    @pytest.mark.parametrize("separator", [b"\n", b".", b"\r\n", b"--"], ids=lambda p: f"separator=={p}")
+    @pytest.mark.parametrize("separator", [b"\n", b".", b"\r\n", b"--"], ids=lambda p: f"separator__{p}")
     def test____properties____right_values(self, separator: bytes, debug_mode: bool) -> None:
         # Arrange
 
@@ -196,7 +196,7 @@ class TestAutoSeparatedPacketSerializer:
         with pytest.raises(ValueError, match=r"^Empty separator$"):
             _ = _AutoSeparatedPacketSerializerForTest(b"")
 
-    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit__{p}")
     def test____dunder_init____invalid_limit(self, limit: int) -> None:
         # Arrange
 
@@ -462,7 +462,7 @@ class TestAutoSeparatedPacketSerializer:
         assert bytes(exception.remaining_data) == expected_remaining_data
         assert exception.error_info is mocker.sentinel.error_info
 
-    @pytest.mark.parametrize("separator_found", [False, True], ids=lambda p: f"separator_found=={p}")
+    @pytest.mark.parametrize("separator_found", [False, True], ids=lambda p: f"separator_found__{p}")
     def test____incremental_deserialize____reached_limit(
         self,
         separator_found: bool,
@@ -492,7 +492,7 @@ class TestAutoSeparatedPacketSerializer:
         assert bytes(exc_info.value.remaining_data) == b""
         assert exc_info.value.error_info is None
 
-    @pytest.mark.parametrize("separator_found", [False, True], ids=lambda p: f"separator_found=={p}")
+    @pytest.mark.parametrize("separator_found", [False, True], ids=lambda p: f"separator_found__{p}")
     def test____incremental_deserialize____reached_limit____separator_partially_received(
         self,
         separator_found: bool,
@@ -581,7 +581,7 @@ class _FixedSizePacketSerializerForTest(FixedSizePacketSerializer[Any, Any]):
 
 
 class TestFixedSizePacketSerializer:
-    @pytest.fixture(params=[1, 10, 65536], ids=lambda p: f"packet_size=={p}")
+    @pytest.fixture(params=[1, 10, 65536], ids=lambda p: f"packet_size__{p}")
     @staticmethod
     def packet_size(request: Any) -> int:
         return request.param
@@ -921,7 +921,7 @@ class TestFileBasedPacketSerializer:
         assert serializer.debug is debug_mode
         assert serializer.buffer_limit == 123456789
 
-    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit__{p}")
     def test____dunder_init____invalid_limit(self, limit: int) -> None:
         # Arrange
 
@@ -991,7 +991,7 @@ class TestFileBasedPacketSerializer:
         else:
             assert exception.error_info is None
 
-    @pytest.mark.parametrize("give_as_tuple", [False, True], ids=lambda boolean: f"give_as_tuple=={boolean}")
+    @pytest.mark.parametrize("give_as_tuple", [False, True], ids=lambda boolean: f"give_as_tuple__{boolean}")
     def test____deserialize____translate_given_exceptions(
         self,
         give_as_tuple: bool,
@@ -1221,7 +1221,7 @@ class TestFileBasedPacketSerializer:
         assert packet is mocker.sentinel.packet
         assert remaining_data == b""
 
-    @pytest.mark.parametrize("give_as_tuple", [False, True], ids=lambda boolean: f"give_as_tuple=={boolean}")
+    @pytest.mark.parametrize("give_as_tuple", [False, True], ids=lambda boolean: f"give_as_tuple__{boolean}")
     def test____incremental_deserialize____load_from_file____translate_given_exceptions(
         self,
         give_as_tuple: bool,
@@ -1284,7 +1284,7 @@ class TestFileBasedPacketSerializer:
         else:
             assert exception.error_info is None
 
-    @pytest.mark.parametrize("at_first_chunk", [False, True], ids=lambda p: f"at_first_chunk=={p}")
+    @pytest.mark.parametrize("at_first_chunk", [False, True], ids=lambda p: f"at_first_chunk__{p}")
     def test____incremental_deserialize____load_from_file____buffer_limit_overrun(
         self,
         at_first_chunk: bool,

--- a/tests/unit_test/test_serializers/test_cbor.py
+++ b/tests/unit_test/test_serializers/test_cbor.py
@@ -61,7 +61,7 @@ class TestCBORSerializer(BaseSerializerConfigInstanceCheck):
 
         return mocker.NonCallableMagicMock(spec=BytesIO)
 
-    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_encoder_config=={boolean}")
+    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_encoder_config__{boolean}")
     @staticmethod
     def encoder_config(request: Any, mocker: MockerFixture) -> CBOREncoderConfig | None:
         use_default_config: bool = request.param
@@ -78,7 +78,7 @@ class TestCBORSerializer(BaseSerializerConfigInstanceCheck):
             indefinite_containers=mocker.sentinel.indefinite_containers,
         )
 
-    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_decoder_config=={boolean}")
+    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_decoder_config__{boolean}")
     @staticmethod
     def decoder_config(request: Any, mocker: MockerFixture) -> CBORDecoderConfig | None:
         use_default_config: bool = request.param
@@ -113,7 +113,7 @@ class TestCBORSerializer(BaseSerializerConfigInstanceCheck):
         # Act & Assert
         assert getattr(CBORSerializer, method) is getattr(FileBasedPacketSerializer, method)
 
-    @pytest.mark.parametrize("limit", [147258369, None], ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("limit", [147258369, None], ids=lambda p: f"limit__{p}")
     def test____properties____right_values(self, debug_mode: bool, limit: int | None) -> None:
         # Arrange
 
@@ -130,7 +130,7 @@ class TestCBORSerializer(BaseSerializerConfigInstanceCheck):
         else:
             assert serializer.buffer_limit == limit
 
-    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit__{p}")
     def test____dunder_init____invalid_limit(self, limit: int) -> None:
         # Arrange
 

--- a/tests/unit_test/test_serializers/test_compressor.py
+++ b/tests/unit_test/test_serializers/test_compressor.py
@@ -171,7 +171,7 @@ class TestAbstractCompressorSerializer:
         mock_serializer.deserialize.assert_called_once_with(mocker.sentinel.decompressed_data)
         assert packet is mocker.sentinel.packet
 
-    @pytest.mark.parametrize("give_as_tuple", [False, True], ids=lambda boolean: f"give_as_tuple=={boolean}")
+    @pytest.mark.parametrize("give_as_tuple", [False, True], ids=lambda boolean: f"give_as_tuple__{boolean}")
     def test____deserialize____translates_given_exceptions(
         self,
         give_as_tuple: bool,
@@ -339,7 +339,7 @@ class TestAbstractCompressorSerializer:
         assert packet is mocker.sentinel.packet
         assert remaining_data == b"some extra data"
 
-    @pytest.mark.parametrize("give_as_tuple", [False, True], ids=lambda boolean: f"give_as_tuple=={boolean}")
+    @pytest.mark.parametrize("give_as_tuple", [False, True], ids=lambda boolean: f"give_as_tuple__{boolean}")
     def test____incremental_deserialize____translate_given_exceptions(
         self,
         give_as_tuple: bool,

--- a/tests/unit_test/test_serializers/test_json.py
+++ b/tests/unit_test/test_serializers/test_json.py
@@ -58,7 +58,7 @@ class TestJSONSerializer(BaseSerializerConfigInstanceCheck):
     def mock_decoder_cls(mocker: MockerFixture, mock_decoder: MagicMock) -> MagicMock:
         return mocker.patch("json.JSONDecoder", return_value=mock_decoder)
 
-    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_encoder_config=={boolean}")
+    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_encoder_config__{boolean}")
     @staticmethod
     def encoder_config(request: Any, mocker: MockerFixture) -> JSONEncoderConfig | None:
         use_default_config: bool = request.param
@@ -72,7 +72,7 @@ class TestJSONSerializer(BaseSerializerConfigInstanceCheck):
             default=mocker.sentinel.object_default,
         )
 
-    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_decoder_config=={boolean}")
+    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_decoder_config__{boolean}")
     @staticmethod
     def decoder_config(request: Any, mocker: MockerFixture) -> JSONDecoderConfig | None:
         use_default_config: bool = request.param
@@ -87,7 +87,7 @@ class TestJSONSerializer(BaseSerializerConfigInstanceCheck):
             strict=mocker.sentinel.strict,
         )
 
-    @pytest.fixture(params=[True, False], ids=lambda boolean: f"use_lines=={boolean}")
+    @pytest.fixture(params=[True, False], ids=lambda boolean: f"use_lines__{boolean}")
     @staticmethod
     def use_lines(request: pytest.FixtureRequest) -> bool:
         return request.param
@@ -171,7 +171,7 @@ class TestJSONSerializer(BaseSerializerConfigInstanceCheck):
             strict=mocker.sentinel.strict if decoder_config is not None else True,
         )
 
-    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit__{p}")
     def test____dunder_init____invalid_limit(self, limit: int) -> None:
         # Arrange
 
@@ -517,7 +517,7 @@ class TestJSONSerializer(BaseSerializerConfigInstanceCheck):
 
 class TestJSONParser:
     @staticmethod
-    @pytest.fixture(params=[False, True], ids=lambda p: f"buffered=={p}")
+    @pytest.fixture(params=[False, True], ids=lambda p: f"buffered__{p}")
     def buffered(request: pytest.FixtureRequest) -> bool:
         return request.param
 
@@ -835,7 +835,7 @@ class TestJSONParser:
         assert bytes(complete) == b"true"
         assert bytes(remainder) == b"remainder"
 
-    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit__{p}")
     def test____raw_parse____invalid_limit(self, limit: int) -> None:
         # Arrange
         consumer = self.raw_parse(limit=limit, buffered=False)
@@ -861,7 +861,7 @@ class TestJSONParser:
             pytest.param(b"123", b"45\n", id="plain value"),
         ],
     )
-    @pytest.mark.parametrize("add_end_frame", [False, True], ids=lambda p: f"add_end_frame=={p}")
+    @pytest.mark.parametrize("add_end_frame", [False, True], ids=lambda p: f"add_end_frame__{p}")
     def test____raw_parse____reached_limit(
         self,
         start_frame: bytes,

--- a/tests/unit_test/test_serializers/test_line.py
+++ b/tests/unit_test/test_serializers/test_line.py
@@ -34,12 +34,12 @@ class TestStringLineSerializer:
     def unicode_errors(request: pytest.FixtureRequest) -> str:
         return request.param
 
-    @pytest.fixture(params=[False, True], ids=lambda p: f"keep_end=={p}")
+    @pytest.fixture(params=[False, True], ids=lambda p: f"keep_end__{p}")
     @staticmethod
     def keep_end(request: pytest.FixtureRequest) -> bool:
         return bool(request.param)
 
-    @pytest.fixture(params=[DEFAULT_SERIALIZER_LIMIT], ids=lambda p: f"limit=={p}")
+    @pytest.fixture(params=[DEFAULT_SERIALIZER_LIMIT], ids=lambda p: f"limit__{p}")
     @staticmethod
     def buffer_limit(request: pytest.FixtureRequest) -> int:
         return int(request.param)
@@ -85,7 +85,7 @@ class TestStringLineSerializer:
 
     @pytest.mark.parametrize("encoding", ["ascii", "utf-8"], indirect=True)
     @pytest.mark.parametrize("unicode_errors", ["strict", "ignore", "replace"], indirect=True)
-    @pytest.mark.parametrize("keep_end", [False, True], ids=lambda p: f"keep_end=={p}", indirect=True)
+    @pytest.mark.parametrize("keep_end", [False, True], ids=lambda p: f"keep_end__{p}", indirect=True)
     def test____dunder_init____with_parameters(
         self,
         newline: Literal["LF", "CR", "CRLF"],
@@ -123,7 +123,7 @@ class TestStringLineSerializer:
         with pytest.raises(AssertionError):
             StringLineSerializer("something else")  # type: ignore[arg-type]
 
-    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit__{p}")
     def test____dunder_init____invalid_limit(self, limit: int) -> None:
         # Arrange
 
@@ -167,7 +167,7 @@ class TestStringLineSerializer:
         assert isinstance(data, bytes)
         assert data == b""
 
-    @pytest.mark.parametrize("with_newlines", [False, True], ids=lambda boolean: f"with_newlines=={boolean}")
+    @pytest.mark.parametrize("with_newlines", [False, True], ids=lambda boolean: f"with_newlines__{boolean}")
     def test____deserialize____decode_string(
         self,
         with_newlines: bool,
@@ -187,7 +187,7 @@ class TestStringLineSerializer:
         else:
             assert line == "abc"
 
-    @pytest.mark.parametrize("with_newlines", [False, True], ids=lambda boolean: f"with_newlines=={boolean}")
+    @pytest.mark.parametrize("with_newlines", [False, True], ids=lambda boolean: f"with_newlines__{boolean}")
     @pytest.mark.parametrize("encoding", ["ascii", "utf-8"], indirect=True)
     def test____deserialize____decode_string_error(
         self,
@@ -396,9 +396,9 @@ class TestStringLineSerializer:
         else:
             assert exception.error_info is None
 
-    @pytest.mark.parametrize("separator_found", [False, True], ids=lambda p: f"separator_found=={p}")
+    @pytest.mark.parametrize("separator_found", [False, True], ids=lambda p: f"separator_found__{p}")
     @pytest.mark.parametrize("newline", ["CRLF"], indirect=True)
-    @pytest.mark.parametrize("buffer_limit", [1], indirect=True, ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("buffer_limit", [1], indirect=True, ids=lambda p: f"limit__{p}")
     def test____incremental_deserialize____reached_limit(
         self,
         separator_found: bool,
@@ -423,9 +423,9 @@ class TestStringLineSerializer:
         assert bytes(exc_info.value.remaining_data) == b""
         assert exc_info.value.error_info is None
 
-    @pytest.mark.parametrize("separator_found", [False, True], ids=lambda p: f"separator_found=={p}")
+    @pytest.mark.parametrize("separator_found", [False, True], ids=lambda p: f"separator_found__{p}")
     @pytest.mark.parametrize("newline", ["CRLF"], indirect=True)
-    @pytest.mark.parametrize("buffer_limit", [1], indirect=True, ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("buffer_limit", [1], indirect=True, ids=lambda p: f"limit__{p}")
     def test____incremental_deserialize____reached_limit____separator_partially_received(
         self,
         separator_found: bool,
@@ -452,7 +452,7 @@ class TestStringLineSerializer:
         assert exc_info.value.error_info is None
 
     @pytest.mark.parametrize("newline", ["CRLF"], indirect=True)
-    @pytest.mark.parametrize("buffer_limit", [1024], indirect=True, ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("buffer_limit", [1024], indirect=True, ids=lambda p: f"limit__{p}")
     def test____buffered_incremental_deserialize____reached_limit(
         self,
         serializer: StringLineSerializer,
@@ -473,7 +473,7 @@ class TestStringLineSerializer:
         assert exc_info.value.error_info is None
 
     @pytest.mark.parametrize("newline", ["CRLF"], indirect=True)
-    @pytest.mark.parametrize("buffer_limit", [1024], indirect=True, ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("buffer_limit", [1024], indirect=True, ids=lambda p: f"limit__{p}")
     def test____buffered_incremental_deserialize____reached_limit____separator_partially_received(
         self,
         serializer: StringLineSerializer,

--- a/tests/unit_test/test_serializers/test_msgpack.py
+++ b/tests/unit_test/test_serializers/test_msgpack.py
@@ -66,7 +66,7 @@ class TestMessagePackSerializer(BaseSerializerConfigInstanceCheck):
     def mock_unpacker_cls(mock_unpacker: MagicMock, mocker: MockerFixture) -> MagicMock:
         return mocker.patch("msgpack.Unpacker", return_value=mock_unpacker)
 
-    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_packer_config=={boolean}")
+    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_packer_config__{boolean}")
     @staticmethod
     def packer_config(request: Any, mocker: MockerFixture) -> MessagePackerConfig | None:
         use_default_config: bool = request.param
@@ -81,7 +81,7 @@ class TestMessagePackSerializer(BaseSerializerConfigInstanceCheck):
             unicode_errors=mocker.sentinel.unicode_errors,
         )
 
-    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_unpacker_config=={boolean}")
+    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_unpacker_config__{boolean}")
     @staticmethod
     def unpacker_config(request: Any, mocker: MockerFixture) -> MessageUnpackerConfig | None:
         use_default_config: bool = request.param
@@ -114,7 +114,7 @@ class TestMessagePackSerializer(BaseSerializerConfigInstanceCheck):
         # Act & Assert
         assert getattr(MessagePackSerializer, method) is getattr(FileBasedPacketSerializer, method)
 
-    @pytest.mark.parametrize("limit", [147258369, None], ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("limit", [147258369, None], ids=lambda p: f"limit__{p}")
     def test____properties____right_values(self, debug_mode: bool, limit: int | None) -> None:
         # Arrange
 
@@ -286,7 +286,7 @@ class TestMessagePackSerializer(BaseSerializerConfigInstanceCheck):
         mock_packer.pack.assert_called_once_with(mocker.sentinel.packet)
         mock_packb.assert_not_called()
 
-    @pytest.mark.parametrize("limit", [147258369, DEFAULT_SERIALIZER_LIMIT], ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("limit", [147258369, DEFAULT_SERIALIZER_LIMIT], ids=lambda p: f"limit__{p}")
     def test____load_from_file____with_config(
         self,
         limit: int,

--- a/tests/unit_test/test_serializers/test_pickle.py
+++ b/tests/unit_test/test_serializers/test_pickle.py
@@ -78,7 +78,7 @@ class TestPickleSerializer(BaseSerializerConfigInstanceCheck):
     def mock_unpickler_cls(mocker: MockerFixture, mock_unpickler: MagicMock) -> MagicMock:
         return mocker.patch("pickle.Unpickler", return_value=mock_unpickler)
 
-    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_pickler_config=={boolean}")
+    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_pickler_config__{boolean}")
     @staticmethod
     def pickler_config(request: Any, mocker: MockerFixture) -> PicklerConfig | None:
         use_default_config: bool = request.param
@@ -89,7 +89,7 @@ class TestPickleSerializer(BaseSerializerConfigInstanceCheck):
             fix_imports=mocker.sentinel.fix_imports,
         )
 
-    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_unpickler_config=={boolean}")
+    @pytest.fixture(params=[True, False], ids=lambda boolean: f"default_unpickler_config__{boolean}")
     @staticmethod
     def unpickler_config(request: Any, mocker: MockerFixture) -> UnpicklerConfig | None:
         use_default_config: bool = request.param
@@ -101,7 +101,7 @@ class TestPickleSerializer(BaseSerializerConfigInstanceCheck):
             errors=mocker.sentinel.errors,
         )
 
-    @pytest.fixture(params=[False, True], ids=lambda boolean: f"optimize=={boolean}")
+    @pytest.fixture(params=[False, True], ids=lambda boolean: f"optimize__{boolean}")
     @staticmethod
     def pickler_optimize(request: Any) -> bool:
         return request.param

--- a/tests/unit_test/test_serializers/test_struct.py
+++ b/tests/unit_test/test_serializers/test_struct.py
@@ -445,12 +445,12 @@ class TestNamedTupleStructSerializer(BaseTestStructBasedSerializer):
     @pytest.mark.parametrize(
         "strip_string_trailing_nul_bytes",
         [True, False],
-        ids=lambda boolean: f"strip_string_trailing_nul_bytes=={boolean}",
+        ids=lambda boolean: f"strip_string_trailing_nul_bytes__{boolean}",
     )
     @pytest.mark.parametrize(
         "encoding",
         [None, "utf-8"],
-        ids=lambda value: f"encoding=={value}",
+        ids=lambda value: f"encoding__{value}",
     )
     def test____from_tuple____construct_namedtuple____string_padding(
         self,

--- a/tests/unit_test/test_serializers/test_tools.py
+++ b/tests/unit_test/test_serializers/test_tools.py
@@ -69,7 +69,7 @@ class TestGeneratorStreamReader:
         # Assert
         assert data is value
 
-    @pytest.mark.parametrize("initial", [False, True], ids=lambda p: f"initial=={p}")
+    @pytest.mark.parametrize("initial", [False, True], ids=lambda p: f"initial__{p}")
     def test____read____shrink_too_big_buffer(self, initial: bool) -> None:
         # Arrange
         value = b"data"
@@ -122,7 +122,7 @@ class TestGeneratorStreamReader:
         # Assert
         assert data == b"data"
 
-    @pytest.mark.parametrize("initial", [False, True], ids=lambda p: f"initial=={p}")
+    @pytest.mark.parametrize("initial", [False, True], ids=lambda p: f"initial__{p}")
     def test____read_exactly____size_already_fit(self, initial: bool) -> None:
         # Arrange
         value = b"data"
@@ -139,7 +139,7 @@ class TestGeneratorStreamReader:
         # Assert
         assert data is value
 
-    @pytest.mark.parametrize("initial", [False, True], ids=lambda p: f"initial=={p}")
+    @pytest.mark.parametrize("initial", [False, True], ids=lambda p: f"initial__{p}")
     def test____read_exactly____shrink_too_big_buffer(self, initial: bool) -> None:
         # Arrange
         prefix = b"dat"
@@ -184,7 +184,7 @@ class TestGeneratorStreamReader:
             pytest.param(b"remaining\r\nother", id="with remaining data including separator"),
         ],
     )
-    @pytest.mark.parametrize("keep_end", [False, True], ids=lambda p: f"keep_end=={p}")
+    @pytest.mark.parametrize("keep_end", [False, True], ids=lambda p: f"keep_end__{p}")
     def test____read_until____one_shot_chunk(self, expected_remaining_data: bytes, keep_end: bool) -> None:
         # Arrange
         reader = GeneratorStreamReader()
@@ -210,7 +210,7 @@ class TestGeneratorStreamReader:
             pytest.param(b"remaining\r\nother", id="with remaining data including separator"),
         ],
     )
-    @pytest.mark.parametrize("keep_end", [False, True], ids=lambda p: f"keep_end=={p}")
+    @pytest.mark.parametrize("keep_end", [False, True], ids=lambda p: f"keep_end__{p}")
     def test____read_until____several_chunks(self, expected_remaining_data: bytes, keep_end: bool) -> None:
         # Arrange
         reader = GeneratorStreamReader(b"d")
@@ -228,7 +228,7 @@ class TestGeneratorStreamReader:
             assert data == b"data"
         assert reader.read_all() == expected_remaining_data
 
-    @pytest.mark.parametrize("separator_found", [False, True], ids=lambda p: f"separator_found=={p}")
+    @pytest.mark.parametrize("separator_found", [False, True], ids=lambda p: f"separator_found__{p}")
     def test____read_until____reached_limit(self, separator_found: bytes) -> None:
         # Arrange
         reader = GeneratorStreamReader()
@@ -259,7 +259,7 @@ class TestGeneratorStreamReader:
         with pytest.raises(ValueError, match=r"^Empty separator$"):
             next_return(consumer)
 
-    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit=={p}")
+    @pytest.mark.parametrize("limit", [0, -42], ids=lambda p: f"limit__{p}")
     def test____read_until____invalid_limit(self, limit: int) -> None:
         # Arrange
         reader = GeneratorStreamReader()

--- a/tests/unit_test/test_sync/test_api/test_client/base.py
+++ b/tests/unit_test/test_sync/test_api/test_client/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterator
+from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
 from easynetwork.lowlevel._utils import validate_timeout_delay
@@ -17,7 +17,7 @@ class BaseTestClient(BaseTestSocket):
 
 
 @contextlib.contextmanager
-def dummy_lock_with_timeout(lock: Lock, timeout: float | None, *args: Any, **kwargs: Any) -> Iterator[float | None]:
+def dummy_lock_with_timeout(lock: Lock, timeout: float | None, *args: Any, **kwargs: Any) -> Generator[float | None]:
     with contextlib.ExitStack() as stack:
         if timeout is None:
             stack.enter_context(lock)

--- a/tests/unit_test/test_sync/test_api/test_client/test_tcp.py
+++ b/tests/unit_test/test_sync/test_api/test_client/test_tcp.py
@@ -261,8 +261,8 @@ class TestTCPNetworkClient(BaseTestClient):
     def send_timeout(request: pytest.FixtureRequest) -> float:
         return request.param
 
-    @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size=={p}")
-    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval=={p}")
+    @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size__{p}")
+    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval__{p}")
     def test____dunder_init____connect_to_remote(
         self,
         request: pytest.FixtureRequest,
@@ -319,8 +319,8 @@ class TestTCPNetworkClient(BaseTestClient):
         assert mock_ssl_socket.mock_calls == []
         assert isinstance(client.socket, SocketProxy)
 
-    @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size=={p}")
-    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval=={p}")
+    @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size__{p}")
+    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval__{p}")
     def test____dunder_init____use_given_socket(
         self,
         request: pytest.FixtureRequest,
@@ -475,7 +475,7 @@ class TestTCPNetworkClient(BaseTestClient):
 
         assert mock_tcp_socket.mock_calls == []
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     def test____dunder_init____protocol____invalid_value(
         self,
         use_socket: bool,
@@ -498,8 +498,8 @@ class TestTCPNetworkClient(BaseTestClient):
                     protocol=mock_datagram_protocol,
                 )
 
-    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size=={p}")
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size__{p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     def test____dunder_init____max_recv_size____invalid_value(
         self,
         max_recv_size: Any,
@@ -529,7 +529,7 @@ class TestTCPNetworkClient(BaseTestClient):
         mock_socket_stream_transport_cls.assert_not_called()
         mock_stream_endpoint_cls.assert_not_called()
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     def test____dunder_init____unexpected_error(
         self,
         use_socket: bool,
@@ -550,9 +550,9 @@ class TestTCPNetworkClient(BaseTestClient):
                 _ = TCPNetworkClient(remote_address, protocol=mock_stream_protocol)
         mock_socket_stream_transport.close.assert_called_once()
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
-    @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size=={p}")
-    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
+    @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size__{p}")
+    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval__{p}")
     def test____dunder_init____ssl(
         self,
         request: pytest.FixtureRequest,
@@ -648,9 +648,9 @@ class TestTCPNetworkClient(BaseTestClient):
         )
         assert isinstance(client.socket, SocketProxy)
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
-    @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size=={p}")
-    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
+    @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size__{p}")
+    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval__{p}")
     def test____dunder_init____ssl____default_values(
         self,
         request: pytest.FixtureRequest,
@@ -703,7 +703,7 @@ class TestTCPNetworkClient(BaseTestClient):
             standard_compatible=True,
         )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     @pytest.mark.parametrize(
         "ssl_parameter",
         [
@@ -776,7 +776,7 @@ class TestTCPNetworkClient(BaseTestClient):
             standard_compatible=True,
         )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     def test____dunder_init____ssl____server_hostname____do_not_disable_hostname_check_for_external_context(
         self,
         request: pytest.FixtureRequest,
@@ -822,7 +822,7 @@ class TestTCPNetworkClient(BaseTestClient):
             standard_compatible=True,
         )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     def test____dunder_init____ssl____server_hostname____no_host_to_use(
         self,
         use_socket: bool,
@@ -851,8 +851,8 @@ class TestTCPNetworkClient(BaseTestClient):
                     server_hostname=None,
                 )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
-    @pytest.mark.parametrize("OP_IGNORE_UNEXPECTED_EOF", [False, True], ids=lambda p: f"OP_IGNORE_UNEXPECTED_EOF=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
+    @pytest.mark.parametrize("OP_IGNORE_UNEXPECTED_EOF", [False, True], ids=lambda p: f"OP_IGNORE_UNEXPECTED_EOF__{p}")
     def test____dunder_init____ssl____create_default_context(
         self,
         request: pytest.FixtureRequest,
@@ -904,7 +904,7 @@ class TestTCPNetworkClient(BaseTestClient):
             standard_compatible=True,
         )
 
-    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+    @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
     def test____dunder_init____ssl____create_default_context____disable_hostname_check(
         self,
         request: pytest.FixtureRequest,

--- a/tests/unit_test/test_sync/test_api/test_client/test_udp.py
+++ b/tests/unit_test/test_sync/test_api/test_client/test_udp.py
@@ -174,7 +174,7 @@ class TestUDPNetworkClient(BaseTestClient):
     def send_timeout(request: pytest.FixtureRequest) -> Any:
         return request.param
 
-    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval=={p}")
+    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval__{p}")
     def test____dunder_init____with_remote_address(
         self,
         request: pytest.FixtureRequest,
@@ -209,9 +209,9 @@ class TestUDPNetworkClient(BaseTestClient):
         ]
 
     @pytest.mark.parametrize(
-        "local_address", [None, ("local_address", 12345)], ids=lambda p: f"local_address=={p}", indirect=True
+        "local_address", [None, ("local_address", 12345)], ids=lambda p: f"local_address__{p}", indirect=True
     )
-    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval=={p}")
+    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval__{p}")
     def test____dunder_init____with_remote_address____with_parameters(
         self,
         request: pytest.FixtureRequest,
@@ -259,7 +259,7 @@ class TestUDPNetworkClient(BaseTestClient):
         assert isinstance(client.socket, SocketProxy)
 
     @pytest.mark.parametrize(
-        "local_address", [None, ("local_address", 12345)], ids=lambda p: f"local_address=={p}", indirect=True
+        "local_address", [None, ("local_address", 12345)], ids=lambda p: f"local_address__{p}", indirect=True
     )
     def test____dunder_init____with_remote_address____with_parameters____explicit_AF_UNSPEC(
         self,
@@ -306,7 +306,7 @@ class TestUDPNetworkClient(BaseTestClient):
             )
         mock_create_udp_socket.assert_not_called()
 
-    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval=={p}")
+    @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval__{p}")
     def test____dunder_init____use_given_socket____default(
         self,
         request: pytest.FixtureRequest,
@@ -830,7 +830,7 @@ class TestUDPSocketFactory:
         mock_socket_ipv4.setsockopt.assert_not_called()
         mock_socket_ipv4.close.assert_not_called()
 
-    @pytest.mark.parametrize("with_local_address", [False, True], ids=lambda boolean: f"with_local_address=={boolean}")
+    @pytest.mark.parametrize("with_local_address", [False, True], ids=lambda boolean: f"with_local_address__{boolean}")
     @pytest.mark.parametrize(
         ["family", "socket_families"],
         [
@@ -892,7 +892,7 @@ class TestUDPSocketFactory:
         not_used_socket.bind.assert_not_called()
         not_used_socket.connect.assert_not_called()
 
-    @pytest.mark.parametrize("fail_on", ["socket", "bind", "connect"], ids=lambda fail_on: f"fail_on=={fail_on}")
+    @pytest.mark.parametrize("fail_on", ["socket", "bind", "connect"], ids=lambda fail_on: f"fail_on__{fail_on}")
     def test____create_udp_socket____first_failed(
         self,
         fail_on: Literal["socket", "bind", "connect"],
@@ -945,7 +945,7 @@ class TestUDPSocketFactory:
         mock_socket_ipv6.connect.assert_called_once_with(("::1", 12345, 0, 0))
         mock_socket_ipv6.close.assert_not_called()
 
-    @pytest.mark.parametrize("fail_on", ["socket", "bind", "connect"], ids=lambda fail_on: f"fail_on=={fail_on}")
+    @pytest.mark.parametrize("fail_on", ["socket", "bind", "connect"], ids=lambda fail_on: f"fail_on__{fail_on}")
     def test____create_udp_socket____all_failed(
         self,
         fail_on: Literal["socket", "bind", "connect"],
@@ -1004,7 +1004,7 @@ class TestUDPSocketFactory:
             mock_socket_ipv6.connect.assert_not_called()
             mock_socket_ipv6.close.assert_not_called()
 
-    @pytest.mark.parametrize("fail_on", ["socket", "bind"], ids=lambda fail_on: f"fail_on=={fail_on}")
+    @pytest.mark.parametrize("fail_on", ["socket", "bind"], ids=lambda fail_on: f"fail_on__{fail_on}")
     def test____create_udp_socket____unrelated_exception(
         self,
         fail_on: Literal["socket", "bind"],

--- a/tests/unit_test/test_sync/test_api/test_client/test_unix_datagram.py
+++ b/tests/unit_test/test_sync/test_api/test_client/test_unix_datagram.py
@@ -228,7 +228,7 @@ if sys.platform != "win32":
                 case _:
                     pytest.fail(f"Invalid ancillary_data param: {request.param}")
 
-        @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval=={p}")
+        @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval__{p}")
         def test____dunder_init____with_remote_address(
             self,
             request: pytest.FixtureRequest,
@@ -413,7 +413,7 @@ if sys.platform != "win32":
                 )
             mock_create_unix_datagram_socket.assert_not_called()
 
-        @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval=={p}")
+        @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval__{p}")
         def test____dunder_init____use_given_socket____default(
             self,
             request: pytest.FixtureRequest,
@@ -986,7 +986,7 @@ if sys.platform != "win32":
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -996,7 +996,7 @@ if sys.platform != "win32":
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         def test____create_unix_datagram_socket____default(
             self,
@@ -1037,7 +1037,7 @@ if sys.platform != "win32":
                 "\0local_sock",
                 b"\x00local_sock",
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -1047,7 +1047,7 @@ if sys.platform != "win32":
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "bind_error",
@@ -1055,7 +1055,7 @@ if sys.platform != "win32":
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
                 OSError("AF_UNIX path too long."),
             ],
-            ids=lambda exc: f"bind_error=={exc!r}",
+            ids=lambda exc: f"bind_error__{exc!r}",
         )
         def test____create_unix_datagram_socket____bind_error(
             self,
@@ -1092,7 +1092,7 @@ if sys.platform != "win32":
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "connect_error",
@@ -1100,7 +1100,7 @@ if sys.platform != "win32":
                 OSError(errno.ECONNREFUSED, os.strerror(errno.ECONNREFUSED)),
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
             ],
-            ids=lambda exc: f"connect_error=={exc!r}",
+            ids=lambda exc: f"connect_error__{exc!r}",
         )
         def test____create_unix_datagram_socket____connect_error(
             self,

--- a/tests/unit_test/test_sync/test_api/test_client/test_unix_stream.py
+++ b/tests/unit_test/test_sync/test_api/test_client/test_unix_stream.py
@@ -228,8 +228,8 @@ if sys.platform != "win32":
                 case _:
                     pytest.fail(f"Invalid ancillary_data param: {request.param}")
 
-        @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size=={p}")
-        @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval=={p}")
+        @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size__{p}")
+        @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval__{p}")
         def test____dunder_init____connect_to_remote(
             self,
             request: pytest.FixtureRequest,
@@ -366,8 +366,8 @@ if sys.platform != "win32":
             # Assert
             mock_socket_create_connection.assert_called_once_with(remote_address, local_path="")
 
-        @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size=={p}")
-        @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval=={p}")
+        @pytest.mark.parametrize("max_recv_size", [None, 123456789], ids=lambda p: f"max_recv_size__{p}")
+        @pytest.mark.parametrize("retry_interval", [1.0, float("+inf")], ids=lambda p: f"retry_interval__{p}")
         def test____dunder_init____use_given_socket(
             self,
             request: pytest.FixtureRequest,
@@ -479,7 +479,7 @@ if sys.platform != "win32":
 
             assert mock_unix_stream_socket.mock_calls == []
 
-        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
         def test____dunder_init____protocol____invalid_value(
             self,
             use_socket: bool,
@@ -502,8 +502,8 @@ if sys.platform != "win32":
                         protocol=mock_datagram_protocol,
                     )
 
-        @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size=={p}")
-        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+        @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size__{p}")
+        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
         def test____dunder_init____max_recv_size____invalid_value(
             self,
             max_recv_size: Any,
@@ -533,7 +533,7 @@ if sys.platform != "win32":
             mock_socket_stream_transport_cls.assert_not_called()
             mock_stream_endpoint_cls.assert_not_called()
 
-        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket=={p}")
+        @pytest.mark.parametrize("use_socket", [False, True], ids=lambda p: f"use_socket__{p}")
         def test____dunder_init____unexpected_error(
             self,
             use_socket: bool,
@@ -1120,7 +1120,7 @@ if sys.platform != "win32":
                 "",  # <- Arbitrary abstract Unix address given by kernel
                 b"",  # <- Arbitrary abstract Unix address given by kernel
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -1130,9 +1130,9 @@ if sys.platform != "win32":
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
-        @pytest.mark.parametrize("connect_timeout", [None, 10.4], ids=lambda p: f"connect_timeout=={p}")
+        @pytest.mark.parametrize("connect_timeout", [None, 10.4], ids=lambda p: f"connect_timeout__{p}")
         def test____create_unix_stream_connection____default(
             self,
             local_address: str | bytes | None,
@@ -1176,7 +1176,7 @@ if sys.platform != "win32":
                 "\0local_sock",
                 b"\x00local_sock",
             ],
-            ids=lambda addr: f"local_address=={addr!r}",
+            ids=lambda addr: f"local_address__{addr!r}",
         )
         @pytest.mark.parametrize(
             "remote_address",
@@ -1186,16 +1186,16 @@ if sys.platform != "win32":
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
-        @pytest.mark.parametrize("connect_timeout", [None, 10.4], ids=lambda p: f"connect_timeout=={p}")
+        @pytest.mark.parametrize("connect_timeout", [None, 10.4], ids=lambda p: f"connect_timeout__{p}")
         @pytest.mark.parametrize(
             "bind_error",
             [
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
                 OSError("AF_UNIX path too long."),
             ],
-            ids=lambda exc: f"bind_error=={exc!r}",
+            ids=lambda exc: f"bind_error__{exc!r}",
         )
         def test____create_unix_stream_connection____bind_error(
             self,
@@ -1234,16 +1234,16 @@ if sys.platform != "win32":
                 "\0unix_sock",
                 b"\x00unix_sock",
             ],
-            ids=lambda addr: f"remote_address=={addr!r}",
+            ids=lambda addr: f"remote_address__{addr!r}",
         )
-        @pytest.mark.parametrize("connect_timeout", [None, 10.4], ids=lambda p: f"connect_timeout=={p}")
+        @pytest.mark.parametrize("connect_timeout", [None, 10.4], ids=lambda p: f"connect_timeout__{p}")
         @pytest.mark.parametrize(
             "connect_error",
             [
                 OSError(errno.ECONNREFUSED, os.strerror(errno.ECONNREFUSED)),
                 OSError(errno.EPERM, os.strerror(errno.EPERM)),
             ],
-            ids=lambda exc: f"connect_error=={exc!r}",
+            ids=lambda exc: f"connect_error__{exc!r}",
         )
         def test____create_unix_stream_connection____connect_error(
             self,

--- a/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/base.py
+++ b/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/base.py
@@ -418,7 +418,7 @@ class BaseEndpointReceiveTests(BaseEndpointTests):
         # Assert
         assert exc_info.value is expected_error
 
-    @pytest.mark.parametrize("before_transport_reading", [False, True], ids=lambda p: f"before_transport_reading=={p}")
+    @pytest.mark.parametrize("before_transport_reading", [False, True], ids=lambda p: f"before_transport_reading__{p}")
     def test____recv_packet____blocking_or_not____protocol_crashed(
         self,
         before_transport_reading: bool,
@@ -628,7 +628,7 @@ class BaseEndpointReceiveTests(BaseEndpointTests):
         assert exc_info.value is expected_error
         ancillary_data_received.assert_called_once_with(mocker.sentinel.ancdata)
 
-    @pytest.mark.parametrize("before_transport_reading", [False, True], ids=lambda p: f"before_transport_reading=={p}")
+    @pytest.mark.parametrize("before_transport_reading", [False, True], ids=lambda p: f"before_transport_reading__{p}")
     def test____recv_packet_with_ancillary____blocking_or_not____protocol_crashed(
         self,
         before_transport_reading: bool,

--- a/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/test_fullduplex.py
+++ b/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/test_fullduplex.py
@@ -61,7 +61,7 @@ class TestStreamEndpoint(BaseEndpointSendTests, BaseEndpointReceiveTests):
         with pytest.raises(TypeError, match=r"^Expected a StreamProtocol or a BufferedStreamProtocol object, got .*$"):
             _ = StreamEndpoint(mock_stream_transport, mock_invalid_protocol, max_recv_size)
 
-    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size=={p}")
+    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size__{p}")
     def test____dunder_init____max_recv_size____invalid_value(
         self,
         mock_stream_transport: MagicMock,
@@ -93,7 +93,7 @@ class TestStreamEndpoint(BaseEndpointSendTests, BaseEndpointReceiveTests):
 
         mock_stream_transport.close.assert_called()
 
-    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed=={p}")
+    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed__{p}")
     def test____send_eof____default(
         self,
         transport_closed: bool,
@@ -118,7 +118,7 @@ class TestStreamEndpoint(BaseEndpointSendTests, BaseEndpointReceiveTests):
         mock_stream_transport.send_all_from_iterable.assert_not_called()
         mock_stream_transport.send_all_with_ancillary.assert_not_called()
 
-    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed=={p}")
+    @pytest.mark.parametrize("transport_closed", [False, True], ids=lambda p: f"transport_closed__{p}")
     def test____send_eof____idempotent(
         self,
         transport_closed: bool,
@@ -140,7 +140,7 @@ class TestStreamEndpoint(BaseEndpointSendTests, BaseEndpointReceiveTests):
         with pytest.raises(RuntimeError, match=r"^send_eof\(\) has been called earlier$"):
             endpoint.send_packet_with_ancillary(mocker.sentinel.packet, mocker.sentinel.ancdata)
 
-    @pytest.mark.parametrize("with_ancillary", [False, True], ids=lambda p: f"with_ancillary=={p}")
+    @pytest.mark.parametrize("with_ancillary", [False, True], ids=lambda p: f"with_ancillary__{p}")
     def test____special_case____send_packet____eof_error____still_try_socket_send(
         self,
         stream_protocol_mode: Literal["data", "buffer"],

--- a/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/test_readonly.py
+++ b/tests/unit_test/test_sync/test_lowlevel_api/test_endpoints/test_stream/test_readonly.py
@@ -64,7 +64,7 @@ class TestStreamReceiverEndpoint(BaseEndpointReceiveTests):
         with pytest.raises(TypeError, match=r"^Expected a StreamProtocol or a BufferedStreamProtocol object, got .*$"):
             _ = StreamReceiverEndpoint(mock_stream_transport, mock_invalid_protocol, max_recv_size)
 
-    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size=={p}")
+    @pytest.mark.parametrize("max_recv_size", [0, -1, 10.4], ids=lambda p: f"max_recv_size__{p}")
     def test____dunder_init____max_recv_size____invalid_value(
         self,
         mock_stream_transport: MagicMock,

--- a/tests/unit_test/test_sync/test_lowlevel_api/test_transports/test_selector.py
+++ b/tests/unit_test/test_sync/test_lowlevel_api/test_transports/test_selector.py
@@ -245,8 +245,8 @@ class TestSelectorBaseTransport:
         mock_selector_select.assert_not_called()
 
     @pytest.mark.parametrize("blocking_error", [WouldBlockOnRead, WouldBlockOnWrite])
-    @pytest.mark.parametrize("available", [False, True], ids=lambda p: f"available=={p}")
-    @pytest.mark.parametrize("retry_interval", [math.inf, 5], ids=lambda p: f"retry_interval=={p}", indirect=True)
+    @pytest.mark.parametrize("available", [False, True], ids=lambda p: f"available__{p}")
+    @pytest.mark.parametrize("retry_interval", [math.inf, 5], ids=lambda p: f"retry_interval__{p}", indirect=True)
     def test____retry____timeout(
         self,
         blocking_error: type[WouldBlockOnRead] | type[WouldBlockOnWrite],
@@ -294,8 +294,8 @@ class TestSelectorBaseTransport:
             pytest.param(WouldBlockOnWrite, EVENT_WRITE),
         ],
     )
-    @pytest.mark.parametrize("available", [False, True], ids=lambda p: f"available=={p}")
-    @pytest.mark.parametrize("retry_interval", [1], ids=lambda p: f"retry_interval=={p}", indirect=True)
+    @pytest.mark.parametrize("available", [False, True], ids=lambda p: f"available__{p}")
+    @pytest.mark.parametrize("retry_interval", [1], ids=lambda p: f"retry_interval__{p}", indirect=True)
     def test____retry____timeout____retry_interval(
         self,
         blocking_error: type[WouldBlockOnRead] | type[WouldBlockOnWrite],

--- a/tests/unit_test/test_sync/test_lowlevel_api/test_transports/test_socket.py
+++ b/tests/unit_test/test_sync/test_lowlevel_api/test_transports/test_socket.py
@@ -553,7 +553,7 @@ class TestSocketStreamTransport(BaseTestSocketTransport, MixinTestSocketSendMSG)
     @PlatformMarkers.supports_socket_sendmsg
     @pytest.mark.usefixtures("SC_IOV_MAX")
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
-    @pytest.mark.parametrize("SC_IOV_MAX", [2], ids=lambda p: f"SC_IOV_MAX=={p}", indirect=True)
+    @pytest.mark.parametrize("SC_IOV_MAX", [2], ids=lambda p: f"SC_IOV_MAX__{p}", indirect=True)
     def test____send_all_noblock_with_ancillary____message_too_long____nb_buffers_greather_than_SC_IOV_MAX(
         self,
         transport: SocketStreamTransport,
@@ -602,8 +602,8 @@ class TestSocketStreamTransport(BaseTestSocketTransport, MixinTestSocketSendMSG)
 
     @PlatformMarkers.supports_socket_sendmsg
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
-    @pytest.mark.parametrize("data_is_iterator", [False, True], ids=lambda p: f"data_is_iterator=={p}")
-    @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator=={p}")
+    @pytest.mark.parametrize("data_is_iterator", [False, True], ids=lambda p: f"data_is_iterator__{p}")
+    @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator__{p}")
     @pytest.mark.parametrize("error", [BlockingIOError, InterruptedError])
     def test____send_all_with_ancillary____correctly_handle_iterables(
         self,
@@ -677,7 +677,7 @@ class TestSocketStreamTransport(BaseTestSocketTransport, MixinTestSocketSendMSG)
 
     @PlatformMarkers.supports_socket_sendmsg
     @pytest.mark.usefixtures("SC_IOV_MAX")
-    @pytest.mark.parametrize("SC_IOV_MAX", [2], ids=lambda p: f"SC_IOV_MAX=={p}", indirect=True)
+    @pytest.mark.parametrize("SC_IOV_MAX", [2], ids=lambda p: f"SC_IOV_MAX__{p}", indirect=True)
     def test____send_all_from_iterable____use_socket_sendmsg____nb_buffers_greather_than_SC_IOV_MAX(
         self,
         transport: SocketStreamTransport,
@@ -1034,7 +1034,7 @@ class TestSSLStreamTransport:
         mock_transport_retry.assert_called_once_with(transport, mocker.ANY, SSL_HANDSHAKE_TIMEOUT)
         assert mock_ssl_socket.do_handshake.call_args_list == [mocker.call() for _ in range(3)]
 
-    @pytest.mark.parametrize("standard_compatible", [False, True], ids=lambda p: f"standard_compatible=={p}", indirect=True)
+    @pytest.mark.parametrize("standard_compatible", [False, True], ids=lambda p: f"standard_compatible__{p}", indirect=True)
     def test____dunder_init____ssl_context_parameters(
         self,
         request: pytest.FixtureRequest,
@@ -1180,7 +1180,7 @@ class TestSSLStreamTransport:
 
     @pytest.mark.parametrize("unwrap_error", [None, OSError])
     @pytest.mark.parametrize("shutdown_error", [None, OSError])
-    @pytest.mark.parametrize("standard_compatible", [False, True], ids=lambda p: f"standard_compatible=={p}", indirect=True)
+    @pytest.mark.parametrize("standard_compatible", [False, True], ids=lambda p: f"standard_compatible__{p}", indirect=True)
     def test____close____default(
         self,
         standard_compatible: bool,
@@ -1639,7 +1639,7 @@ class TestSocketDatagramTransport(BaseTestSocketTransport):
         with pytest.raises(ValueError, match=r"^A 'SOCK_DGRAM' socket is expected$"):
             _ = SocketDatagramTransport(mock_tcp_socket, math.inf)
 
-    @pytest.mark.parametrize("max_datagram_size", [0, -42], ids=lambda p: f"max_datagram_size=={p}")
+    @pytest.mark.parametrize("max_datagram_size", [0, -42], ids=lambda p: f"max_datagram_size__{p}")
     def test____dunder_init____invalid_datagram_size(
         self,
         max_datagram_size: int,
@@ -1729,7 +1729,7 @@ class TestSocketDatagramTransport(BaseTestSocketTransport):
         # Assert
         assert fd == socket_fileno
 
-    @pytest.mark.parametrize("max_datagram_size", [None, 1024], ids=lambda p: f"max_datagram_size=={p}", indirect=True)
+    @pytest.mark.parametrize("max_datagram_size", [None, 1024], ids=lambda p: f"max_datagram_size__{p}", indirect=True)
     def test____recv_noblock____default(
         self,
         max_datagram_size: int | None,
@@ -1752,7 +1752,7 @@ class TestSocketDatagramTransport(BaseTestSocketTransport):
         assert result is mocker.sentinel.bytes
 
     @pytest.mark.parametrize("error", [BlockingIOError, InterruptedError])
-    @pytest.mark.parametrize("max_datagram_size", [None, 1024], ids=lambda p: f"max_datagram_size=={p}", indirect=True)
+    @pytest.mark.parametrize("max_datagram_size", [None, 1024], ids=lambda p: f"max_datagram_size__{p}", indirect=True)
     def test____recv_noblock____blocking_error(
         self,
         max_datagram_size: int | None,
@@ -1776,7 +1776,7 @@ class TestSocketDatagramTransport(BaseTestSocketTransport):
 
     @PlatformMarkers.supports_socket_recvmsg
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
-    @pytest.mark.parametrize("max_datagram_size", [None, 1024], ids=lambda p: f"max_datagram_size=={p}", indirect=True)
+    @pytest.mark.parametrize("max_datagram_size", [None, 1024], ids=lambda p: f"max_datagram_size__{p}", indirect=True)
     def test____recv_noblock_with_ancillary____default(
         self,
         max_datagram_size: int | None,
@@ -1821,7 +1821,7 @@ class TestSocketDatagramTransport(BaseTestSocketTransport):
     @PlatformMarkers.supports_socket_recvmsg
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
     @pytest.mark.parametrize("error", [BlockingIOError, InterruptedError])
-    @pytest.mark.parametrize("max_datagram_size", [None, 1024], ids=lambda p: f"max_datagram_size=={p}", indirect=True)
+    @pytest.mark.parametrize("max_datagram_size", [None, 1024], ids=lambda p: f"max_datagram_size__{p}", indirect=True)
     def test____recv_noblock_with_ancillary____blocking_error(
         self,
         max_datagram_size: int | None,
@@ -1941,7 +1941,7 @@ class TestSocketDatagramTransport(BaseTestSocketTransport):
 
     @PlatformMarkers.supports_socket_sendmsg
     @pytest.mark.parametrize("socket_family_name", _SUPPORTS_ANCILLARY, indirect=True)
-    @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator=={p}")
+    @pytest.mark.parametrize("ancillary_data_is_iterator", [False, True], ids=lambda p: f"ancillary_data_is_iterator__{p}")
     @pytest.mark.parametrize("error", [BlockingIOError, InterruptedError])
     def test____send_with_ancillary____correctly_handle_iterables(
         self,

--- a/tests/unit_test/test_tools/test_stream.py
+++ b/tests/unit_test/test_tools/test_stream.py
@@ -66,7 +66,7 @@ class TestStreamDataProducer:
         mock_generate_chunks_func.assert_called_once_with(mocker.sentinel.packet)
         assert chunks == [b"chunk 1", b"chunk 2"]
 
-    @pytest.mark.parametrize("before_yielding", [False, True], ids=lambda p: f"before_yielding=={p}")
+    @pytest.mark.parametrize("before_yielding", [False, True], ids=lambda p: f"before_yielding__{p}")
     def test____generate____generator_raised(
         self,
         before_yielding: bool,
@@ -294,7 +294,7 @@ class TestStreamDataConsumer:
         mock_build_packet_from_chunks_func.assert_called_once_with()
         assert consumer.get_buffer().tobytes() == b"Hello"
 
-    @pytest.mark.parametrize("before_yielding", [False, True], ids=lambda p: f"before_yielding=={p}")
+    @pytest.mark.parametrize("before_yielding", [False, True], ids=lambda p: f"before_yielding__{p}")
     def test____next____generator_raised(
         self,
         before_yielding: bool,
@@ -413,7 +413,7 @@ class TestBufferedStreamDataConsumer:
     def sizehint() -> int:
         return 1024
 
-    @pytest.fixture(params=[None, 0], ids=lambda p: f"zero_or_none=={p}")
+    @pytest.fixture(params=[None, 0], ids=lambda p: f"zero_or_none__{p}")
     @staticmethod
     def zero_or_none(request: pytest.FixtureRequest) -> int | None:
         return request.param
@@ -979,7 +979,7 @@ class TestBufferedStreamDataConsumer:
         # Assert
         assert consumer.get_value() == b""
 
-    @pytest.mark.parametrize("before_yielding", [False, True], ids=lambda p: f"before_yielding=={p}")
+    @pytest.mark.parametrize("before_yielding", [False, True], ids=lambda p: f"before_yielding__{p}")
     def test____next____generator_raised(
         self,
         before_yielding: bool,

--- a/tests/unit_test/test_tools/test_unix_utils.py
+++ b/tests/unit_test/test_tools/test_unix_utils.py
@@ -337,9 +337,9 @@ if sys.platform != "win32":
             mock_unix_stream_socket.getsockopt.assert_not_called()
 
         @PlatformMarkers.runs_only_on_platform(LINUX + OPENBSD + NETBSD, "ucred_impl")
-        @pytest.mark.parametrize("invalid_pid", [None, 0], ids=lambda p: f"invalid_pid=={p}")
-        @pytest.mark.parametrize("invalid_gid", [None, -1], ids=lambda p: f"invalid_gid=={p}")
-        @pytest.mark.parametrize("invalid_uid", [None, -1], ids=lambda p: f"invalid_uid=={p}")
+        @pytest.mark.parametrize("invalid_pid", [None, 0], ids=lambda p: f"invalid_pid__{p}")
+        @pytest.mark.parametrize("invalid_gid", [None, -1], ids=lambda p: f"invalid_gid__{p}")
+        @pytest.mark.parametrize("invalid_uid", [None, -1], ids=lambda p: f"invalid_uid__{p}")
         def test____get_peer_credentials_impl_from_platform____ucred_impl____corrupted_result(
             self,
             invalid_pid: int | None,

--- a/tests/unit_test/test_tools/test_utils.py
+++ b/tests/unit_test/test_tools/test_utils.py
@@ -126,7 +126,7 @@ def test____make_callback____build_no_arg_callable(mocker: MockerFixture) -> Non
     stub.assert_called_once_with(mocker.sentinel.arg1, mocker.sentinel.arg2, kw1=mocker.sentinel.kw1, kw2=mocker.sentinel.kw2)
 
 
-@pytest.mark.parametrize("already_weak_method", [True, False], ids=lambda p: f"already_weak_method=={p}")
+@pytest.mark.parametrize("already_weak_method", [True, False], ids=lambda p: f"already_weak_method__{p}")
 def test____weak_method_proxy_____wrap_method(already_weak_method: bool, mocker: MockerFixture) -> None:
     # Arrange
     @dataclasses.dataclass
@@ -227,7 +227,7 @@ def test____prepend_argument____several_prepend(mocker: MockerFixture) -> None:
     )
 
 
-@pytest.mark.parametrize("module", ["package.module", None], ids=lambda p: f"module=={p!r}")
+@pytest.mark.parametrize("module", ["package.module", None], ids=lambda p: f"module__{p!r}")
 def test____get_callable_name____qualname(module: str | None, mocker: MockerFixture) -> None:
     # Arrange
     func = mocker.stub()
@@ -245,7 +245,7 @@ def test____get_callable_name____qualname(module: str | None, mocker: MockerFixt
         assert name == "namespace.func"
 
 
-@pytest.mark.parametrize("module", ["package.module", None], ids=lambda p: f"module=={p!r}")
+@pytest.mark.parametrize("module", ["package.module", None], ids=lambda p: f"module__{p!r}")
 def test____get_callable_name____name_without_qualname(module: str | None, mocker: MockerFixture) -> None:
     # Arrange
     func = mocker.stub()
@@ -263,7 +263,7 @@ def test____get_callable_name____name_without_qualname(module: str | None, mocke
         assert name == "func"
 
 
-@pytest.mark.parametrize("module", ["package.module", None], ids=lambda p: f"module=={p!r}")
+@pytest.mark.parametrize("module", ["package.module", None], ids=lambda p: f"module__{p!r}")
 def test____get_callable_name____neither_name_nor_qualname(module: str | None, mocker: MockerFixture) -> None:
     # Arrange
     func = mocker.stub()
@@ -523,8 +523,8 @@ class _validate_timeout_delay_func_type(Protocol):
         raise NotImplementedError
 
 
-@pytest.mark.parametrize("delay", [1, 3.14, math.inf])
-@pytest.mark.parametrize("positive_check", [False, True], ids=lambda positive_check: f"{positive_check=}")
+@pytest.mark.parametrize("delay", [1, 3.14, math.inf], ids=lambda p: f"delay__{p}")
+@pytest.mark.parametrize("positive_check", [False, True], ids=lambda p: f"positive_check__{p}")
 @pytest.mark.parametrize("validator_func", [validate_timeout_delay, validate_optional_timeout_delay])
 def test____validate_timeout_delay____positive_value(
     delay: float,
@@ -537,7 +537,7 @@ def test____validate_timeout_delay____positive_value(
     assert validator_func(delay, positive_check=positive_check) == delay
 
 
-@pytest.mark.parametrize("positive_check", [False, True], ids=lambda positive_check: f"{positive_check=}")
+@pytest.mark.parametrize("positive_check", [False, True], ids=lambda p: f"positive_check__{p}")
 @pytest.mark.parametrize("validator_func", [validate_timeout_delay, validate_optional_timeout_delay])
 def test____validate_timeout_delay____null_value(
     positive_check: bool,
@@ -550,8 +550,8 @@ def test____validate_timeout_delay____null_value(
     assert validator_func(delay, positive_check=positive_check) == delay
 
 
-@pytest.mark.parametrize("delay", [-1, -3.14, -math.inf])
-@pytest.mark.parametrize("positive_check", [False, True], ids=lambda positive_check: f"{positive_check=}")
+@pytest.mark.parametrize("delay", [-1, -3.14, -math.inf], ids=lambda p: f"delay__{p}")
+@pytest.mark.parametrize("positive_check", [False, True], ids=lambda p: f"positive_check__{p}")
 @pytest.mark.parametrize("validator_func", [validate_timeout_delay, validate_optional_timeout_delay])
 def test____validate_timeout_delay____negative_value(
     delay: float,
@@ -568,7 +568,7 @@ def test____validate_timeout_delay____negative_value(
         assert validator_func(delay, positive_check=positive_check) == delay
 
 
-@pytest.mark.parametrize("positive_check", [False, True], ids=lambda positive_check: f"{positive_check=}")
+@pytest.mark.parametrize("positive_check", [False, True], ids=lambda p: f"positive_check__{p}")
 @pytest.mark.parametrize("validator_func", [validate_timeout_delay, validate_optional_timeout_delay])
 def test____validate_timeout_delay____convert_integer_value(
     positive_check: bool,
@@ -585,7 +585,7 @@ def test____validate_timeout_delay____convert_integer_value(
     assert new_delay == 32.0
 
 
-@pytest.mark.parametrize("positive_check", [False, True], ids=lambda positive_check: f"{positive_check=}")
+@pytest.mark.parametrize("positive_check", [False, True], ids=lambda p: f"positive_check__{p}")
 @pytest.mark.parametrize("validator_func", [validate_timeout_delay, validate_optional_timeout_delay])
 def test____validate_timeout_delay____not_a_number(
     positive_check: bool,
@@ -599,7 +599,7 @@ def test____validate_timeout_delay____not_a_number(
         validator_func(delay, positive_check=positive_check)
 
 
-@pytest.mark.parametrize("positive_check", [False, True], ids=lambda positive_check: f"{positive_check=}")
+@pytest.mark.parametrize("positive_check", [False, True], ids=lambda p: f"positive_check__{p}")
 def test____validate_optional_timeout_delay____None_value(positive_check: bool) -> None:
     # Arrange
 

--- a/tests/unit_test/test_tools/test_utils__open_listener_sockets.py
+++ b/tests/unit_test/test_tools/test_utils__open_listener_sockets.py
@@ -51,11 +51,11 @@ def addrinfo_list() -> Sequence[tuple[int, int, int, str, tuple[Any, ...]]]:
     )
 
 
-@pytest.mark.parametrize("reuse_address", [False, True], ids=lambda boolean: f"reuse_address=={boolean}")
-@pytest.mark.parametrize("SO_REUSEADDR_available", [False, True], ids=lambda boolean: f"SO_REUSEADDR_available=={boolean}")
-@pytest.mark.parametrize("SO_REUSEADDR_raise_error", [False, True], ids=lambda boolean: f"SO_REUSEADDR_raise_error=={boolean}")
-@pytest.mark.parametrize("IPPROTO_IPV6_available", [False, True], ids=lambda boolean: f"IPPROTO_IPV6_available=={boolean}")
-@pytest.mark.parametrize("reuse_port", [False, True], ids=lambda boolean: f"reuse_port=={boolean}")
+@pytest.mark.parametrize("reuse_address", [False, True], ids=lambda boolean: f"reuse_address__{boolean}")
+@pytest.mark.parametrize("SO_REUSEADDR_available", [False, True], ids=lambda boolean: f"SO_REUSEADDR_available__{boolean}")
+@pytest.mark.parametrize("SO_REUSEADDR_raise_error", [False, True], ids=lambda boolean: f"SO_REUSEADDR_raise_error__{boolean}")
+@pytest.mark.parametrize("IPPROTO_IPV6_available", [False, True], ids=lambda boolean: f"IPPROTO_IPV6_available__{boolean}")
+@pytest.mark.parametrize("reuse_port", [False, True], ids=lambda boolean: f"reuse_port__{boolean}")
 def test____open_listener_sockets_from_getaddrinfo_result____create_listener_sockets(
     reuse_address: bool,
     SO_REUSEADDR_available: bool,


### PR DESCRIPTION
Use `pytest -k` with `=` or `:` in ids results in a parse error.